### PR TITLE
fix: highlight queries conceal too much

### DIFF
--- a/queries/help/highlights.scm
+++ b/queries/help/highlights.scm
@@ -2,15 +2,8 @@
 (h2) @text.title
 (h3) @text.title
 (column_heading) @text.title
-(tag
-   "*" @conceal (#set! conceal "")
-   text: (_) @label)
-(taglink
-   "|" @conceal (#set! conceal "")
-   text: (_) @text.reference)
-(optionlink
-   text: (_) @text.literal)
-(codespan
-   "`" @conceal (#set! conceal "")
-   text: (_) @string)
+(tag) @label
+(taglink) @text.reference
+(optionlink) @text.reference
+(codespan) @text.literal
 (argument) @parameter


### PR DESCRIPTION
Problem:
The @conceal captures eat whitespace. #23

Solution:
Drop conceal for now, until we find a way to avoid concealing whitespace (either by changing the grammar or adding a "trim" feature to queries).