### PR TITLE
fix(highlights): link to more relevant groups

### DIFF
--- a/queries/help/highlights.scm
+++ b/queries/help/highlights.scm
@@ -9,8 +9,8 @@
    "|" @conceal (#set! conceal "")
    text: (_) @text.reference)
 (optionlink
-   text: (_) @text.literal)
+   text: (_) @text.reference)
 (codespan
    "`" @conceal (#set! conceal "")
-   text: (_) @string)
+   text: (_) @text.literal)
 (argument) @parameter

--- a/queries/help/highlights.scm
+++ b/queries/help/highlights.scm
@@ -13,4 +13,7 @@
 (codespan
    "`" @conceal (#set! conceal "")
    text: (_) @text.literal)
+(codeblock) @text.literal
 (argument) @parameter
+(keycode) @string.special
+(url) @text.uri


### PR DESCRIPTION
- `@text.literal` seems appropriate for a codespan/codeblock.
- `optionlink` and `taglink` should use the same highlight.