### PR TITLE
feat: annotated code blocks

### DIFF
--- a/corpus/codeblock.txt
+++ b/corpus/codeblock.txt
@@ -24,13 +24,15 @@ block3:
   (block
     (line
       (codeblock
-        (line))))
+        (code
+          (line)))))
   (block
     (line
       (word))
     (line
       (codeblock
-        (line))))
+        (code
+          (line)))))
   (block
     (line
       (word)))
@@ -39,7 +41,8 @@ block3:
       (word))
     (line
       (codeblock
-        (line))))
+        (code
+          (line)))))
   (block
     (line
       (word))))
@@ -73,9 +76,10 @@ text
       (word)
       (word)
       (codeblock
-        (line)
-        (line)
-        (line))))
+        (code
+          (line)
+          (line)
+          (line)))))
   (block
     (line
       (word)
@@ -89,12 +93,50 @@ text
       (word))
     (line
       (codeblock
-        (line)
-        (line)
-        (line))))
+        (code
+          (line)
+          (line)
+          (line)))))
   (block
     (line
       (word))))
+
+================================================================================
+codeblock with language annotations
+================================================================================
+This code is in Lua: >lua
+  local foo = 'bar'
+<
+
+This code is in Vimscript: >vim
+  let foo = "bar"
+<
+
+--------------------------------------------------------------------------------
+
+(help_file
+  (block
+    (line
+      (word)
+      (word)
+      (word)
+      (word)
+      (word)
+      (codeblock
+        (language)
+        (code
+          (line)))))
+  (block
+    (line
+      (word)
+      (word)
+      (word)
+      (word)
+      (word)
+      (codeblock
+        (language)
+        (code
+          (line))))))
 
 ================================================================================
 codeblock with implicit stop
@@ -127,9 +169,10 @@ H3 HEADLINE *foo*
   (block
     (line
       (codeblock
-        (line)
-        (line)
-        (line)))
+        (code
+          (line)
+          (line)
+          (line))))
     (line
       (h1
         (word)
@@ -143,8 +186,9 @@ H3 HEADLINE *foo*
   (block
     (line
       (codeblock
-        (line)
-        (line)))
+        (code
+          (line)
+          (line))))
     (line
       (h2
         (word)
@@ -153,8 +197,9 @@ H3 HEADLINE *foo*
   (block
     (line
       (codeblock
-        (line)
-        (line)))
+        (code
+          (line)
+          (line))))
     (line
       (h3
         (uppercase_name)
@@ -185,15 +230,16 @@ x
     (line
       (word)
       (codeblock
-        (line)
-        (line)
-        (line)
-        (line)
-        (line)
-        (line)
-        (line)
-        (line)
-        (line)))
+        (code
+          (line)
+          (line)
+          (line)
+          (line)
+          (line)
+          (line)
+          (line)
+          (line)
+          (line))))
     (line
       (word))))
 
@@ -224,19 +270,21 @@ tricky
   (block
     (line
       (codeblock
-        (line)
-        (line)
-        (line))))
+        (code
+          (line)
+          (line)
+          (line)))))
   (block
     (line
       (word)
       (codeblock
-        (line)
-        (line)
-        (line)
-        (line)
-        (line)
-        (line))))
+        (code
+          (line)
+          (line)
+          (line)
+          (line)
+          (line)
+          (line)))))
   (block
     (line
       (word))))
@@ -266,8 +314,9 @@ To test for a non-empty string, use empty(): >
       (word)
       (word)
       (codeblock
-        (line)
-        (line)))
+        (code
+          (line)
+          (line))))
     (line
       (word)
       (word)
@@ -290,8 +339,9 @@ To test for a non-empty string, use empty(): >
       (word)
       (word)
       (codeblock
-        (line)
-        (line)))
+        (code
+          (line)
+          (line))))
     (line
       (word)
       (word)
@@ -303,7 +353,8 @@ To test for a non-empty string, use empty(): >
       (word)
       (word)
       (codeblock
-        (line)))))
+        (code
+          (line))))))
 
 ================================================================================
 codeblock stop and start on same line
@@ -329,12 +380,14 @@ codeblock stop and start on same line
     (line
       (word)
       (codeblock
-        (line))))
+        (code
+          (line)))))
   (block
     (line
       (word)
       (codeblock
-        (line))))
+        (code
+          (line)))))
   (block
     (line
       (tag
@@ -350,8 +403,9 @@ codeblock stop and start on same line
     (line
       (word)
       (codeblock
-        (line)
-        (line)))))
+        (code
+          (line)
+          (line))))))
 
 ================================================================================
 NOT codeblock: whitespace after ">"
@@ -362,6 +416,11 @@ x >
 x x> 
   line
 
+Not a language annotation: > lua
+  line
+
+Not a language annotation: >lua is not at EOL
+  line
 
 
 --------------------------------------------------------------------------------
@@ -378,4 +437,28 @@ x x>
       (word)
       (word))
     (line
-      (word))))
+     (word)))
+  (block
+    (line
+      (word)
+      (word)
+      (word)
+      (word)
+      (word)
+      (word))
+    (line
+     (word)))
+  (block
+   (line
+    (word)
+    (word)
+    (word)
+    (word)
+    (word)
+    (word)
+    (word)
+    (word)
+    (word)
+    (word))
+   (line
+    (word))))

--- a/corpus/heading3-column_heading.txt
+++ b/corpus/heading3-column_heading.txt
@@ -164,7 +164,8 @@ column_heading should NOT parse atoms (links, tags, etc.) (FIXME)
     (line
       (word)
       (codeblock
-        (line))))
+        (code
+          (line)))))
   (block
     (line
       (column_heading

--- a/corpus/line_block.txt
+++ b/corpus/line_block.txt
@@ -201,7 +201,8 @@ listitem with codeblock
         (word)
         (word))
       (codeblock
-        (line)))
+        (code
+          (line))))
     (line_li
       (line
         (word)
@@ -215,9 +216,10 @@ listitem with codeblock
       (line
         (word)
         (codeblock
-          (line)
-          (line)
-          (line))))
+          (code
+            (line)
+            (line)
+            (line)))))
     (line_li
       (line
         (word))

--- a/grammar.js
+++ b/grammar.js
@@ -121,11 +121,13 @@ module.exports = grammar({
       repeat($._blank),
     ),
 
-    // Codeblock: preformatted block of lines starting with ">".
+    // Codeblock: preformatted block of lines starting with ">" or ">language" at EOL
     codeblock: ($) => prec.right(seq(
       '>',
-      token.immediate('\n'),
-      repeat1(alias($.line_code, $.line)),
+      choice(
+        alias(token.immediate(/[a-z0-9]+\n/), $.language),
+        token.immediate('\n')),
+      alias(repeat1(alias($.line_code, $.line)), $.code),
       // Codeblock ends if a line starts with non-whitespace.
       // Terminating "<" is consumed in other rules.
     )),

--- a/queries/help/highlights.scm
+++ b/queries/help/highlights.scm
@@ -17,7 +17,7 @@
    text: (_) @text.literal)
 (codeblock) @text.literal
 (codeblock
-   ">" @conceal (#set! conceal ""))
+   [">" (language)] @conceal (#set! conceal ""))
 (block
    "<" @conceal (#set! conceal ""))
 (argument) @parameter

--- a/queries/help/injections.scm
+++ b/queries/help/injections.scm
@@ -1,0 +1,3 @@
+(codeblock
+  (language) @language
+  (code) @contents)

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -453,23 +453,45 @@
             "value": ">"
           },
           {
-            "type": "IMMEDIATE_TOKEN",
-            "content": {
-              "type": "STRING",
-              "value": "\n"
-            }
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "IMMEDIATE_TOKEN",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[a-z0-9]+\\n"
+                  }
+                },
+                "named": true,
+                "value": "language"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "STRING",
+                  "value": "\n"
+                }
+              }
+            ]
           },
           {
-            "type": "REPEAT1",
+            "type": "ALIAS",
             "content": {
-              "type": "ALIAS",
+              "type": "REPEAT1",
               "content": {
-                "type": "SYMBOL",
-                "name": "line_code"
-              },
-              "named": true,
-              "value": "line"
-            }
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "line_code"
+                },
+                "named": true,
+                "value": "line"
+              }
+            },
+            "named": true,
+            "value": "code"
           }
         ]
       }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -46,7 +46,7 @@
     }
   },
   {
-    "type": "codeblock",
+    "type": "code",
     "named": true,
     "fields": {},
     "children": {
@@ -55,6 +55,25 @@
       "types": [
         {
           "type": "line",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "codeblock",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "code",
+          "named": true
+        },
+        {
+          "type": "language",
           "named": true
         }
       ]
@@ -474,6 +493,10 @@
   {
     "type": "`",
     "named": false
+  },
+  {
+    "type": "language",
+    "named": true
   },
   {
     "type": "{",

--- a/src/parser.c
+++ b/src/parser.c
@@ -14,15 +14,15 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 104
+#define STATE_COUNT 106
 #define LARGE_STATE_COUNT 8
-#define SYMBOL_COUNT 87
-#define ALIAS_COUNT 0
-#define TOKEN_COUNT 52
+#define SYMBOL_COUNT 88
+#define ALIAS_COUNT 1
+#define TOKEN_COUNT 53
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 3
 #define MAX_ALIAS_SEQUENCE_LENGTH 5
-#define PRODUCTION_ID_COUNT 21
+#define PRODUCTION_ID_COUNT 22
 
 enum {
   aux_sym_word_token1 = 1,
@@ -55,62 +55,64 @@ enum {
   aux_sym_uppercase_name_token1 = 28,
   aux_sym_uppercase_name_token2 = 29,
   anon_sym_LT = 30,
-  anon_sym_LF = 31,
-  anon_sym_LF2 = 32,
-  aux_sym_line_li_token1 = 33,
-  aux_sym_line_code_token1 = 34,
-  aux_sym_h1_token1 = 35,
-  aux_sym_h2_token1 = 36,
-  anon_sym_STAR = 37,
-  aux_sym_tag_token1 = 38,
-  anon_sym_STAR2 = 39,
-  sym_url_word = 40,
-  aux_sym_optionlink_token1 = 41,
-  aux_sym_taglink_token1 = 42,
-  anon_sym_LBRACE2 = 43,
-  anon_sym_RBRACE2 = 44,
-  anon_sym_LPAREN2 = 45,
-  anon_sym_RPAREN = 46,
-  anon_sym_BQUOTE = 47,
-  anon_sym_PIPE2 = 48,
-  anon_sym_BQUOTE2 = 49,
-  aux_sym_codespan_token1 = 50,
-  aux_sym_argument_token1 = 51,
-  sym_help_file = 52,
-  sym__atom = 53,
-  sym_word = 54,
-  sym__atom_noli = 55,
-  sym_word_noli = 56,
-  sym__atom_common = 57,
-  sym__word_common = 58,
-  sym_keycode = 59,
-  sym_uppercase_name = 60,
-  sym__uppercase_words = 61,
-  sym_block = 62,
-  sym_codeblock = 63,
-  sym__blank = 64,
-  sym_line = 65,
-  sym_line_li = 66,
-  sym_line_code = 67,
-  sym__line_noli = 68,
-  sym_column_heading = 69,
-  sym_h1 = 70,
-  sym_h2 = 71,
-  sym_h3 = 72,
-  sym_tag = 73,
-  sym_url = 74,
-  sym_optionlink = 75,
-  sym_taglink = 76,
-  sym_codespan = 77,
-  sym_argument = 78,
-  aux_sym_help_file_repeat1 = 79,
-  aux_sym_help_file_repeat2 = 80,
-  aux_sym_uppercase_name_repeat1 = 81,
-  aux_sym_block_repeat1 = 82,
-  aux_sym_block_repeat2 = 83,
-  aux_sym_codeblock_repeat1 = 84,
-  aux_sym_line_li_repeat1 = 85,
-  aux_sym_line_li_repeat2 = 86,
+  aux_sym_codeblock_token1 = 31,
+  anon_sym_LF = 32,
+  anon_sym_LF2 = 33,
+  aux_sym_line_li_token1 = 34,
+  aux_sym_line_code_token1 = 35,
+  aux_sym_h1_token1 = 36,
+  aux_sym_h2_token1 = 37,
+  anon_sym_STAR = 38,
+  aux_sym_tag_token1 = 39,
+  anon_sym_STAR2 = 40,
+  sym_url_word = 41,
+  aux_sym_optionlink_token1 = 42,
+  aux_sym_taglink_token1 = 43,
+  anon_sym_LBRACE2 = 44,
+  anon_sym_RBRACE2 = 45,
+  anon_sym_LPAREN2 = 46,
+  anon_sym_RPAREN = 47,
+  anon_sym_BQUOTE = 48,
+  anon_sym_PIPE2 = 49,
+  anon_sym_BQUOTE2 = 50,
+  aux_sym_codespan_token1 = 51,
+  aux_sym_argument_token1 = 52,
+  sym_help_file = 53,
+  sym__atom = 54,
+  sym_word = 55,
+  sym__atom_noli = 56,
+  sym_word_noli = 57,
+  sym__atom_common = 58,
+  sym__word_common = 59,
+  sym_keycode = 60,
+  sym_uppercase_name = 61,
+  sym__uppercase_words = 62,
+  sym_block = 63,
+  sym_codeblock = 64,
+  sym__blank = 65,
+  sym_line = 66,
+  sym_line_li = 67,
+  sym_line_code = 68,
+  sym__line_noli = 69,
+  sym_column_heading = 70,
+  sym_h1 = 71,
+  sym_h2 = 72,
+  sym_h3 = 73,
+  sym_tag = 74,
+  sym_url = 75,
+  sym_optionlink = 76,
+  sym_taglink = 77,
+  sym_codespan = 78,
+  sym_argument = 79,
+  aux_sym_help_file_repeat1 = 80,
+  aux_sym_help_file_repeat2 = 81,
+  aux_sym_uppercase_name_repeat1 = 82,
+  aux_sym_block_repeat1 = 83,
+  aux_sym_block_repeat2 = 84,
+  aux_sym_codeblock_repeat1 = 85,
+  aux_sym_line_li_repeat1 = 86,
+  aux_sym_line_li_repeat2 = 87,
+  alias_sym_code = 88,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -145,6 +147,7 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_uppercase_name_token1] = "uppercase_name_token1",
   [aux_sym_uppercase_name_token2] = "uppercase_name_token2",
   [anon_sym_LT] = "<",
+  [aux_sym_codeblock_token1] = "language",
   [anon_sym_LF] = "\n",
   [anon_sym_LF2] = "\n",
   [aux_sym_line_li_token1] = "line_li_token1",
@@ -201,6 +204,7 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_codeblock_repeat1] = "codeblock_repeat1",
   [aux_sym_line_li_repeat1] = "line_li_repeat1",
   [aux_sym_line_li_repeat2] = "line_li_repeat2",
+  [alias_sym_code] = "code",
 };
 
 static const TSSymbol ts_symbol_map[] = {
@@ -235,6 +239,7 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_uppercase_name_token1] = aux_sym_uppercase_name_token1,
   [aux_sym_uppercase_name_token2] = aux_sym_uppercase_name_token2,
   [anon_sym_LT] = anon_sym_LT,
+  [aux_sym_codeblock_token1] = aux_sym_codeblock_token1,
   [anon_sym_LF] = anon_sym_LF,
   [anon_sym_LF2] = anon_sym_LF,
   [aux_sym_line_li_token1] = aux_sym_line_li_token1,
@@ -291,6 +296,7 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_codeblock_repeat1] = aux_sym_codeblock_repeat1,
   [aux_sym_line_li_repeat1] = aux_sym_line_li_repeat1,
   [aux_sym_line_li_repeat2] = aux_sym_line_li_repeat2,
+  [alias_sym_code] = alias_sym_code,
 };
 
 static const TSSymbolMetadata ts_symbol_metadata[] = {
@@ -417,6 +423,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   [anon_sym_LT] = {
     .visible = true,
     .named = false,
+  },
+  [aux_sym_codeblock_token1] = {
+    .visible = true,
+    .named = true,
   },
   [anon_sym_LF] = {
     .visible = true,
@@ -642,6 +652,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
+  [alias_sym_code] = {
+    .visible = true,
+    .named = true,
+  },
 };
 
 enum {
@@ -666,11 +680,11 @@ static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
   [8] = {.index = 6, .length = 1},
   [9] = {.index = 7, .length = 1},
   [10] = {.index = 7, .length = 1},
-  [13] = {.index = 8, .length = 1},
-  [14] = {.index = 9, .length = 2},
-  [18] = {.index = 11, .length = 2},
-  [19] = {.index = 13, .length = 1},
-  [20] = {.index = 14, .length = 2},
+  [14] = {.index = 8, .length = 1},
+  [15] = {.index = 9, .length = 2},
+  [19] = {.index = 11, .length = 2},
+  [20] = {.index = 13, .length = 1},
+  [21] = {.index = 14, .length = 2},
 };
 
 static const TSFieldMapEntry ts_field_map_entries[] = {
@@ -717,20 +731,23 @@ static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE
     [1] = sym_word,
   },
   [11] = {
-    [1] = sym_line,
-    [2] = sym_line,
+    [2] = alias_sym_code,
   },
   [12] = {
     [1] = sym_line,
-  },
-  [15] = {
     [2] = sym_line,
-    [3] = sym_line,
+  },
+  [13] = {
+    [1] = sym_line,
   },
   [16] = {
     [2] = sym_line,
+    [3] = sym_line,
   },
   [17] = {
+    [2] = sym_line,
+  },
+  [18] = {
     [0] = sym_line,
   },
 };
@@ -742,6 +759,9 @@ static const uint16_t ts_non_terminal_alias_map[] = {
   aux_sym_uppercase_name_repeat1, 2,
     aux_sym_uppercase_name_repeat1,
     sym_word,
+  aux_sym_codeblock_repeat1, 2,
+    aux_sym_codeblock_repeat1,
+    alias_sym_code,
   aux_sym_line_li_repeat1, 2,
     aux_sym_line_li_repeat1,
     sym_line,
@@ -794,12 +814,12 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [42] = 42,
   [43] = 43,
   [44] = 44,
-  [45] = 45,
-  [46] = 35,
-  [47] = 41,
+  [45] = 34,
+  [46] = 46,
+  [47] = 47,
   [48] = 48,
   [49] = 49,
-  [50] = 50,
+  [50] = 35,
   [51] = 51,
   [52] = 52,
   [53] = 53,
@@ -810,20 +830,20 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [58] = 58,
   [59] = 59,
   [60] = 60,
-  [61] = 50,
-  [62] = 53,
-  [63] = 63,
-  [64] = 56,
+  [61] = 61,
+  [62] = 48,
+  [63] = 49,
+  [64] = 52,
   [65] = 65,
-  [66] = 66,
+  [66] = 54,
   [67] = 67,
   [68] = 68,
   [69] = 69,
   [70] = 70,
   [71] = 71,
   [72] = 72,
-  [73] = 71,
-  [74] = 74,
+  [73] = 73,
+  [74] = 68,
   [75] = 75,
   [76] = 76,
   [77] = 77,
@@ -842,9 +862,9 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [90] = 90,
   [91] = 91,
   [92] = 92,
-  [93] = 92,
+  [93] = 93,
   [94] = 94,
-  [95] = 95,
+  [95] = 94,
   [96] = 96,
   [97] = 97,
   [98] = 98,
@@ -853,6 +873,8 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [101] = 101,
   [102] = 102,
   [103] = 103,
+  [104] = 104,
+  [105] = 105,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -860,822 +882,825 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(31);
-      if (lookahead == '\n') ADVANCE(382);
-      if (lookahead == '\'') ADVANCE(246);
-      if (lookahead == '(') ADVANCE(473);
-      if (lookahead == ')') ADVANCE(475);
-      if (lookahead == '*') ADVANCE(396);
-      if (lookahead == '+') ADVANCE(225);
-      if (lookahead == '<') ADVANCE(380);
-      if (lookahead == '>') ADVANCE(283);
-      if (lookahead == 'A') ADVANCE(231);
-      if (lookahead == 'C') ADVANCE(233);
-      if (lookahead == 'M') ADVANCE(229);
-      if (lookahead == '`') ADVANCE(477);
-      if (lookahead == 'h') ADVANCE(234);
-      if (lookahead == '{') ADVANCE(469);
-      if (lookahead == '|') ADVANCE(479);
-      if (lookahead == '}') ADVANCE(471);
-      if (lookahead == '~') ADVANCE(278);
+      if (eof) ADVANCE(32);
+      if (lookahead == '\n') ADVANCE(390);
+      if (lookahead == '\'') ADVANCE(253);
+      if (lookahead == '(') ADVANCE(481);
+      if (lookahead == ')') ADVANCE(483);
+      if (lookahead == '*') ADVANCE(404);
+      if (lookahead == '+') ADVANCE(232);
+      if (lookahead == '<') ADVANCE(387);
+      if (lookahead == '>') ADVANCE(290);
+      if (lookahead == 'A') ADVANCE(238);
+      if (lookahead == 'C') ADVANCE(240);
+      if (lookahead == 'M') ADVANCE(236);
+      if (lookahead == '`') ADVANCE(485);
+      if (lookahead == 'h') ADVANCE(241);
+      if (lookahead == '{') ADVANCE(477);
+      if (lookahead == '|') ADVANCE(487);
+      if (lookahead == '}') ADVANCE(479);
+      if (lookahead == '~') ADVANCE(285);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(28)
+          lookahead == ' ') SKIP(29)
       if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(226);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(235);
+          lookahead == 8226) ADVANCE(233);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(237);
-      if (lookahead != 0) ADVANCE(225);
+          lookahead == '_') ADVANCE(244);
+      if (lookahead != 0) ADVANCE(232);
       END_STATE();
     case 1:
-      if (lookahead == '\t') ADVANCE(254);
-      if (lookahead == ' ') ADVANCE(385);
-      if (lookahead == '-') ADVANCE(219);
+      if (lookahead == '\t') ADVANCE(261);
+      if (lookahead == ' ') ADVANCE(393);
+      if (lookahead == '-') ADVANCE(226);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(220);
+          lookahead != '\n') ADVANCE(227);
       END_STATE();
     case 2:
-      if (lookahead == '\t') ADVANCE(254);
-      if (lookahead == ' ') ADVANCE(385);
+      if (lookahead == '\t') ADVANCE(261);
+      if (lookahead == ' ') ADVANCE(393);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(220);
+          lookahead != '\n') ADVANCE(227);
       END_STATE();
     case 3:
-      if (lookahead == '\t') ADVANCE(22);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == ' ') ADVANCE(384);
-      if (lookahead != 0) ADVANCE(209);
+      if (lookahead == '\t') ADVANCE(23);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == ' ') ADVANCE(392);
+      if (lookahead != 0) ADVANCE(216);
       END_STATE();
     case 4:
-      if (lookahead == '\t') ADVANCE(255);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == ' ') ADVANCE(384);
-      if (lookahead != 0) ADVANCE(209);
+      if (lookahead == '\t') ADVANCE(262);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == ' ') ADVANCE(392);
+      if (lookahead != 0) ADVANCE(216);
       END_STATE();
     case 5:
-      if (lookahead == '\n') ADVANCE(382);
-      if (lookahead == '\'') ADVANCE(221);
-      if (lookahead == '(') ADVANCE(269);
-      if (lookahead == '*') ADVANCE(389);
-      if (lookahead == '<') ADVANCE(86);
-      if (lookahead == '>') ADVANCE(283);
-      if (lookahead == 'A') ADVANCE(40);
-      if (lookahead == 'C') ADVANCE(43);
-      if (lookahead == 'M') ADVANCE(39);
-      if (lookahead == '`') ADVANCE(480);
-      if (lookahead == 'h') ADVANCE(48);
-      if (lookahead == '{') ADVANCE(257);
-      if (lookahead == '|') ADVANCE(252);
-      if (lookahead == '}') ADVANCE(259);
-      if (lookahead == '~') ADVANCE(278);
+      if (lookahead == '\n') ADVANCE(390);
+      if (lookahead == '\'') ADVANCE(228);
+      if (lookahead == '(') ADVANCE(276);
+      if (lookahead == '*') ADVANCE(397);
+      if (lookahead == '<') ADVANCE(93);
+      if (lookahead == '>') ADVANCE(290);
+      if (lookahead == 'A') ADVANCE(47);
+      if (lookahead == 'C') ADVANCE(50);
+      if (lookahead == 'M') ADVANCE(46);
+      if (lookahead == '`') ADVANCE(488);
+      if (lookahead == 'h') ADVANCE(55);
+      if (lookahead == '{') ADVANCE(264);
+      if (lookahead == '|') ADVANCE(259);
+      if (lookahead == '}') ADVANCE(266);
+      if (lookahead == '~') ADVANCE(285);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(7)
+          lookahead == ' ') SKIP(8)
       if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(32);
+          lookahead == 8226) ADVANCE(33);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(49);
-      if (lookahead != 0) ADVANCE(88);
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (lookahead != 0) ADVANCE(95);
       END_STATE();
     case 6:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == '\'') ADVANCE(246);
-      if (lookahead == '(') ADVANCE(269);
-      if (lookahead == '*') ADVANCE(389);
-      if (lookahead == '<') ADVANCE(86);
-      if (lookahead == '>') ADVANCE(283);
-      if (lookahead == 'A') ADVANCE(40);
-      if (lookahead == 'C') ADVANCE(43);
-      if (lookahead == 'M') ADVANCE(39);
-      if (lookahead == '`') ADVANCE(480);
-      if (lookahead == 'h') ADVANCE(48);
-      if (lookahead == '{') ADVANCE(257);
-      if (lookahead == '|') ADVANCE(252);
-      if (lookahead == '}') ADVANCE(259);
-      if (lookahead == '~') ADVANCE(278);
+      if (lookahead == '\n') ADVANCE(390);
+      if (lookahead == '\'') ADVANCE(228);
+      if (lookahead == '(') ADVANCE(276);
+      if (lookahead == '*') ADVANCE(397);
+      if (lookahead == '<') ADVANCE(93);
+      if (lookahead == '>') ADVANCE(290);
+      if (lookahead == 'A') ADVANCE(47);
+      if (lookahead == 'C') ADVANCE(50);
+      if (lookahead == 'M') ADVANCE(46);
+      if (lookahead == '`') ADVANCE(488);
+      if (lookahead == 'h') ADVANCE(38);
+      if (lookahead == '{') ADVANCE(264);
+      if (lookahead == '|') ADVANCE(259);
+      if (lookahead == '}') ADVANCE(266);
+      if (lookahead == '~') ADVANCE(285);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(7)
+          lookahead == ' ') SKIP(8)
       if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(32);
+          lookahead == 8226) ADVANCE(33);
+      if (('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(56);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(49);
-      if (lookahead != 0) ADVANCE(88);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
+      if (lookahead != 0) ADVANCE(95);
       END_STATE();
     case 7:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == '\'') ADVANCE(221);
-      if (lookahead == '(') ADVANCE(269);
-      if (lookahead == '*') ADVANCE(389);
-      if (lookahead == '<') ADVANCE(86);
-      if (lookahead == '>') ADVANCE(283);
-      if (lookahead == 'A') ADVANCE(40);
-      if (lookahead == 'C') ADVANCE(43);
-      if (lookahead == 'M') ADVANCE(39);
-      if (lookahead == '`') ADVANCE(480);
-      if (lookahead == 'h') ADVANCE(48);
-      if (lookahead == '{') ADVANCE(257);
-      if (lookahead == '|') ADVANCE(252);
-      if (lookahead == '}') ADVANCE(259);
-      if (lookahead == '~') ADVANCE(278);
+      if (lookahead == '\n') ADVANCE(391);
+      if (lookahead == '\'') ADVANCE(253);
+      if (lookahead == '(') ADVANCE(276);
+      if (lookahead == '*') ADVANCE(397);
+      if (lookahead == '<') ADVANCE(93);
+      if (lookahead == '>') ADVANCE(290);
+      if (lookahead == 'A') ADVANCE(47);
+      if (lookahead == 'C') ADVANCE(50);
+      if (lookahead == 'M') ADVANCE(46);
+      if (lookahead == '`') ADVANCE(488);
+      if (lookahead == 'h') ADVANCE(55);
+      if (lookahead == '{') ADVANCE(264);
+      if (lookahead == '|') ADVANCE(259);
+      if (lookahead == '}') ADVANCE(266);
+      if (lookahead == '~') ADVANCE(285);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(7)
+          lookahead == ' ') SKIP(8)
       if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(32);
+          lookahead == 8226) ADVANCE(33);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(49);
-      if (lookahead != 0) ADVANCE(88);
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (lookahead != 0) ADVANCE(95);
       END_STATE();
     case 8:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == '\'') ADVANCE(221);
-      if (lookahead == '(') ADVANCE(269);
-      if (lookahead == '*') ADVANCE(391);
-      if (lookahead == '+') ADVANCE(24);
-      if (lookahead == '<') ADVANCE(205);
-      if (lookahead == '>') ADVANCE(283);
-      if (lookahead == 'A') ADVANCE(148);
-      if (lookahead == 'C') ADVANCE(151);
-      if (lookahead == 'M') ADVANCE(147);
-      if (lookahead == '`') ADVANCE(480);
-      if (lookahead == 'h') ADVANCE(156);
-      if (lookahead == '{') ADVANCE(257);
-      if (lookahead == '|') ADVANCE(252);
-      if (lookahead == '}') ADVANCE(259);
-      if (lookahead == '~') ADVANCE(278);
+      if (lookahead == '\n') ADVANCE(391);
+      if (lookahead == '\'') ADVANCE(228);
+      if (lookahead == '(') ADVANCE(276);
+      if (lookahead == '*') ADVANCE(397);
+      if (lookahead == '<') ADVANCE(93);
+      if (lookahead == '>') ADVANCE(290);
+      if (lookahead == 'A') ADVANCE(47);
+      if (lookahead == 'C') ADVANCE(50);
+      if (lookahead == 'M') ADVANCE(46);
+      if (lookahead == '`') ADVANCE(488);
+      if (lookahead == 'h') ADVANCE(55);
+      if (lookahead == '{') ADVANCE(264);
+      if (lookahead == '|') ADVANCE(259);
+      if (lookahead == '}') ADVANCE(266);
+      if (lookahead == '~') ADVANCE(285);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(8)
       if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(2);
+          lookahead == 8226) ADVANCE(33);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (lookahead != 0) ADVANCE(207);
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (lookahead != 0) ADVANCE(95);
       END_STATE();
     case 9:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == '\'') ADVANCE(221);
-      if (lookahead == '(') ADVANCE(273);
-      if (lookahead == '*') ADVANCE(391);
-      if (lookahead == '+') ADVANCE(24);
-      if (lookahead == '-') ADVANCE(1);
-      if (lookahead == '<') ADVANCE(381);
-      if (lookahead == '=') ADVANCE(174);
-      if (lookahead == '>') ADVANCE(283);
-      if (lookahead == 'A') ADVANCE(159);
-      if (lookahead == 'C') ADVANCE(160);
-      if (lookahead == 'M') ADVANCE(158);
-      if (lookahead == '`') ADVANCE(480);
-      if (lookahead == 'h') ADVANCE(156);
-      if (lookahead == '{') ADVANCE(257);
-      if (lookahead == '|') ADVANCE(252);
-      if (lookahead == '}') ADVANCE(259);
-      if (lookahead == '~') ADVANCE(278);
-      if (lookahead == 8226) ADVANCE(2);
+      if (lookahead == '\n') ADVANCE(391);
+      if (lookahead == '\'') ADVANCE(228);
+      if (lookahead == '(') ADVANCE(276);
+      if (lookahead == '*') ADVANCE(399);
+      if (lookahead == '+') ADVANCE(25);
+      if (lookahead == '<') ADVANCE(212);
+      if (lookahead == '>') ADVANCE(290);
+      if (lookahead == 'A') ADVANCE(155);
+      if (lookahead == 'C') ADVANCE(158);
+      if (lookahead == 'M') ADVANCE(154);
+      if (lookahead == '`') ADVANCE(488);
+      if (lookahead == 'h') ADVANCE(163);
+      if (lookahead == '{') ADVANCE(264);
+      if (lookahead == '|') ADVANCE(259);
+      if (lookahead == '}') ADVANCE(266);
+      if (lookahead == '~') ADVANCE(285);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(14);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(206);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(161);
-      if (lookahead != 0) ADVANCE(207);
-      END_STATE();
-    case 10:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == '\'') ADVANCE(221);
-      if (lookahead == '(') ADVANCE(273);
-      if (lookahead == '*') ADVANCE(391);
-      if (lookahead == '+') ADVANCE(24);
-      if (lookahead == '<') ADVANCE(381);
-      if (lookahead == '>') ADVANCE(283);
-      if (lookahead == 'A') ADVANCE(159);
-      if (lookahead == 'C') ADVANCE(160);
-      if (lookahead == 'M') ADVANCE(158);
-      if (lookahead == '`') ADVANCE(480);
-      if (lookahead == 'h') ADVANCE(156);
-      if (lookahead == '{') ADVANCE(257);
-      if (lookahead == '|') ADVANCE(252);
-      if (lookahead == '}') ADVANCE(259);
-      if (lookahead == '~') ADVANCE(278);
-      if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(8)
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(206);
+          lookahead == ' ') SKIP(9)
       if (lookahead == '-' ||
           lookahead == 8226) ADVANCE(2);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(161);
-      if (lookahead != 0) ADVANCE(207);
-      END_STATE();
-    case 11:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == '\'') ADVANCE(221);
-      if (lookahead == '(') ADVANCE(273);
-      if (lookahead == '*') ADVANCE(391);
-      if (lookahead == '+') ADVANCE(24);
-      if (lookahead == '<') ADVANCE(381);
-      if (lookahead == '>') ADVANCE(283);
-      if (lookahead == 'A') ADVANCE(159);
-      if (lookahead == 'C') ADVANCE(160);
-      if (lookahead == 'M') ADVANCE(158);
-      if (lookahead == '`') ADVANCE(480);
-      if (lookahead == 'h') ADVANCE(156);
-      if (lookahead == '{') ADVANCE(257);
-      if (lookahead == '|') ADVANCE(252);
-      if (lookahead == '}') ADVANCE(259);
-      if (lookahead == '~') ADVANCE(278);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(14);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(206);
-      if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(2);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(161);
-      if (lookahead != 0) ADVANCE(207);
-      END_STATE();
-    case 12:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == '\'') ADVANCE(221);
-      if (lookahead == '(') ADVANCE(272);
-      if (lookahead == '*') ADVANCE(393);
-      if (lookahead == '<') ADVANCE(240);
-      if (lookahead == '>') ADVANCE(286);
-      if (lookahead == 'A') ADVANCE(230);
-      if (lookahead == 'C') ADVANCE(232);
-      if (lookahead == 'M') ADVANCE(228);
-      if (lookahead == '`') ADVANCE(483);
-      if (lookahead == 'h') ADVANCE(238);
-      if (lookahead == '{') ADVANCE(258);
-      if (lookahead == '|') ADVANCE(253);
-      if (lookahead == '}') ADVANCE(261);
-      if (lookahead == '~') ADVANCE(281);
-      if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(7)
-      if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(227);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(239);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(236);
-      if (lookahead != 0) ADVANCE(241);
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (lookahead != 0) ADVANCE(214);
+      END_STATE();
+    case 10:
+      if (lookahead == '\n') ADVANCE(391);
+      if (lookahead == '\'') ADVANCE(228);
+      if (lookahead == '(') ADVANCE(280);
+      if (lookahead == '*') ADVANCE(399);
+      if (lookahead == '+') ADVANCE(25);
+      if (lookahead == '-') ADVANCE(1);
+      if (lookahead == '<') ADVANCE(388);
+      if (lookahead == '=') ADVANCE(181);
+      if (lookahead == '>') ADVANCE(290);
+      if (lookahead == 'A') ADVANCE(166);
+      if (lookahead == 'C') ADVANCE(167);
+      if (lookahead == 'M') ADVANCE(165);
+      if (lookahead == '`') ADVANCE(488);
+      if (lookahead == 'h') ADVANCE(163);
+      if (lookahead == '{') ADVANCE(264);
+      if (lookahead == '|') ADVANCE(259);
+      if (lookahead == '}') ADVANCE(266);
+      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == 8226) ADVANCE(2);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(15);
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(213);
+      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(168);
+      if (lookahead != 0) ADVANCE(214);
+      END_STATE();
+    case 11:
+      if (lookahead == '\n') ADVANCE(391);
+      if (lookahead == '\'') ADVANCE(228);
+      if (lookahead == '(') ADVANCE(280);
+      if (lookahead == '*') ADVANCE(399);
+      if (lookahead == '+') ADVANCE(25);
+      if (lookahead == '<') ADVANCE(388);
+      if (lookahead == '>') ADVANCE(290);
+      if (lookahead == 'A') ADVANCE(166);
+      if (lookahead == 'C') ADVANCE(167);
+      if (lookahead == 'M') ADVANCE(165);
+      if (lookahead == '`') ADVANCE(488);
+      if (lookahead == 'h') ADVANCE(163);
+      if (lookahead == '{') ADVANCE(264);
+      if (lookahead == '|') ADVANCE(259);
+      if (lookahead == '}') ADVANCE(266);
+      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(9)
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(213);
+      if (lookahead == '-' ||
+          lookahead == 8226) ADVANCE(2);
+      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(168);
+      if (lookahead != 0) ADVANCE(214);
+      END_STATE();
+    case 12:
+      if (lookahead == '\n') ADVANCE(391);
+      if (lookahead == '\'') ADVANCE(228);
+      if (lookahead == '(') ADVANCE(280);
+      if (lookahead == '*') ADVANCE(399);
+      if (lookahead == '+') ADVANCE(25);
+      if (lookahead == '<') ADVANCE(388);
+      if (lookahead == '>') ADVANCE(290);
+      if (lookahead == 'A') ADVANCE(166);
+      if (lookahead == 'C') ADVANCE(167);
+      if (lookahead == 'M') ADVANCE(165);
+      if (lookahead == '`') ADVANCE(488);
+      if (lookahead == 'h') ADVANCE(163);
+      if (lookahead == '{') ADVANCE(264);
+      if (lookahead == '|') ADVANCE(259);
+      if (lookahead == '}') ADVANCE(266);
+      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(15);
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(213);
+      if (lookahead == '-' ||
+          lookahead == 8226) ADVANCE(2);
+      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(168);
+      if (lookahead != 0) ADVANCE(214);
       END_STATE();
     case 13:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == '\'') ADVANCE(221);
-      if (lookahead == '(') ADVANCE(274);
-      if (lookahead == '*') ADVANCE(389);
-      if (lookahead == '<') ADVANCE(86);
-      if (lookahead == '>') ADVANCE(283);
-      if (lookahead == 'A') ADVANCE(51);
-      if (lookahead == 'C') ADVANCE(52);
-      if (lookahead == 'M') ADVANCE(50);
-      if (lookahead == '`') ADVANCE(480);
-      if (lookahead == 'h') ADVANCE(48);
-      if (lookahead == '{') ADVANCE(257);
-      if (lookahead == '|') ADVANCE(252);
-      if (lookahead == '}') ADVANCE(259);
-      if (lookahead == '~') ADVANCE(278);
+      if (lookahead == '\n') ADVANCE(391);
+      if (lookahead == '\'') ADVANCE(228);
+      if (lookahead == '(') ADVANCE(279);
+      if (lookahead == '*') ADVANCE(401);
+      if (lookahead == '<') ADVANCE(247);
+      if (lookahead == '>') ADVANCE(293);
+      if (lookahead == 'A') ADVANCE(237);
+      if (lookahead == 'C') ADVANCE(239);
+      if (lookahead == 'M') ADVANCE(235);
+      if (lookahead == '`') ADVANCE(491);
+      if (lookahead == 'h') ADVANCE(245);
+      if (lookahead == '{') ADVANCE(265);
+      if (lookahead == '|') ADVANCE(260);
+      if (lookahead == '}') ADVANCE(268);
+      if (lookahead == '~') ADVANCE(288);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(13)
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(87);
+          lookahead == ' ') SKIP(8)
       if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(32);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+          lookahead == 8226) ADVANCE(234);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(246);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(53);
-      if (lookahead != 0) ADVANCE(88);
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(243);
+      if (lookahead != 0) ADVANCE(248);
       END_STATE();
     case 14:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == '\'') ADVANCE(222);
-      if (lookahead == '(') ADVANCE(270);
-      if (lookahead == '*') ADVANCE(390);
-      if (lookahead == '+') ADVANCE(3);
-      if (lookahead == '<') ADVANCE(136);
-      if (lookahead == '>') ADVANCE(284);
-      if (lookahead == 'A') ADVANCE(97);
-      if (lookahead == 'C') ADVANCE(100);
-      if (lookahead == 'M') ADVANCE(96);
-      if (lookahead == '`') ADVANCE(481);
-      if (lookahead == 'h') ADVANCE(105);
-      if (lookahead == '{') ADVANCE(256);
-      if (lookahead == '|') ADVANCE(250);
-      if (lookahead == '}') ADVANCE(260);
-      if (lookahead == '~') ADVANCE(279);
+      if (lookahead == '\n') ADVANCE(391);
+      if (lookahead == '\'') ADVANCE(228);
+      if (lookahead == '(') ADVANCE(281);
+      if (lookahead == '*') ADVANCE(397);
+      if (lookahead == '<') ADVANCE(93);
+      if (lookahead == '>') ADVANCE(290);
+      if (lookahead == 'A') ADVANCE(58);
+      if (lookahead == 'C') ADVANCE(59);
+      if (lookahead == 'M') ADVANCE(57);
+      if (lookahead == '`') ADVANCE(488);
+      if (lookahead == 'h') ADVANCE(55);
+      if (lookahead == '{') ADVANCE(264);
+      if (lookahead == '|') ADVANCE(259);
+      if (lookahead == '}') ADVANCE(266);
+      if (lookahead == '~') ADVANCE(285);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(14);
+          lookahead == ' ') SKIP(14)
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(94);
+      if (lookahead == '-' ||
+          lookahead == 8226) ADVANCE(33);
+      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(60);
+      if (lookahead != 0) ADVANCE(95);
+      END_STATE();
+    case 15:
+      if (lookahead == '\n') ADVANCE(391);
+      if (lookahead == '\'') ADVANCE(229);
+      if (lookahead == '(') ADVANCE(277);
+      if (lookahead == '*') ADVANCE(398);
+      if (lookahead == '+') ADVANCE(3);
+      if (lookahead == '<') ADVANCE(143);
+      if (lookahead == '>') ADVANCE(291);
+      if (lookahead == 'A') ADVANCE(104);
+      if (lookahead == 'C') ADVANCE(107);
+      if (lookahead == 'M') ADVANCE(103);
+      if (lookahead == '`') ADVANCE(489);
+      if (lookahead == 'h') ADVANCE(112);
+      if (lookahead == '{') ADVANCE(263);
+      if (lookahead == '|') ADVANCE(257);
+      if (lookahead == '}') ADVANCE(267);
+      if (lookahead == '~') ADVANCE(286);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(15);
       if (lookahead == '-' ||
           lookahead == 8226) ADVANCE(4);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(106);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 15:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == '\'') ADVANCE(224);
-      if (lookahead == '(') ADVANCE(474);
-      if (lookahead == ')') ADVANCE(476);
-      if (lookahead == '*') ADVANCE(394);
-      if (lookahead == '<') ADVANCE(466);
-      if (lookahead == '>') ADVANCE(287);
-      if (lookahead == 'A') ADVANCE(417);
-      if (lookahead == 'C') ADVANCE(420);
-      if (lookahead == 'M') ADVANCE(416);
-      if (lookahead == '`') ADVANCE(478);
-      if (lookahead == 'h') ADVANCE(425);
-      if (lookahead == '{') ADVANCE(470);
-      if (lookahead == '|') ADVANCE(252);
-      if (lookahead == '}') ADVANCE(472);
-      if (lookahead == '~') ADVANCE(282);
-      if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(7)
-      if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(409);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(426);
-      if (lookahead != 0) ADVANCE(468);
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(113);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 16:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == '\'') ADVANCE(223);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == '*') ADVANCE(392);
-      if (lookahead == '<') ADVANCE(537);
-      if (lookahead == '>') ADVANCE(285);
-      if (lookahead == 'A') ADVANCE(498);
-      if (lookahead == 'C') ADVANCE(501);
-      if (lookahead == 'M') ADVANCE(497);
-      if (lookahead == '`') ADVANCE(482);
-      if (lookahead == 'h') ADVANCE(506);
-      if (lookahead == '{') ADVANCE(257);
-      if (lookahead == '|') ADVANCE(251);
-      if (lookahead == '}') ADVANCE(259);
-      if (lookahead == '~') ADVANCE(280);
+      if (lookahead == '\n') ADVANCE(391);
+      if (lookahead == '\'') ADVANCE(231);
+      if (lookahead == '(') ADVANCE(482);
+      if (lookahead == ')') ADVANCE(484);
+      if (lookahead == '*') ADVANCE(402);
+      if (lookahead == '<') ADVANCE(474);
+      if (lookahead == '>') ADVANCE(294);
+      if (lookahead == 'A') ADVANCE(425);
+      if (lookahead == 'C') ADVANCE(428);
+      if (lookahead == 'M') ADVANCE(424);
+      if (lookahead == '`') ADVANCE(486);
+      if (lookahead == 'h') ADVANCE(433);
+      if (lookahead == '{') ADVANCE(478);
+      if (lookahead == '|') ADVANCE(259);
+      if (lookahead == '}') ADVANCE(480);
+      if (lookahead == '~') ADVANCE(289);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(7)
+          lookahead == ' ') SKIP(8)
       if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(485);
+          lookahead == 8226) ADVANCE(417);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(507);
-      if (lookahead != 0) ADVANCE(538);
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(434);
+      if (lookahead != 0) ADVANCE(476);
       END_STATE();
     case 17:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == '<') ADVANCE(379);
-      if (lookahead == '`') ADVANCE(477);
-      if (lookahead == '|') ADVANCE(479);
-      if (lookahead == '}') ADVANCE(471);
+      if (lookahead == '\n') ADVANCE(391);
+      if (lookahead == '\'') ADVANCE(230);
+      if (lookahead == '(') ADVANCE(278);
+      if (lookahead == '*') ADVANCE(400);
+      if (lookahead == '<') ADVANCE(545);
+      if (lookahead == '>') ADVANCE(292);
+      if (lookahead == 'A') ADVANCE(506);
+      if (lookahead == 'C') ADVANCE(509);
+      if (lookahead == 'M') ADVANCE(505);
+      if (lookahead == '`') ADVANCE(490);
+      if (lookahead == 'h') ADVANCE(514);
+      if (lookahead == '{') ADVANCE(264);
+      if (lookahead == '|') ADVANCE(258);
+      if (lookahead == '}') ADVANCE(266);
+      if (lookahead == '~') ADVANCE(287);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(18)
-      if (lookahead == '*' ||
-          lookahead == '+' ||
-          lookahead == '-' ||
-          lookahead == 8226) ADVANCE(23);
+          lookahead == ' ') SKIP(8)
+      if (lookahead == '-' ||
+          lookahead == 8226) ADVANCE(493);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+      if (lookahead != 0) ADVANCE(546);
       END_STATE();
     case 18:
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(391);
+      if (lookahead == '<') ADVANCE(386);
+      if (lookahead == '`') ADVANCE(485);
+      if (lookahead == '|') ADVANCE(487);
+      if (lookahead == '}') ADVANCE(479);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(18)
+          lookahead == ' ') SKIP(19)
       if (lookahead == '*' ||
           lookahead == '+' ||
           lookahead == '-' ||
-          lookahead == 8226) ADVANCE(23);
+          lookahead == 8226) ADVANCE(24);
       END_STATE();
     case 19:
-      if (lookahead == '\n') ADVANCE(388);
+      if (lookahead == '\n') ADVANCE(391);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(19);
+          lookahead == ' ') SKIP(19)
+      if (lookahead == '*' ||
+          lookahead == '+' ||
+          lookahead == '-' ||
+          lookahead == 8226) ADVANCE(24);
       END_STATE();
     case 20:
-      if (lookahead == '\n') ADVANCE(387);
+      if (lookahead == '\n') ADVANCE(396);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(20);
       END_STATE();
     case 21:
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '>') ADVANCE(294);
-      if (lookahead != 0) ADVANCE(22);
+      if (lookahead == '\n') ADVANCE(395);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
       END_STATE();
     case 22:
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead != 0) ADVANCE(22);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '>') ADVANCE(301);
+      if (lookahead != 0) ADVANCE(23);
       END_STATE();
     case 23:
-      if (lookahead == ' ') ADVANCE(385);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead != 0) ADVANCE(23);
       END_STATE();
     case 24:
-      if (lookahead == ' ') ADVANCE(385);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(220);
+      if (lookahead == ' ') ADVANCE(393);
       END_STATE();
     case 25:
-      if (lookahead == '*') ADVANCE(396);
+      if (lookahead == ' ') ADVANCE(393);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n') ADVANCE(227);
+      END_STATE();
+    case 26:
+      if (lookahead == '*') ADVANCE(404);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(395);
-      END_STATE();
-    case 26:
-      if (lookahead == '>') ADVANCE(292);
+          lookahead != ' ') ADVANCE(403);
       END_STATE();
     case 27:
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '`') ADVANCE(484);
+      if (lookahead == '>') ADVANCE(299);
       END_STATE();
     case 28:
-      if (eof) ADVANCE(31);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == '\'') ADVANCE(221);
-      if (lookahead == '(') ADVANCE(269);
-      if (lookahead == '*') ADVANCE(389);
-      if (lookahead == '+') ADVANCE(88);
-      if (lookahead == '<') ADVANCE(86);
-      if (lookahead == '>') ADVANCE(283);
-      if (lookahead == 'A') ADVANCE(40);
-      if (lookahead == 'C') ADVANCE(43);
-      if (lookahead == 'M') ADVANCE(39);
-      if (lookahead == '`') ADVANCE(480);
-      if (lookahead == 'h') ADVANCE(48);
-      if (lookahead == '{') ADVANCE(257);
-      if (lookahead == '|') ADVANCE(249);
-      if (lookahead == '}') ADVANCE(259);
-      if (lookahead == '~') ADVANCE(278);
-      if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(28)
-      if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(32);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(49);
-      if (lookahead != 0) ADVANCE(88);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '`') ADVANCE(492);
       END_STATE();
     case 29:
-      if (eof) ADVANCE(31);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == '\'') ADVANCE(221);
-      if (lookahead == '(') ADVANCE(269);
-      if (lookahead == '*') ADVANCE(391);
-      if (lookahead == '+') ADVANCE(24);
-      if (lookahead == '<') ADVANCE(205);
-      if (lookahead == '>') ADVANCE(283);
-      if (lookahead == 'A') ADVANCE(148);
-      if (lookahead == 'C') ADVANCE(151);
-      if (lookahead == 'M') ADVANCE(147);
-      if (lookahead == '`') ADVANCE(480);
-      if (lookahead == 'h') ADVANCE(156);
-      if (lookahead == '{') ADVANCE(257);
-      if (lookahead == '|') ADVANCE(252);
-      if (lookahead == '}') ADVANCE(259);
-      if (lookahead == '~') ADVANCE(278);
+      if (eof) ADVANCE(32);
+      if (lookahead == '\n') ADVANCE(391);
+      if (lookahead == '\'') ADVANCE(228);
+      if (lookahead == '(') ADVANCE(276);
+      if (lookahead == '*') ADVANCE(397);
+      if (lookahead == '+') ADVANCE(95);
+      if (lookahead == '<') ADVANCE(93);
+      if (lookahead == '>') ADVANCE(290);
+      if (lookahead == 'A') ADVANCE(47);
+      if (lookahead == 'C') ADVANCE(50);
+      if (lookahead == 'M') ADVANCE(46);
+      if (lookahead == '`') ADVANCE(488);
+      if (lookahead == 'h') ADVANCE(55);
+      if (lookahead == '{') ADVANCE(264);
+      if (lookahead == '|') ADVANCE(256);
+      if (lookahead == '}') ADVANCE(266);
+      if (lookahead == '~') ADVANCE(285);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(29)
+      if (lookahead == '-' ||
+          lookahead == 8226) ADVANCE(33);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (lookahead != 0) ADVANCE(95);
+      END_STATE();
+    case 30:
+      if (eof) ADVANCE(32);
+      if (lookahead == '\n') ADVANCE(391);
+      if (lookahead == '\'') ADVANCE(228);
+      if (lookahead == '(') ADVANCE(276);
+      if (lookahead == '*') ADVANCE(399);
+      if (lookahead == '+') ADVANCE(25);
+      if (lookahead == '<') ADVANCE(212);
+      if (lookahead == '>') ADVANCE(290);
+      if (lookahead == 'A') ADVANCE(155);
+      if (lookahead == 'C') ADVANCE(158);
+      if (lookahead == 'M') ADVANCE(154);
+      if (lookahead == '`') ADVANCE(488);
+      if (lookahead == 'h') ADVANCE(163);
+      if (lookahead == '{') ADVANCE(264);
+      if (lookahead == '|') ADVANCE(259);
+      if (lookahead == '}') ADVANCE(266);
+      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(30)
       if (lookahead == '-' ||
           lookahead == 8226) ADVANCE(2);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (lookahead != 0) ADVANCE(207);
-      END_STATE();
-    case 30:
-      if (eof) ADVANCE(31);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == '\'') ADVANCE(221);
-      if (lookahead == '(') ADVANCE(273);
-      if (lookahead == '*') ADVANCE(391);
-      if (lookahead == '+') ADVANCE(24);
-      if (lookahead == '-') ADVANCE(1);
-      if (lookahead == '<') ADVANCE(381);
-      if (lookahead == '=') ADVANCE(174);
-      if (lookahead == '>') ADVANCE(283);
-      if (lookahead == 'A') ADVANCE(159);
-      if (lookahead == 'C') ADVANCE(160);
-      if (lookahead == 'M') ADVANCE(158);
-      if (lookahead == '`') ADVANCE(480);
-      if (lookahead == 'h') ADVANCE(156);
-      if (lookahead == '{') ADVANCE(257);
-      if (lookahead == '|') ADVANCE(252);
-      if (lookahead == '}') ADVANCE(259);
-      if (lookahead == '~') ADVANCE(278);
-      if (lookahead == 8226) ADVANCE(2);
-      if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(29)
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(206);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(161);
-      if (lookahead != 0) ADVANCE(207);
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (lookahead != 0) ADVANCE(214);
       END_STATE();
     case 31:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+      if (eof) ADVANCE(32);
+      if (lookahead == '\n') ADVANCE(391);
+      if (lookahead == '\'') ADVANCE(228);
+      if (lookahead == '(') ADVANCE(280);
+      if (lookahead == '*') ADVANCE(399);
+      if (lookahead == '+') ADVANCE(25);
+      if (lookahead == '-') ADVANCE(1);
+      if (lookahead == '<') ADVANCE(388);
+      if (lookahead == '=') ADVANCE(181);
+      if (lookahead == '>') ADVANCE(290);
+      if (lookahead == 'A') ADVANCE(166);
+      if (lookahead == 'C') ADVANCE(167);
+      if (lookahead == 'M') ADVANCE(165);
+      if (lookahead == '`') ADVANCE(488);
+      if (lookahead == 'h') ADVANCE(163);
+      if (lookahead == '{') ADVANCE(264);
+      if (lookahead == '|') ADVANCE(259);
+      if (lookahead == '}') ADVANCE(266);
+      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == 8226) ADVANCE(2);
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(30)
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(213);
+      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(168);
+      if (lookahead != 0) ADVANCE(214);
       END_STATE();
     case 32:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\t') ADVANCE(254);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 33:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == '-') ADVANCE(82);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+      if (lookahead == '\t') ADVANCE(261);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 34:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == '-') ADVANCE(59);
+      if (lookahead == '\n') ADVANCE(389);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == ':') ADVANCE(92);
+      if (lookahead == 's') ADVANCE(35);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(56);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 35:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == '-') ADVANCE(83);
+      if (lookahead == '\n') ADVANCE(389);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == ':') ADVANCE(92);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(56);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 36:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == ':') ADVANCE(85);
-      if (lookahead == 's') ADVANCE(37);
+      if (lookahead == '\n') ADVANCE(389);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'p') ADVANCE(34);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(56);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 37:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == ':') ADVANCE(85);
+      if (lookahead == '\n') ADVANCE(389);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 't') ADVANCE(36);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(56);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 38:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'A') ADVANCE(35);
+      if (lookahead == '\n') ADVANCE(389);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 't') ADVANCE(37);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(56);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 39:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'E') ADVANCE(45);
+      if (lookahead == '\n') ADVANCE(389);
+      if (lookahead == '(') ADVANCE(282);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(56);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 40:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'L') ADVANCE(44);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == '-') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 41:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'L') ADVANCE(34);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == '-') ADVANCE(66);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 42:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'R') ADVANCE(41);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == '-') ADVANCE(90);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 43:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'T') ADVANCE(42);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == ':') ADVANCE(92);
+      if (lookahead == 's') ADVANCE(44);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 44:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'T') ADVANCE(33);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == ':') ADVANCE(92);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 45:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'T') ADVANCE(38);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'A') ADVANCE(42);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 46:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'p') ADVANCE(36);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'E') ADVANCE(52);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 47:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 't') ADVANCE(46);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'L') ADVANCE(51);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 48:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 't') ADVANCE(47);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'L') ADVANCE(41);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 49:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(275);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'R') ADVANCE(48);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 50:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(277);
-      if (lookahead == 'E') ADVANCE(368);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(378);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'T') ADVANCE(49);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(369);
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 51:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(277);
-      if (lookahead == 'L') ADVANCE(367);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(378);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'T') ADVANCE(40);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(369);
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 52:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(277);
-      if (lookahead == 'T') ADVANCE(366);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(378);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'T') ADVANCE(45);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(369);
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 53:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(277);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(378);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'p') ADVANCE(43);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(369);
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 54:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '-') ADVANCE(57);
-      if (lookahead == '>') ADVANCE(288);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 't') ADVANCE(53);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
@@ -1683,288 +1708,389 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 55:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '-') ADVANCE(84);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 't') ADVANCE(54);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 56:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '>') ADVANCE(288);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '(') ADVANCE(282);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 57:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '>') ADVANCE(291);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(26);
+      if (lookahead == '(') ADVANCE(284);
+      if (lookahead == 'E') ADVANCE(375);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(385);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(376);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(95);
+      END_STATE();
+    case 58:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(284);
+      if (lookahead == 'L') ADVANCE(374);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(385);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(376);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(95);
+      END_STATE();
+    case 59:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(284);
+      if (lookahead == 'T') ADVANCE(373);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(385);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(376);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(95);
+      END_STATE();
+    case 60:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(284);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(385);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(376);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(95);
+      END_STATE();
+    case 61:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '-') ADVANCE(64);
+      if (lookahead == '>') ADVANCE(295);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(63);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(95);
+      END_STATE();
+    case 62:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '-') ADVANCE(91);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(95);
+      END_STATE();
+    case 63:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '>') ADVANCE(295);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(58);
-      END_STATE();
-    case 58:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '>') ADVANCE(292);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(63);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
-      END_STATE();
-    case 59:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'B') ADVANCE(318);
-      if (lookahead == 'D') ADVANCE(312);
-      if (lookahead == 'I') ADVANCE(315);
-      if (lookahead == 'P') ADVANCE(307);
-      if (lookahead == 'S') ADVANCE(304);
-      if (lookahead == '{') ADVANCE(310);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(295);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(295);
-      END_STATE();
-    case 60:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'D') ADVANCE(74);
-      if (lookahead == 'U') ADVANCE(75);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
-      END_STATE();
-    case 61:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'F') ADVANCE(63);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
-      END_STATE();
-    case 62:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'I') ADVANCE(61);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
-      END_STATE();
-    case 63:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'T') ADVANCE(55);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 64:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'a') ADVANCE(71);
+      if (lookahead == '>') ADVANCE(298);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(27);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(63);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != '\n') ADVANCE(65);
       END_STATE();
     case 65:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'a') ADVANCE(77);
+      if (lookahead == '>') ADVANCE(299);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 66:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'e') ADVANCE(64);
+      if (lookahead == 'B') ADVANCE(325);
+      if (lookahead == 'D') ADVANCE(319);
+      if (lookahead == 'I') ADVANCE(322);
+      if (lookahead == 'P') ADVANCE(314);
+      if (lookahead == 'S') ADVANCE(311);
+      if (lookahead == '{') ADVANCE(317);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(302);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != '\n') ADVANCE(302);
       END_STATE();
     case 67:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'e') ADVANCE(76);
+      if (lookahead == 'D') ADVANCE(81);
+      if (lookahead == 'U') ADVANCE(82);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 68:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'e') ADVANCE(60);
+      if (lookahead == 'F') ADVANCE(70);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 69:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'g') ADVANCE(68);
+      if (lookahead == 'I') ADVANCE(68);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 70:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'h') ADVANCE(65);
+      if (lookahead == 'T') ADVANCE(62);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 71:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'k') ADVANCE(326);
+      if (lookahead == 'a') ADVANCE(78);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 72:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'l') ADVANCE(326);
+      if (lookahead == 'a') ADVANCE(84);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 73:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'n') ADVANCE(326);
+      if (lookahead == 'e') ADVANCE(71);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 74:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'o') ADVANCE(80);
+      if (lookahead == 'e') ADVANCE(83);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 75:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'p') ADVANCE(326);
+      if (lookahead == 'e') ADVANCE(67);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 76:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'r') ADVANCE(79);
+      if (lookahead == 'g') ADVANCE(75);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 77:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'r') ADVANCE(81);
+      if (lookahead == 'h') ADVANCE(72);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 78:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 's') ADVANCE(67);
+      if (lookahead == 'k') ADVANCE(333);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 79:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 't') ADVANCE(326);
+      if (lookahead == 'l') ADVANCE(333);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 80:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'w') ADVANCE(73);
+      if (lookahead == 'n') ADVANCE(333);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 81:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '}') ADVANCE(328);
+      if (lookahead == 'o') ADVANCE(87);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 82:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(334);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(334);
-      END_STATE();
-    case 83:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(330);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(330);
-      END_STATE();
-    case 84:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(322);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(322);
-      END_STATE();
-    case 85:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(88);
+      if (lookahead == 'p') ADVANCE(333);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(398);
+          lookahead != ' ') ADVANCE(95);
+      END_STATE();
+    case 83:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'r') ADVANCE(86);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(95);
+      END_STATE();
+    case 84:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'r') ADVANCE(88);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(95);
+      END_STATE();
+    case 85:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 's') ADVANCE(74);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 86:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 't') ADVANCE(333);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(95);
+      END_STATE();
+    case 87:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'w') ADVANCE(80);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(95);
+      END_STATE();
+    case 88:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '}') ADVANCE(335);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(95);
+      END_STATE();
+    case 89:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(341);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(341);
+      END_STATE();
+    case 90:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(337);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(337);
+      END_STATE();
+    case 91:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(329);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(329);
+      END_STATE();
+    case 92:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(95);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(406);
+      END_STATE();
+    case 93:
       ACCEPT_TOKEN(aux_sym_word_token1);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(54);
+          lookahead == 'S') ADVANCE(61);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(63);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
-    case 87:
+    case 94:
       ACCEPT_TOKEN(aux_sym_word_token1);
       if (lookahead == '(' ||
           lookahead == ')' ||
@@ -1972,915 +2098,859 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(378);
+          lookahead == '_') ADVANCE(385);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
-    case 88:
+    case 95:
       ACCEPT_TOKEN(aux_sym_word_token1);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(88);
-      END_STATE();
-    case 89:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(387);
-      if (lookahead == '=') ADVANCE(89);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(20);
-      if (lookahead != 0) ADVANCE(207);
-      END_STATE();
-    case 90:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == '-') ADVANCE(112);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(106);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 91:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == '-') ADVANCE(138);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(106);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 92:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == '-') ADVANCE(139);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(106);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 93:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == ':') ADVANCE(135);
-      if (lookahead == 's') ADVANCE(94);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(106);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 94:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == ':') ADVANCE(135);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(106);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 95:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == 'A') ADVANCE(92);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(106);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead != ' ') ADVANCE(95);
       END_STATE();
     case 96:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == 'E') ADVANCE(102);
+      if (lookahead == '\n') ADVANCE(395);
+      if (lookahead == '=') ADVANCE(96);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(106);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(214);
       END_STATE();
     case 97:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == 'L') ADVANCE(101);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '(') ADVANCE(283);
+      if (lookahead == '-') ADVANCE(119);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
+          lookahead == ' ') ADVANCE(23);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(106);
-      if (lookahead != 0) ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 98:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == 'L') ADVANCE(90);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '(') ADVANCE(283);
+      if (lookahead == '-') ADVANCE(145);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
+          lookahead == ' ') ADVANCE(23);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(106);
-      if (lookahead != 0) ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 99:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == 'R') ADVANCE(98);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '(') ADVANCE(283);
+      if (lookahead == '-') ADVANCE(146);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
+          lookahead == ' ') ADVANCE(23);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(106);
-      if (lookahead != 0) ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 100:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == 'T') ADVANCE(99);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '(') ADVANCE(283);
+      if (lookahead == ':') ADVANCE(142);
+      if (lookahead == 's') ADVANCE(101);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
+          lookahead == ' ') ADVANCE(23);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(106);
-      if (lookahead != 0) ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 101:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == 'T') ADVANCE(91);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '(') ADVANCE(283);
+      if (lookahead == ':') ADVANCE(142);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
+          lookahead == ' ') ADVANCE(23);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(106);
-      if (lookahead != 0) ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 102:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == 'T') ADVANCE(95);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '(') ADVANCE(283);
+      if (lookahead == 'A') ADVANCE(99);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
+          lookahead == ' ') ADVANCE(23);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(106);
-      if (lookahead != 0) ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 103:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == 'p') ADVANCE(93);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '(') ADVANCE(283);
+      if (lookahead == 'E') ADVANCE(109);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
+          lookahead == ' ') ADVANCE(23);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(106);
-      if (lookahead != 0) ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 104:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == 't') ADVANCE(103);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '(') ADVANCE(283);
+      if (lookahead == 'L') ADVANCE(108);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
+          lookahead == ' ') ADVANCE(23);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(106);
-      if (lookahead != 0) ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 105:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == 't') ADVANCE(104);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '(') ADVANCE(283);
+      if (lookahead == 'L') ADVANCE(97);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
+          lookahead == ' ') ADVANCE(23);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(106);
-      if (lookahead != 0) ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 106:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '(') ADVANCE(276);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '(') ADVANCE(283);
+      if (lookahead == 'R') ADVANCE(105);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
+          lookahead == ' ') ADVANCE(23);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(106);
-      if (lookahead != 0) ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 107:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '-') ADVANCE(110);
-      if (lookahead == '>') ADVANCE(290);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '(') ADVANCE(283);
+      if (lookahead == 'T') ADVANCE(106);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
+          lookahead == ' ') ADVANCE(23);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(109);
-      if (lookahead != 0) ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 108:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '-') ADVANCE(140);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '(') ADVANCE(283);
+      if (lookahead == 'T') ADVANCE(98);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 109:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '>') ADVANCE(290);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '(') ADVANCE(283);
+      if (lookahead == 'T') ADVANCE(102);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == ' ') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(109);
-      if (lookahead != 0) ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 110:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '>') ADVANCE(289);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '(') ADVANCE(283);
+      if (lookahead == 'p') ADVANCE(100);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
+          lookahead == ' ') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
+      if (lookahead != 0) ADVANCE(144);
+      END_STATE();
+    case 111:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '(') ADVANCE(283);
+      if (lookahead == 't') ADVANCE(110);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
+      if (lookahead != 0) ADVANCE(144);
+      END_STATE();
+    case 112:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '(') ADVANCE(283);
+      if (lookahead == 't') ADVANCE(111);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
+      if (lookahead != 0) ADVANCE(144);
+      END_STATE();
+    case 113:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '(') ADVANCE(283);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
+      if (lookahead != 0) ADVANCE(144);
+      END_STATE();
+    case 114:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '-') ADVANCE(117);
+      if (lookahead == '>') ADVANCE(297);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead != 0) ADVANCE(144);
+      END_STATE();
+    case 115:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '-') ADVANCE(147);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
+      END_STATE();
+    case 116:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '>') ADVANCE(297);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(109);
-      if (lookahead != 0) ADVANCE(111);
-      END_STATE();
-    case 111:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '>') ADVANCE(293);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 112:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'B') ADVANCE(301);
-      if (lookahead == 'D') ADVANCE(299);
-      if (lookahead == 'I') ADVANCE(300);
-      if (lookahead == 'P') ADVANCE(297);
-      if (lookahead == 'S') ADVANCE(296);
-      if (lookahead == '{') ADVANCE(298);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(303);
-      if (lookahead != 0) ADVANCE(302);
-      END_STATE();
-    case 113:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'D') ADVANCE(127);
-      if (lookahead == 'U') ADVANCE(128);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 114:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'F') ADVANCE(116);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 115:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'I') ADVANCE(114);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 116:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'T') ADVANCE(108);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 117:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'a') ADVANCE(124);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '>') ADVANCE(296);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead != 0) ADVANCE(118);
       END_STATE();
     case 118:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'a') ADVANCE(130);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '>') ADVANCE(300);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 119:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'e') ADVANCE(117);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'B') ADVANCE(308);
+      if (lookahead == 'D') ADVANCE(306);
+      if (lookahead == 'I') ADVANCE(307);
+      if (lookahead == 'P') ADVANCE(304);
+      if (lookahead == 'S') ADVANCE(303);
+      if (lookahead == '{') ADVANCE(305);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(310);
+      if (lookahead != 0) ADVANCE(309);
       END_STATE();
     case 120:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'e') ADVANCE(129);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'D') ADVANCE(134);
+      if (lookahead == 'U') ADVANCE(135);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 121:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'e') ADVANCE(113);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'F') ADVANCE(123);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 122:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'g') ADVANCE(121);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'I') ADVANCE(121);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 123:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'h') ADVANCE(118);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'T') ADVANCE(115);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 124:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'k') ADVANCE(327);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'a') ADVANCE(131);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 125:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'l') ADVANCE(327);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'a') ADVANCE(137);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 126:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'n') ADVANCE(327);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'e') ADVANCE(124);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 127:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'o') ADVANCE(133);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'e') ADVANCE(136);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 128:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'p') ADVANCE(327);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'e') ADVANCE(120);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 129:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'r') ADVANCE(132);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'g') ADVANCE(128);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 130:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'r') ADVANCE(134);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'h') ADVANCE(125);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 131:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 's') ADVANCE(120);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'k') ADVANCE(334);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 132:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 't') ADVANCE(327);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'l') ADVANCE(334);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 133:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'w') ADVANCE(126);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'n') ADVANCE(334);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 134:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '}') ADVANCE(329);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'o') ADVANCE(140);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 135:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'p') ADVANCE(334);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(137);
-      if (lookahead != 0) ADVANCE(397);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 136:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'r') ADVANCE(139);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
+      END_STATE();
+    case 137:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'r') ADVANCE(141);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
+      END_STATE();
+    case 138:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 's') ADVANCE(127);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
+      END_STATE();
+    case 139:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 't') ADVANCE(334);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
+      END_STATE();
+    case 140:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'w') ADVANCE(133);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
+      END_STATE();
+    case 141:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '}') ADVANCE(336);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
+      END_STATE();
+    case 142:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(144);
+      if (lookahead != 0) ADVANCE(405);
+      END_STATE();
+    case 143:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(107);
+          lookahead == 'S') ADVANCE(114);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(109);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 137:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 138:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(336);
-      if (lookahead != 0) ADVANCE(335);
-      END_STATE();
-    case 139:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(332);
-      if (lookahead != 0) ADVANCE(331);
-      END_STATE();
-    case 140:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(324);
-      if (lookahead != 0) ADVANCE(323);
-      END_STATE();
-    case 141:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == '-') ADVANCE(201);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
-      END_STATE();
-    case 142:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == '-') ADVANCE(178);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
-      END_STATE();
-    case 143:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == '-') ADVANCE(202);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 144:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == ':') ADVANCE(204);
-      if (lookahead == 's') ADVANCE(145);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 145:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == ':') ADVANCE(204);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(343);
+      if (lookahead != 0) ADVANCE(342);
       END_STATE();
     case 146:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'A') ADVANCE(143);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(339);
+      if (lookahead != 0) ADVANCE(338);
       END_STATE();
     case 147:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'E') ADVANCE(153);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(331);
+      if (lookahead != 0) ADVANCE(330);
       END_STATE();
     case 148:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'L') ADVANCE(152);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == '-') ADVANCE(208);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 149:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'L') ADVANCE(142);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == '-') ADVANCE(185);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 150:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'R') ADVANCE(149);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == '-') ADVANCE(209);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 151:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'T') ADVANCE(150);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == ':') ADVANCE(211);
+      if (lookahead == 's') ADVANCE(152);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 152:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'T') ADVANCE(141);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == ':') ADVANCE(211);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 153:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'T') ADVANCE(146);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'A') ADVANCE(150);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 154:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'p') ADVANCE(144);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'E') ADVANCE(160);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 155:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 't') ADVANCE(154);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'L') ADVANCE(159);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 156:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 't') ADVANCE(155);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'L') ADVANCE(149);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 157:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(275);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'R') ADVANCE(156);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 158:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(360);
-      if (lookahead == 'E') ADVANCE(345);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(360);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(346);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
-      END_STATE();
-    case 159:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(360);
-      if (lookahead == 'L') ADVANCE(344);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(360);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(346);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
-      END_STATE();
-    case 160:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(360);
-      if (lookahead == 'T') ADVANCE(343);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(360);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(346);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
-      END_STATE();
-    case 161:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(360);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(360);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(346);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
-      END_STATE();
-    case 162:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '-') ADVANCE(176);
-      if (lookahead == '>') ADVANCE(288);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'T') ADVANCE(157);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(175);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
+      END_STATE();
+    case 159:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'T') ADVANCE(148);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(214);
+      END_STATE();
+    case 160:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'T') ADVANCE(153);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(214);
+      END_STATE();
+    case 161:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'p') ADVANCE(151);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(214);
+      END_STATE();
+    case 162:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 't') ADVANCE(161);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 163:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '-') ADVANCE(203);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 't') ADVANCE(162);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 164:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(89);
+      if (lookahead == '(') ADVANCE(282);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 165:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(164);
+      if (lookahead == '(') ADVANCE(367);
+      if (lookahead == 'E') ADVANCE(352);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(367);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(353);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 166:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(165);
+      if (lookahead == '(') ADVANCE(367);
+      if (lookahead == 'L') ADVANCE(351);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(367);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(353);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 167:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(166);
+      if (lookahead == '(') ADVANCE(367);
+      if (lookahead == 'T') ADVANCE(350);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(367);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(353);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 168:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(167);
+      if (lookahead == '(') ADVANCE(367);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(367);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(353);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 169:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(168);
+      if (lookahead == '-') ADVANCE(183);
+      if (lookahead == '>') ADVANCE(295);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 170:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(169);
+      if (lookahead == '-') ADVANCE(210);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 171:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(170);
+      if (lookahead == '=') ADVANCE(96);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 172:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
@@ -2888,7 +2958,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 173:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
@@ -2896,7 +2966,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 174:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
@@ -2904,280 +2974,336 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 175:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '>') ADVANCE(288);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(175);
+      if (lookahead == '=') ADVANCE(174);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 176:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '>') ADVANCE(291);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(26);
+      if (lookahead == '=') ADVANCE(175);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(214);
+      END_STATE();
+    case 177:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '=') ADVANCE(176);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(214);
+      END_STATE();
+    case 178:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '=') ADVANCE(177);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(214);
+      END_STATE();
+    case 179:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '=') ADVANCE(178);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(214);
+      END_STATE();
+    case 180:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '=') ADVANCE(179);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(214);
+      END_STATE();
+    case 181:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '=') ADVANCE(180);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(214);
+      END_STATE();
+    case 182:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '>') ADVANCE(295);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(175);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(177);
-      END_STATE();
-    case 177:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '>') ADVANCE(292);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
-      END_STATE();
-    case 178:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'B') ADVANCE(320);
-      if (lookahead == 'D') ADVANCE(314);
-      if (lookahead == 'I') ADVANCE(317);
-      if (lookahead == 'P') ADVANCE(309);
-      if (lookahead == 'S') ADVANCE(305);
-      if (lookahead == '{') ADVANCE(311);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(295);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(295);
-      END_STATE();
-    case 179:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'D') ADVANCE(193);
-      if (lookahead == 'U') ADVANCE(194);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
-      END_STATE();
-    case 180:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'F') ADVANCE(182);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
-      END_STATE();
-    case 181:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'I') ADVANCE(180);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
-      END_STATE();
-    case 182:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'T') ADVANCE(163);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 183:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'a') ADVANCE(190);
+      if (lookahead == '>') ADVANCE(298);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(27);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != '\n') ADVANCE(184);
       END_STATE();
     case 184:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'a') ADVANCE(196);
+      if (lookahead == '>') ADVANCE(299);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 185:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'e') ADVANCE(183);
+      if (lookahead == 'B') ADVANCE(327);
+      if (lookahead == 'D') ADVANCE(321);
+      if (lookahead == 'I') ADVANCE(324);
+      if (lookahead == 'P') ADVANCE(316);
+      if (lookahead == 'S') ADVANCE(312);
+      if (lookahead == '{') ADVANCE(318);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(302);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != '\n') ADVANCE(302);
       END_STATE();
     case 186:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'e') ADVANCE(195);
+      if (lookahead == 'D') ADVANCE(200);
+      if (lookahead == 'U') ADVANCE(201);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 187:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'e') ADVANCE(179);
+      if (lookahead == 'F') ADVANCE(189);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 188:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'g') ADVANCE(187);
+      if (lookahead == 'I') ADVANCE(187);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 189:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'h') ADVANCE(184);
+      if (lookahead == 'T') ADVANCE(170);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 190:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'k') ADVANCE(326);
+      if (lookahead == 'a') ADVANCE(197);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 191:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'l') ADVANCE(326);
+      if (lookahead == 'a') ADVANCE(203);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 192:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'n') ADVANCE(326);
+      if (lookahead == 'e') ADVANCE(190);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 193:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'o') ADVANCE(199);
+      if (lookahead == 'e') ADVANCE(202);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 194:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'p') ADVANCE(326);
+      if (lookahead == 'e') ADVANCE(186);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 195:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'r') ADVANCE(198);
+      if (lookahead == 'g') ADVANCE(194);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 196:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'r') ADVANCE(200);
+      if (lookahead == 'h') ADVANCE(191);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 197:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 's') ADVANCE(186);
+      if (lookahead == 'k') ADVANCE(333);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 198:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 't') ADVANCE(326);
+      if (lookahead == 'l') ADVANCE(333);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 199:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'w') ADVANCE(192);
+      if (lookahead == 'n') ADVANCE(333);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 200:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '}') ADVANCE(328);
+      if (lookahead == 'o') ADVANCE(206);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 201:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(334);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(334);
-      END_STATE();
-    case 202:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(330);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(330);
-      END_STATE();
-    case 203:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(322);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(322);
-      END_STATE();
-    case 204:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(207);
+      if (lookahead == 'p') ADVANCE(333);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(398);
+          lookahead != ' ') ADVANCE(214);
+      END_STATE();
+    case 202:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'r') ADVANCE(205);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(214);
+      END_STATE();
+    case 203:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'r') ADVANCE(207);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(214);
+      END_STATE();
+    case 204:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 's') ADVANCE(193);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 205:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 't') ADVANCE(333);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(214);
+      END_STATE();
+    case 206:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'w') ADVANCE(199);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(214);
+      END_STATE();
+    case 207:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '}') ADVANCE(335);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(214);
+      END_STATE();
+    case 208:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(341);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(341);
+      END_STATE();
+    case 209:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(337);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(337);
+      END_STATE();
+    case 210:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(329);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(329);
+      END_STATE();
+    case 211:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(214);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(406);
+      END_STATE();
+    case 212:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(162);
+          lookahead == 'S') ADVANCE(169);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(175);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
-    case 206:
+    case 213:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
       if (lookahead == '(' ||
           lookahead == ')' ||
@@ -3185,97 +3311,41 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(360);
+          lookahead == '_') ADVANCE(367);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
-    case 207:
+    case 214:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(207);
-      END_STATE();
-    case 208:
-      ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '\n') ADVANCE(388);
-      if (lookahead == '-') ADVANCE(208);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(19);
-      if (lookahead != 0) ADVANCE(220);
-      END_STATE();
-    case 209:
-      ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(209);
-      END_STATE();
-    case 210:
-      ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(208);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(220);
-      END_STATE();
-    case 211:
-      ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(210);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(220);
-      END_STATE();
-    case 212:
-      ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(211);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(220);
-      END_STATE();
-    case 213:
-      ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(212);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(220);
-      END_STATE();
-    case 214:
-      ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(213);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(220);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
     case 215:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(214);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(220);
+      if (lookahead == '\n') ADVANCE(396);
+      if (lookahead == '-') ADVANCE(215);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(20);
+      if (lookahead != 0) ADVANCE(227);
       END_STATE();
     case 216:
+      ACCEPT_TOKEN(aux_sym_word_noli_token2);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(216);
+      END_STATE();
+    case 217:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
       if (lookahead == '-') ADVANCE(215);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(220);
-      END_STATE();
-    case 217:
-      ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(216);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(220);
+          lookahead != ' ') ADVANCE(227);
       END_STATE();
     case 218:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
@@ -3283,7 +3353,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(220);
+          lookahead != ' ') ADVANCE(227);
       END_STATE();
     case 219:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
@@ -3291,380 +3361,426 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(220);
+          lookahead != ' ') ADVANCE(227);
       END_STATE();
     case 220:
+      ACCEPT_TOKEN(aux_sym_word_noli_token2);
+      if (lookahead == '-') ADVANCE(219);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(227);
+      END_STATE();
+    case 221:
+      ACCEPT_TOKEN(aux_sym_word_noli_token2);
+      if (lookahead == '-') ADVANCE(220);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(227);
+      END_STATE();
+    case 222:
+      ACCEPT_TOKEN(aux_sym_word_noli_token2);
+      if (lookahead == '-') ADVANCE(221);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(227);
+      END_STATE();
+    case 223:
+      ACCEPT_TOKEN(aux_sym_word_noli_token2);
+      if (lookahead == '-') ADVANCE(222);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(227);
+      END_STATE();
+    case 224:
+      ACCEPT_TOKEN(aux_sym_word_noli_token2);
+      if (lookahead == '-') ADVANCE(223);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(227);
+      END_STATE();
+    case 225:
+      ACCEPT_TOKEN(aux_sym_word_noli_token2);
+      if (lookahead == '-') ADVANCE(224);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(227);
+      END_STATE();
+    case 226:
+      ACCEPT_TOKEN(aux_sym_word_noli_token2);
+      if (lookahead == '-') ADVANCE(225);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(227);
+      END_STATE();
+    case 227:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(220);
+          lookahead != ' ') ADVANCE(227);
       END_STATE();
-    case 221:
+    case 228:
       ACCEPT_TOKEN(anon_sym_SQUOTE);
       END_STATE();
-    case 222:
+    case 229:
       ACCEPT_TOKEN(anon_sym_SQUOTE);
-      if (lookahead == '\n') ADVANCE(386);
+      if (lookahead == '\n') ADVANCE(394);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
-    case 223:
+    case 230:
       ACCEPT_TOKEN(anon_sym_SQUOTE);
-      if (lookahead == ' ') ADVANCE(540);
+      if (lookahead == ' ') ADVANCE(548);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
-    case 224:
+    case 231:
       ACCEPT_TOKEN(anon_sym_SQUOTE);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
-      END_STATE();
-    case 225:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      END_STATE();
-    case 226:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '\t') ADVANCE(254);
-      END_STATE();
-    case 227:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '\t') ADVANCE(254);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(244);
-      END_STATE();
-    case 228:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'E') ADVANCE(45);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(49);
-      END_STATE();
-    case 229:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'E') ADVANCE(45);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
-      END_STATE();
-    case 230:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'L') ADVANCE(44);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(49);
-      END_STATE();
-    case 231:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'L') ADVANCE(44);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 232:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'T') ADVANCE(42);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(49);
       END_STATE();
     case 233:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'T') ADVANCE(42);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+      if (lookahead == '\t') ADVANCE(261);
       END_STATE();
     case 234:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 't') ADVANCE(402);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(403);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(49);
+      if (lookahead == '\t') ADVANCE(261);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
       END_STATE();
     case 235:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(403);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'E') ADVANCE(52);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(249);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(49);
+          lookahead == '_') ADVANCE(56);
       END_STATE();
     case 236:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(49);
-      END_STATE();
-    case 237:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(275);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'E') ADVANCE(52);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      END_STATE();
+    case 237:
+      ACCEPT_TOKEN(aux_sym__word_common_token1);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'L') ADVANCE(51);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(249);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(56);
       END_STATE();
     case 238:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(244);
-      if (lookahead == 't') ADVANCE(407);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(408);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'L') ADVANCE(51);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(242);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(244);
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
       END_STATE();
     case 239:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(244);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(408);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'T') ADVANCE(49);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(249);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(242);
+          lookahead == '_') ADVANCE(56);
+      END_STATE();
+    case 240:
+      ACCEPT_TOKEN(aux_sym__word_common_token1);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'T') ADVANCE(49);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      END_STATE();
+    case 241:
+      ACCEPT_TOKEN(aux_sym__word_common_token1);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 't') ADVANCE(410);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(411);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(56);
+      END_STATE();
+    case 242:
+      ACCEPT_TOKEN(aux_sym__word_common_token1);
+      if (lookahead == '(') ADVANCE(282);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(411);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(56);
+      END_STATE();
+    case 243:
+      ACCEPT_TOKEN(aux_sym__word_common_token1);
+      if (lookahead == '(') ADVANCE(282);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(249);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(56);
+      END_STATE();
+    case 244:
+      ACCEPT_TOKEN(aux_sym__word_common_token1);
+      if (lookahead == '(') ADVANCE(282);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      END_STATE();
+    case 245:
+      ACCEPT_TOKEN(aux_sym__word_common_token1);
+      if (lookahead == '(') ADVANCE(251);
+      if (lookahead == 't') ADVANCE(415);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(416);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(249);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(244);
+          lookahead != '\'') ADVANCE(251);
       END_STATE();
-    case 240:
+    case 246:
+      ACCEPT_TOKEN(aux_sym__word_common_token1);
+      if (lookahead == '(') ADVANCE(251);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(416);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(249);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '\'') ADVANCE(251);
+      END_STATE();
+    case 247:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(54);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(243);
+          lookahead == 'S') ADVANCE(61);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(250);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(63);
       END_STATE();
-    case 241:
+    case 248:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(244);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
       END_STATE();
-    case 242:
+    case 249:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == '(') ADVANCE(275);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
+      if (lookahead == '(') ADVANCE(282);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(249);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(49);
+          lookahead == '_') ADVANCE(56);
       END_STATE();
-    case 243:
+    case 250:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == '>') ADVANCE(288);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(243);
+      if (lookahead == '>') ADVANCE(295);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(250);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(63);
       END_STATE();
-    case 244:
+    case 251:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(244);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
       END_STATE();
-    case 245:
+    case 252:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(245);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(252);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != ')' &&
-          lookahead != ']') ADVANCE(398);
-      END_STATE();
-    case 246:
-      ACCEPT_TOKEN(anon_sym_SQUOTE2);
-      END_STATE();
-    case 247:
-      ACCEPT_TOKEN(aux_sym__word_common_token3);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '|') ADVANCE(247);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 248:
-      ACCEPT_TOKEN(aux_sym__word_common_token3);
-      if (lookahead == '|') ADVANCE(248);
-      END_STATE();
-    case 249:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      END_STATE();
-    case 250:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '|') ADVANCE(247);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 251:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '|') ADVANCE(535);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          (lookahead < '{' || '}' < lookahead)) ADVANCE(538);
-      END_STATE();
-    case 252:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '|') ADVANCE(248);
+          lookahead != ']') ADVANCE(406);
       END_STATE();
     case 253:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '|') ADVANCE(248);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(244);
+      ACCEPT_TOKEN(anon_sym_SQUOTE2);
       END_STATE();
     case 254:
-      ACCEPT_TOKEN(aux_sym__word_common_token4);
+      ACCEPT_TOKEN(aux_sym__word_common_token3);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '|') ADVANCE(254);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 255:
-      ACCEPT_TOKEN(aux_sym__word_common_token4);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead != 0) ADVANCE(22);
+      ACCEPT_TOKEN(aux_sym__word_common_token3);
+      if (lookahead == '|') ADVANCE(255);
       END_STATE();
     case 256:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '{') ADVANCE(265);
-      if (lookahead == '}') ADVANCE(263);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+      ACCEPT_TOKEN(anon_sym_PIPE);
       END_STATE();
     case 257:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
-      if (lookahead == '{') ADVANCE(267);
-      if (lookahead == '}') ADVANCE(262);
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '|') ADVANCE(254);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 258:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
-      if (lookahead == '{') ADVANCE(267);
-      if (lookahead == '}') ADVANCE(262);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(244);
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '|') ADVANCE(543);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          (lookahead < '{' || '}' < lookahead)) ADVANCE(546);
       END_STATE();
     case 259:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == '|') ADVANCE(255);
       END_STATE();
     case 260:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == '|') ADVANCE(255);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
       END_STATE();
     case 261:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(244);
+      ACCEPT_TOKEN(aux_sym__word_common_token4);
       END_STATE();
     case 262:
-      ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
+      ACCEPT_TOKEN(aux_sym__word_common_token4);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead != 0) ADVANCE(23);
       END_STATE();
     case 263:
-      ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
-      if (lookahead == '\n') ADVANCE(386);
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '{') ADVANCE(272);
+      if (lookahead == '}') ADVANCE(270);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 264:
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      if (lookahead == '{') ADVANCE(274);
+      if (lookahead == '}') ADVANCE(269);
+      END_STATE();
+    case 265:
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      if (lookahead == '{') ADVANCE(274);
+      if (lookahead == '}') ADVANCE(269);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
+      END_STATE();
+    case 266:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
+      END_STATE();
+    case 267:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
+      END_STATE();
+    case 268:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
+      END_STATE();
+    case 269:
+      ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
+      END_STATE();
+    case 270:
+      ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
+      END_STATE();
+    case 271:
       ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
-      END_STATE();
-    case 265:
-      ACCEPT_TOKEN(aux_sym__word_common_token5);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '{') ADVANCE(265);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(266);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 266:
-      ACCEPT_TOKEN(aux_sym__word_common_token5);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(266);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 267:
-      ACCEPT_TOKEN(aux_sym__word_common_token5);
-      if (lookahead == '{') ADVANCE(267);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(268);
-      END_STATE();
-    case 268:
-      ACCEPT_TOKEN(aux_sym__word_common_token5);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(268);
-      END_STATE();
-    case 269:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      END_STATE();
-    case 270:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 271:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 272:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(244);
+      ACCEPT_TOKEN(aux_sym__word_common_token5);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '{') ADVANCE(272);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(273);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 273:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(360);
+      ACCEPT_TOKEN(aux_sym__word_common_token5);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(273);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 274:
+      ACCEPT_TOKEN(aux_sym__word_common_token5);
+      if (lookahead == '{') ADVANCE(274);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(275);
+      END_STATE();
+    case 275:
+      ACCEPT_TOKEN(aux_sym__word_common_token5);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(275);
+      END_STATE();
+    case 276:
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      END_STATE();
+    case 277:
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
+      END_STATE();
+    case 278:
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(546);
+      END_STATE();
+    case 279:
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
+      END_STATE();
+    case 280:
       ACCEPT_TOKEN(anon_sym_LPAREN);
       if (lookahead == '(' ||
           lookahead == ')' ||
@@ -3672,19 +3788,29 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(378);
+          lookahead == '_') ADVANCE(367);
       END_STATE();
-    case 275:
+    case 281:
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(385);
+      END_STATE();
+    case 282:
       ACCEPT_TOKEN(aux_sym__word_common_token6);
       END_STATE();
-    case 276:
+    case 283:
       ACCEPT_TOKEN(aux_sym__word_common_token6);
-      if (lookahead == '\n') ADVANCE(386);
+      if (lookahead == '\n') ADVANCE(394);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
-    case 277:
+    case 284:
       ACCEPT_TOKEN(aux_sym__word_common_token6);
       if (lookahead == '(' ||
           lookahead == ')' ||
@@ -3692,274 +3818,274 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(378);
-      END_STATE();
-    case 278:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      END_STATE();
-    case 279:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 280:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
-      END_STATE();
-    case 281:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(244);
-      END_STATE();
-    case 282:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
-      END_STATE();
-    case 283:
-      ACCEPT_TOKEN(anon_sym_GT);
-      END_STATE();
-    case 284:
-      ACCEPT_TOKEN(anon_sym_GT);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == '_') ADVANCE(385);
       END_STATE();
     case 285:
-      ACCEPT_TOKEN(anon_sym_GT);
-      if (lookahead == ' ') ADVANCE(540);
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      END_STATE();
+    case 286:
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
+      END_STATE();
+    case 287:
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      if (lookahead == ' ') ADVANCE(548);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
-    case 286:
+    case 288:
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
+      END_STATE();
+    case 289:
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(476);
+      END_STATE();
+    case 290:
       ACCEPT_TOKEN(anon_sym_GT);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(244);
       END_STATE();
-    case 287:
+    case 291:
+      ACCEPT_TOKEN(anon_sym_GT);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
+      END_STATE();
+    case 292:
+      ACCEPT_TOKEN(anon_sym_GT);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(546);
+      END_STATE();
+    case 293:
+      ACCEPT_TOKEN(anon_sym_GT);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
+      END_STATE();
+    case 294:
       ACCEPT_TOKEN(anon_sym_GT);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
-      END_STATE();
-    case 288:
-      ACCEPT_TOKEN(aux_sym_keycode_token1);
-      END_STATE();
-    case 289:
-      ACCEPT_TOKEN(aux_sym_keycode_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '>') ADVANCE(293);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 290:
-      ACCEPT_TOKEN(aux_sym_keycode_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 291:
-      ACCEPT_TOKEN(aux_sym_keycode_token1);
-      if (lookahead == '>') ADVANCE(292);
-      END_STATE();
-    case 292:
-      ACCEPT_TOKEN(aux_sym_keycode_token2);
-      END_STATE();
-    case 293:
-      ACCEPT_TOKEN(aux_sym_keycode_token2);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 294:
-      ACCEPT_TOKEN(aux_sym_keycode_token2);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead != 0) ADVANCE(22);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 295:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      ACCEPT_TOKEN(aux_sym_keycode_token1);
       END_STATE();
     case 296:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'H') ADVANCE(115);
+      ACCEPT_TOKEN(aux_sym_keycode_token1);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '>') ADVANCE(300);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 297:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'a') ADVANCE(122);
+      ACCEPT_TOKEN(aux_sym_keycode_token1);
+      if (lookahead == '\n') ADVANCE(394);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 298:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'c') ADVANCE(123);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+      ACCEPT_TOKEN(aux_sym_keycode_token1);
+      if (lookahead == '>') ADVANCE(299);
       END_STATE();
     case 299:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'e') ADVANCE(125);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+      ACCEPT_TOKEN(aux_sym_keycode_token2);
       END_STATE();
     case 300:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'n') ADVANCE(131);
+      ACCEPT_TOKEN(aux_sym_keycode_token2);
+      if (lookahead == '\n') ADVANCE(394);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 301:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == 'r') ADVANCE(119);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+      ACCEPT_TOKEN(aux_sym_keycode_token2);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead != 0) ADVANCE(23);
       END_STATE();
     case 302:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
       END_STATE();
     case 303:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead != 0) ADVANCE(22);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'H') ADVANCE(122);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 304:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'H') ADVANCE(62);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'a') ADVANCE(129);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 305:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'H') ADVANCE(181);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'c') ADVANCE(130);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 306:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'H') ADVANCE(373);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(378);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'e') ADVANCE(132);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 307:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'a') ADVANCE(69);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'n') ADVANCE(138);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 308:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'a') ADVANCE(69);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(378);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == 'r') ADVANCE(126);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 309:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'a') ADVANCE(188);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 310:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'c') ADVANCE(70);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead != 0) ADVANCE(23);
       END_STATE();
     case 311:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'c') ADVANCE(189);
+      if (lookahead == 'H') ADVANCE(69);
       END_STATE();
     case 312:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'e') ADVANCE(72);
+      if (lookahead == 'H') ADVANCE(188);
       END_STATE();
     case 313:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'e') ADVANCE(72);
+      if (lookahead == 'H') ADVANCE(380);
       if (lookahead == '(' ||
           lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(378);
+          lookahead == '_') ADVANCE(385);
       END_STATE();
     case 314:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'e') ADVANCE(191);
+      if (lookahead == 'a') ADVANCE(76);
       END_STATE();
     case 315:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'n') ADVANCE(78);
+      if (lookahead == 'a') ADVANCE(76);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(385);
       END_STATE();
     case 316:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'n') ADVANCE(78);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(378);
+      if (lookahead == 'a') ADVANCE(195);
       END_STATE();
     case 317:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'n') ADVANCE(197);
+      if (lookahead == 'c') ADVANCE(77);
       END_STATE();
     case 318:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'r') ADVANCE(66);
+      if (lookahead == 'c') ADVANCE(196);
       END_STATE();
     case 319:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'r') ADVANCE(66);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(378);
+      if (lookahead == 'e') ADVANCE(79);
       END_STATE();
     case 320:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'r') ADVANCE(185);
+      if (lookahead == 'e') ADVANCE(79);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(385);
       END_STATE();
     case 321:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'e') ADVANCE(198);
+      END_STATE();
+    case 322:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'n') ADVANCE(85);
+      END_STATE();
+    case 323:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'n') ADVANCE(85);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(385);
+      END_STATE();
+    case 324:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'n') ADVANCE(204);
+      END_STATE();
+    case 325:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'r') ADVANCE(73);
+      END_STATE();
+    case 326:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'r') ADVANCE(73);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(385);
+      END_STATE();
+    case 327:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'r') ADVANCE(192);
+      END_STATE();
+    case 328:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
       if (lookahead == '(' ||
           lookahead == ')' ||
@@ -3967,69 +4093,69 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(378);
-      END_STATE();
-    case 322:
-      ACCEPT_TOKEN(aux_sym_keycode_token4);
-      END_STATE();
-    case 323:
-      ACCEPT_TOKEN(aux_sym_keycode_token4);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 324:
-      ACCEPT_TOKEN(aux_sym_keycode_token4);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead != 0) ADVANCE(22);
-      END_STATE();
-    case 325:
-      ACCEPT_TOKEN(aux_sym_keycode_token4);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(378);
-      END_STATE();
-    case 326:
-      ACCEPT_TOKEN(aux_sym_keycode_token5);
-      END_STATE();
-    case 327:
-      ACCEPT_TOKEN(aux_sym_keycode_token5);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
-      END_STATE();
-    case 328:
-      ACCEPT_TOKEN(aux_sym_keycode_token6);
+          lookahead == '_') ADVANCE(385);
       END_STATE();
     case 329:
-      ACCEPT_TOKEN(aux_sym_keycode_token6);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+      ACCEPT_TOKEN(aux_sym_keycode_token4);
       END_STATE();
     case 330:
-      ACCEPT_TOKEN(aux_sym_keycode_token7);
+      ACCEPT_TOKEN(aux_sym_keycode_token4);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 331:
-      ACCEPT_TOKEN(aux_sym_keycode_token7);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+      ACCEPT_TOKEN(aux_sym_keycode_token4);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead != 0) ADVANCE(23);
       END_STATE();
     case 332:
-      ACCEPT_TOKEN(aux_sym_keycode_token7);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead != 0) ADVANCE(22);
+      ACCEPT_TOKEN(aux_sym_keycode_token4);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(385);
       END_STATE();
     case 333:
+      ACCEPT_TOKEN(aux_sym_keycode_token5);
+      END_STATE();
+    case 334:
+      ACCEPT_TOKEN(aux_sym_keycode_token5);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
+      END_STATE();
+    case 335:
+      ACCEPT_TOKEN(aux_sym_keycode_token6);
+      END_STATE();
+    case 336:
+      ACCEPT_TOKEN(aux_sym_keycode_token6);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
+      END_STATE();
+    case 337:
+      ACCEPT_TOKEN(aux_sym_keycode_token7);
+      END_STATE();
+    case 338:
+      ACCEPT_TOKEN(aux_sym_keycode_token7);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
+      END_STATE();
+    case 339:
+      ACCEPT_TOKEN(aux_sym_keycode_token7);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead != 0) ADVANCE(23);
+      END_STATE();
+    case 340:
       ACCEPT_TOKEN(aux_sym_keycode_token7);
       if (lookahead == '(' ||
           lookahead == ')' ||
@@ -4037,24 +4163,24 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(378);
+          lookahead == '_') ADVANCE(385);
       END_STATE();
-    case 334:
+    case 341:
       ACCEPT_TOKEN(aux_sym_keycode_token8);
       END_STATE();
-    case 335:
+    case 342:
       ACCEPT_TOKEN(aux_sym_keycode_token8);
-      if (lookahead == '\n') ADVANCE(386);
+      if (lookahead == '\n') ADVANCE(394);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
-    case 336:
+    case 343:
       ACCEPT_TOKEN(aux_sym_keycode_token8);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead != 0) ADVANCE(22);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead != 0) ADVANCE(23);
       END_STATE();
-    case 337:
+    case 344:
       ACCEPT_TOKEN(aux_sym_keycode_token8);
       if (lookahead == '(' ||
           lookahead == ')' ||
@@ -4062,273 +4188,273 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(378);
-      END_STATE();
-    case 338:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(360);
-      if (lookahead == '-') ADVANCE(357);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(360);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(346);
-      END_STATE();
-    case 339:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(360);
-      if (lookahead == '-') ADVANCE(348);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(360);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(346);
-      END_STATE();
-    case 340:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(360);
-      if (lookahead == '-') ADVANCE(358);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(360);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(346);
-      END_STATE();
-    case 341:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(360);
-      if (lookahead == 'A') ADVANCE(340);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(360);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(346);
-      END_STATE();
-    case 342:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(360);
-      if (lookahead == 'L') ADVANCE(339);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(360);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(346);
-      END_STATE();
-    case 343:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(360);
-      if (lookahead == 'R') ADVANCE(342);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(360);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(346);
-      END_STATE();
-    case 344:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(360);
-      if (lookahead == 'T') ADVANCE(338);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(360);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(346);
+          lookahead == '_') ADVANCE(385);
       END_STATE();
     case 345:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(360);
-      if (lookahead == 'T') ADVANCE(341);
+      if (lookahead == '(') ADVANCE(367);
+      if (lookahead == '-') ADVANCE(364);
       if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(360);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
+          lookahead == '.') ADVANCE(367);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(346);
+          lookahead == '_') ADVANCE(353);
       END_STATE();
     case 346:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(360);
+      if (lookahead == '(') ADVANCE(367);
+      if (lookahead == '-') ADVANCE(355);
       if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(360);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
+          lookahead == '.') ADVANCE(367);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(346);
+          lookahead == '_') ADVANCE(353);
       END_STATE();
     case 347:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '-') ADVANCE(359);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '(') ADVANCE(367);
+      if (lookahead == '-') ADVANCE(365);
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(367);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(360);
+          lookahead == '_') ADVANCE(353);
       END_STATE();
     case 348:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'B') ADVANCE(356);
-      if (lookahead == 'D') ADVANCE(354);
-      if (lookahead == 'I') ADVANCE(355);
-      if (lookahead == 'P') ADVANCE(353);
-      if (lookahead == 'S') ADVANCE(350);
-      if (lookahead == '{') ADVANCE(311);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(295);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(367);
+      if (lookahead == 'A') ADVANCE(347);
+      if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(360);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(295);
+          lookahead == '.') ADVANCE(367);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(353);
       END_STATE();
     case 349:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'F') ADVANCE(352);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(367);
+      if (lookahead == 'L') ADVANCE(346);
+      if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.') ADVANCE(367);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(360);
+          lookahead == '_') ADVANCE(353);
       END_STATE();
     case 350:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'H') ADVANCE(351);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(367);
+      if (lookahead == 'R') ADVANCE(349);
+      if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.') ADVANCE(367);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(360);
+          lookahead == '_') ADVANCE(353);
       END_STATE();
     case 351:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'I') ADVANCE(349);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(367);
+      if (lookahead == 'T') ADVANCE(345);
+      if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.') ADVANCE(367);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(360);
+          lookahead == '_') ADVANCE(353);
       END_STATE();
     case 352:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'T') ADVANCE(347);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(367);
+      if (lookahead == 'T') ADVANCE(348);
+      if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.') ADVANCE(367);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(360);
+          lookahead == '_') ADVANCE(353);
       END_STATE();
     case 353:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'a') ADVANCE(188);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(367);
+      if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.') ADVANCE(367);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(360);
+          lookahead == '_') ADVANCE(353);
       END_STATE();
     case 354:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'e') ADVANCE(191);
+      if (lookahead == '-') ADVANCE(366);
       if (lookahead == '(' ||
           lookahead == ')' ||
-          lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(360);
+          lookahead == '_') ADVANCE(367);
       END_STATE();
     case 355:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'n') ADVANCE(197);
+      if (lookahead == 'B') ADVANCE(363);
+      if (lookahead == 'D') ADVANCE(361);
+      if (lookahead == 'I') ADVANCE(362);
+      if (lookahead == 'P') ADVANCE(360);
+      if (lookahead == 'S') ADVANCE(357);
+      if (lookahead == '{') ADVANCE(318);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(302);
       if (lookahead == '(' ||
           lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(360);
+          lookahead == '_') ADVANCE(367);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(302);
       END_STATE();
     case 356:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'r') ADVANCE(185);
+      if (lookahead == 'F') ADVANCE(359);
       if (lookahead == '(' ||
           lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(360);
+          lookahead == '_') ADVANCE(367);
       END_STATE();
     case 357:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(334);
+      if (lookahead == 'H') ADVANCE(358);
       if (lookahead == '(' ||
           lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(360);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(334);
+          lookahead == '_') ADVANCE(367);
       END_STATE();
     case 358:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(330);
+      if (lookahead == 'I') ADVANCE(356);
       if (lookahead == '(' ||
           lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(360);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(330);
+          lookahead == '_') ADVANCE(367);
       END_STATE();
     case 359:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(322);
+      if (lookahead == 'T') ADVANCE(354);
       if (lookahead == '(' ||
           lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(360);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(322);
+          lookahead == '_') ADVANCE(367);
       END_STATE();
     case 360:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == 'a') ADVANCE(195);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(367);
+      END_STATE();
+    case 361:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == 'e') ADVANCE(198);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(367);
+      END_STATE();
+    case 362:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == 'n') ADVANCE(204);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(367);
+      END_STATE();
+    case 363:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == 'r') ADVANCE(192);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(367);
+      END_STATE();
+    case 364:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(341);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(367);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(341);
+      END_STATE();
+    case 365:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(337);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(367);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(337);
+      END_STATE();
+    case 366:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(329);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(367);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(329);
+      END_STATE();
+    case 367:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
       if (lookahead == '(' ||
           lookahead == ')' ||
@@ -4336,218 +4462,218 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(360);
-      END_STATE();
-    case 361:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(277);
-      if (lookahead == '-') ADVANCE(375);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(378);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(369);
-      END_STATE();
-    case 362:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(277);
-      if (lookahead == '-') ADVANCE(371);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(378);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(369);
-      END_STATE();
-    case 363:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(277);
-      if (lookahead == '-') ADVANCE(376);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(378);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(369);
-      END_STATE();
-    case 364:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(277);
-      if (lookahead == 'A') ADVANCE(363);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(378);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(369);
-      END_STATE();
-    case 365:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(277);
-      if (lookahead == 'L') ADVANCE(362);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(378);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(369);
-      END_STATE();
-    case 366:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(277);
-      if (lookahead == 'R') ADVANCE(365);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(378);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(369);
-      END_STATE();
-    case 367:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(277);
-      if (lookahead == 'T') ADVANCE(361);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(378);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(369);
+          lookahead == '_') ADVANCE(367);
       END_STATE();
     case 368:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(277);
-      if (lookahead == 'T') ADVANCE(364);
+      if (lookahead == '(') ADVANCE(284);
+      if (lookahead == '-') ADVANCE(382);
       if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(378);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+          lookahead == '.') ADVANCE(385);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(369);
+          lookahead == '_') ADVANCE(376);
       END_STATE();
     case 369:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(277);
+      if (lookahead == '(') ADVANCE(284);
+      if (lookahead == '-') ADVANCE(378);
       if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(378);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+          lookahead == '.') ADVANCE(385);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(369);
+          lookahead == '_') ADVANCE(376);
       END_STATE();
     case 370:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '-') ADVANCE(377);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '(') ADVANCE(284);
+      if (lookahead == '-') ADVANCE(383);
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(385);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(378);
+          lookahead == '_') ADVANCE(376);
       END_STATE();
     case 371:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == 'B') ADVANCE(319);
-      if (lookahead == 'D') ADVANCE(313);
-      if (lookahead == 'I') ADVANCE(316);
-      if (lookahead == 'P') ADVANCE(308);
-      if (lookahead == 'S') ADVANCE(306);
-      if (lookahead == '{') ADVANCE(310);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(295);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(284);
+      if (lookahead == 'A') ADVANCE(370);
+      if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(321);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(295);
+          lookahead == '.') ADVANCE(385);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(376);
       END_STATE();
     case 372:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == 'F') ADVANCE(374);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(284);
+      if (lookahead == 'L') ADVANCE(369);
+      if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.') ADVANCE(385);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(378);
+          lookahead == '_') ADVANCE(376);
       END_STATE();
     case 373:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == 'I') ADVANCE(372);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(284);
+      if (lookahead == 'R') ADVANCE(372);
+      if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.') ADVANCE(385);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(378);
+          lookahead == '_') ADVANCE(376);
       END_STATE();
     case 374:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == 'T') ADVANCE(370);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(284);
+      if (lookahead == 'T') ADVANCE(368);
+      if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.') ADVANCE(385);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(378);
+          lookahead == '_') ADVANCE(376);
       END_STATE();
     case 375:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(334);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(284);
+      if (lookahead == 'T') ADVANCE(371);
+      if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.') ADVANCE(385);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(337);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(334);
+          lookahead == '_') ADVANCE(376);
       END_STATE();
     case 376:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(330);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(284);
+      if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.') ADVANCE(385);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(333);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(330);
+          lookahead == '_') ADVANCE(376);
       END_STATE();
     case 377:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '-') ADVANCE(384);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(385);
+      END_STATE();
+    case 378:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == 'B') ADVANCE(326);
+      if (lookahead == 'D') ADVANCE(320);
+      if (lookahead == 'I') ADVANCE(323);
+      if (lookahead == 'P') ADVANCE(315);
+      if (lookahead == 'S') ADVANCE(313);
+      if (lookahead == '{') ADVANCE(317);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(322);
+          lookahead == ' ') ADVANCE(302);
       if (lookahead == '(' ||
           lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(325);
+          lookahead == '_') ADVANCE(328);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(322);
+          lookahead != '\n') ADVANCE(302);
       END_STATE();
-    case 378:
+    case 379:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == 'F') ADVANCE(381);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(385);
+      END_STATE();
+    case 380:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == 'I') ADVANCE(379);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(385);
+      END_STATE();
+    case 381:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == 'T') ADVANCE(377);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(385);
+      END_STATE();
+    case 382:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(341);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(344);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(341);
+      END_STATE();
+    case 383:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(337);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(340);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(337);
+      END_STATE();
+    case 384:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(329);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(332);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(329);
+      END_STATE();
+    case 385:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
       if (lookahead == '(' ||
           lookahead == ')' ||
@@ -4555,1649 +4681,1652 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(378);
-      END_STATE();
-    case 379:
-      ACCEPT_TOKEN(anon_sym_LT);
-      END_STATE();
-    case 380:
-      ACCEPT_TOKEN(anon_sym_LT);
-      if (lookahead == 'A' ||
-          lookahead == 'C' ||
-          lookahead == 'D' ||
-          lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(54);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      END_STATE();
-    case 381:
-      ACCEPT_TOKEN(anon_sym_LT);
-      if (lookahead == 'A' ||
-          lookahead == 'C' ||
-          lookahead == 'D' ||
-          lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(162);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(175);
-      END_STATE();
-    case 382:
-      ACCEPT_TOKEN(anon_sym_LF);
-      END_STATE();
-    case 383:
-      ACCEPT_TOKEN(anon_sym_LF2);
-      END_STATE();
-    case 384:
-      ACCEPT_TOKEN(aux_sym_line_li_token1);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == ' ') ADVANCE(384);
-      if (lookahead != 0) ADVANCE(22);
-      END_STATE();
-    case 385:
-      ACCEPT_TOKEN(aux_sym_line_li_token1);
-      if (lookahead == ' ') ADVANCE(385);
+          lookahead == '_') ADVANCE(385);
       END_STATE();
     case 386:
-      ACCEPT_TOKEN(aux_sym_line_code_token1);
+      ACCEPT_TOKEN(anon_sym_LT);
       END_STATE();
     case 387:
-      ACCEPT_TOKEN(aux_sym_h1_token1);
+      ACCEPT_TOKEN(anon_sym_LT);
+      if (lookahead == 'A' ||
+          lookahead == 'C' ||
+          lookahead == 'D' ||
+          lookahead == 'M' ||
+          lookahead == 'S') ADVANCE(61);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(63);
       END_STATE();
     case 388:
-      ACCEPT_TOKEN(aux_sym_h2_token1);
+      ACCEPT_TOKEN(anon_sym_LT);
+      if (lookahead == 'A' ||
+          lookahead == 'C' ||
+          lookahead == 'D' ||
+          lookahead == 'M' ||
+          lookahead == 'S') ADVANCE(169);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       END_STATE();
     case 389:
-      ACCEPT_TOKEN(anon_sym_STAR);
+      ACCEPT_TOKEN(aux_sym_codeblock_token1);
       END_STATE();
     case 390:
-      ACCEPT_TOKEN(anon_sym_STAR);
-      if (lookahead == '\t') ADVANCE(22);
-      if (lookahead == '\n') ADVANCE(386);
-      if (lookahead == ' ') ADVANCE(384);
-      if (lookahead != 0) ADVANCE(209);
+      ACCEPT_TOKEN(anon_sym_LF);
       END_STATE();
     case 391:
-      ACCEPT_TOKEN(anon_sym_STAR);
-      if (lookahead == ' ') ADVANCE(385);
+      ACCEPT_TOKEN(anon_sym_LF2);
       END_STATE();
     case 392:
+      ACCEPT_TOKEN(aux_sym_line_li_token1);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == ' ') ADVANCE(392);
+      if (lookahead != 0) ADVANCE(23);
+      END_STATE();
+    case 393:
+      ACCEPT_TOKEN(aux_sym_line_li_token1);
+      if (lookahead == ' ') ADVANCE(393);
+      END_STATE();
+    case 394:
+      ACCEPT_TOKEN(aux_sym_line_code_token1);
+      END_STATE();
+    case 395:
+      ACCEPT_TOKEN(aux_sym_h1_token1);
+      END_STATE();
+    case 396:
+      ACCEPT_TOKEN(aux_sym_h2_token1);
+      END_STATE();
+    case 397:
       ACCEPT_TOKEN(anon_sym_STAR);
-      if (lookahead == ' ') ADVANCE(540);
+      END_STATE();
+    case 398:
+      ACCEPT_TOKEN(anon_sym_STAR);
+      if (lookahead == '\t') ADVANCE(23);
+      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == ' ') ADVANCE(392);
+      if (lookahead != 0) ADVANCE(216);
+      END_STATE();
+    case 399:
+      ACCEPT_TOKEN(anon_sym_STAR);
+      if (lookahead == ' ') ADVANCE(393);
+      END_STATE();
+    case 400:
+      ACCEPT_TOKEN(anon_sym_STAR);
+      if (lookahead == ' ') ADVANCE(548);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
-    case 393:
+    case 401:
       ACCEPT_TOKEN(anon_sym_STAR);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(244);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
       END_STATE();
-    case 394:
+    case 402:
       ACCEPT_TOKEN(anon_sym_STAR);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
-    case 395:
+    case 403:
       ACCEPT_TOKEN(aux_sym_tag_token1);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(395);
+          lookahead != '*') ADVANCE(403);
       END_STATE();
-    case 396:
+    case 404:
       ACCEPT_TOKEN(anon_sym_STAR2);
       END_STATE();
-    case 397:
+    case 405:
       ACCEPT_TOKEN(sym_url_word);
-      if (lookahead == '\n') ADVANCE(386);
+      if (lookahead == '\n') ADVANCE(394);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
+          lookahead == ' ') ADVANCE(23);
       if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(137);
-      if (lookahead != 0) ADVANCE(397);
+          lookahead == ']') ADVANCE(144);
+      if (lookahead != 0) ADVANCE(405);
       END_STATE();
-    case 398:
+    case 406:
       ACCEPT_TOKEN(sym_url_word);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != ')' &&
-          lookahead != ']') ADVANCE(398);
-      END_STATE();
-    case 399:
-      ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == ':') ADVANCE(85);
-      if (lookahead == 's') ADVANCE(400);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(403);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(49);
-      END_STATE();
-    case 400:
-      ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == ':') ADVANCE(85);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(403);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(49);
-      END_STATE();
-    case 401:
-      ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 'p') ADVANCE(399);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(403);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(49);
-      END_STATE();
-    case 402:
-      ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (lookahead == 't') ADVANCE(401);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(403);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(49);
-      END_STATE();
-    case 403:
-      ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(275);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(403);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(49);
-      END_STATE();
-    case 404:
-      ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(244);
-      if (lookahead == ':') ADVANCE(245);
-      if (lookahead == 's') ADVANCE(405);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(408);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(242);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(244);
-      END_STATE();
-    case 405:
-      ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(244);
-      if (lookahead == ':') ADVANCE(245);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(408);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(242);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(244);
-      END_STATE();
-    case 406:
-      ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(244);
-      if (lookahead == 'p') ADVANCE(404);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(408);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(242);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(244);
+          lookahead != ']') ADVANCE(406);
       END_STATE();
     case 407:
       ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(244);
-      if (lookahead == 't') ADVANCE(406);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(408);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == ':') ADVANCE(92);
+      if (lookahead == 's') ADVANCE(408);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(411);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(242);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(244);
+          lookahead == '_') ADVANCE(56);
       END_STATE();
     case 408:
       ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(244);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(408);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == ':') ADVANCE(92);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(411);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(242);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(244);
+          lookahead == '_') ADVANCE(56);
       END_STATE();
     case 409:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '\t') ADVANCE(254);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+      ACCEPT_TOKEN(aux_sym_optionlink_token1);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 'p') ADVANCE(407);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(411);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(56);
       END_STATE();
     case 410:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(468);
-      if (lookahead == '-') ADVANCE(461);
+      ACCEPT_TOKEN(aux_sym_optionlink_token1);
+      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == 't') ADVANCE(409);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(411);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(426);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead == '_') ADVANCE(56);
       END_STATE();
     case 411:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(468);
-      if (lookahead == '-') ADVANCE(432);
+      ACCEPT_TOKEN(aux_sym_optionlink_token1);
+      if (lookahead == '(') ADVANCE(282);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(411);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(426);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead == '_') ADVANCE(56);
       END_STATE();
     case 412:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(468);
-      if (lookahead == '-') ADVANCE(462);
+      ACCEPT_TOKEN(aux_sym_optionlink_token1);
+      if (lookahead == '(') ADVANCE(251);
+      if (lookahead == ':') ADVANCE(252);
+      if (lookahead == 's') ADVANCE(413);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(416);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(426);
+          lookahead == '_') ADVANCE(249);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '\'') ADVANCE(251);
       END_STATE();
     case 413:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(468);
-      if (lookahead == ':') ADVANCE(463);
-      if (lookahead == 's') ADVANCE(414);
+      ACCEPT_TOKEN(aux_sym_optionlink_token1);
+      if (lookahead == '(') ADVANCE(251);
+      if (lookahead == ':') ADVANCE(252);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(416);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(426);
+          lookahead == '_') ADVANCE(249);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '\'') ADVANCE(251);
       END_STATE();
     case 414:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(468);
-      if (lookahead == ':') ADVANCE(463);
+      ACCEPT_TOKEN(aux_sym_optionlink_token1);
+      if (lookahead == '(') ADVANCE(251);
+      if (lookahead == 'p') ADVANCE(412);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(416);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(426);
+          lookahead == '_') ADVANCE(249);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '\'') ADVANCE(251);
       END_STATE();
     case 415:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(468);
-      if (lookahead == 'A') ADVANCE(412);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(426);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
-      END_STATE();
-    case 416:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(468);
-      if (lookahead == 'E') ADVANCE(422);
+      ACCEPT_TOKEN(aux_sym_optionlink_token1);
+      if (lookahead == '(') ADVANCE(251);
+      if (lookahead == 't') ADVANCE(414);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(416);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(426);
+          lookahead == '_') ADVANCE(249);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '\'') ADVANCE(251);
+      END_STATE();
+    case 416:
+      ACCEPT_TOKEN(aux_sym_optionlink_token1);
+      if (lookahead == '(') ADVANCE(251);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(416);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(249);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '\'') ADVANCE(251);
       END_STATE();
     case 417:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(468);
-      if (lookahead == 'L') ADVANCE(421);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(426);
+      if (lookahead == '\t') ADVANCE(261);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 418:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(468);
-      if (lookahead == 'L') ADVANCE(411);
+      if (lookahead == '(') ADVANCE(476);
+      if (lookahead == '-') ADVANCE(469);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(426);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 419:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(468);
-      if (lookahead == 'R') ADVANCE(418);
+      if (lookahead == '(') ADVANCE(476);
+      if (lookahead == '-') ADVANCE(440);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(426);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 420:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(468);
-      if (lookahead == 'T') ADVANCE(419);
+      if (lookahead == '(') ADVANCE(476);
+      if (lookahead == '-') ADVANCE(470);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(426);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 421:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(468);
-      if (lookahead == 'T') ADVANCE(410);
+      if (lookahead == '(') ADVANCE(476);
+      if (lookahead == ':') ADVANCE(471);
+      if (lookahead == 's') ADVANCE(422);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(426);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 422:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(468);
-      if (lookahead == 'T') ADVANCE(415);
+      if (lookahead == '(') ADVANCE(476);
+      if (lookahead == ':') ADVANCE(471);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(426);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 423:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(468);
-      if (lookahead == 'p') ADVANCE(413);
+      if (lookahead == '(') ADVANCE(476);
+      if (lookahead == 'A') ADVANCE(420);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(426);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 424:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(468);
-      if (lookahead == 't') ADVANCE(423);
+      if (lookahead == '(') ADVANCE(476);
+      if (lookahead == 'E') ADVANCE(430);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(426);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 425:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(468);
-      if (lookahead == 't') ADVANCE(424);
+      if (lookahead == '(') ADVANCE(476);
+      if (lookahead == 'L') ADVANCE(429);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(426);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 426:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(468);
+      if (lookahead == '(') ADVANCE(476);
+      if (lookahead == 'L') ADVANCE(419);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(426);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 427:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '-') ADVANCE(431);
-      if (lookahead == '>') ADVANCE(468);
+      if (lookahead == '(') ADVANCE(476);
+      if (lookahead == 'R') ADVANCE(426);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(429);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 428:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '-') ADVANCE(464);
+      if (lookahead == '(') ADVANCE(476);
+      if (lookahead == 'T') ADVANCE(427);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 429:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '>') ADVANCE(468);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '(') ADVANCE(476);
+      if (lookahead == 'T') ADVANCE(418);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(429);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 430:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '>') ADVANCE(468);
+      if (lookahead == '(') ADVANCE(476);
+      if (lookahead == 'T') ADVANCE(423);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 431:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '>') ADVANCE(430);
-      if (lookahead == '|') ADVANCE(58);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(26);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '(') ADVANCE(476);
+      if (lookahead == 'p') ADVANCE(421);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(429);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(430);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 432:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'B') ADVANCE(456);
-      if (lookahead == 'D') ADVANCE(442);
-      if (lookahead == 'I') ADVANCE(451);
-      if (lookahead == 'P') ADVANCE(438);
-      if (lookahead == 'S') ADVANCE(435);
-      if (lookahead == '{') ADVANCE(441);
-      if (lookahead == '|') ADVANCE(295);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(295);
+      if (lookahead == '(') ADVANCE(476);
+      if (lookahead == 't') ADVANCE(431);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(468);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 433:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'D') ADVANCE(452);
-      if (lookahead == 'U') ADVANCE(453);
+      if (lookahead == '(') ADVANCE(476);
+      if (lookahead == 't') ADVANCE(432);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 434:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'F') ADVANCE(437);
+      if (lookahead == '(') ADVANCE(476);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 435:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'H') ADVANCE(436);
+      if (lookahead == '-') ADVANCE(439);
+      if (lookahead == '>') ADVANCE(476);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(437);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 436:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'I') ADVANCE(434);
+      if (lookahead == '-') ADVANCE(472);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 437:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'T') ADVANCE(428);
+      if (lookahead == '>') ADVANCE(476);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(437);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 438:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'a') ADVANCE(446);
+      if (lookahead == '>') ADVANCE(476);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 439:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'a') ADVANCE(448);
+      if (lookahead == '>') ADVANCE(438);
+      if (lookahead == '|') ADVANCE(65);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(27);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(437);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '\n') ADVANCE(438);
       END_STATE();
     case 440:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'a') ADVANCE(455);
+      if (lookahead == 'B') ADVANCE(464);
+      if (lookahead == 'D') ADVANCE(450);
+      if (lookahead == 'I') ADVANCE(459);
+      if (lookahead == 'P') ADVANCE(446);
+      if (lookahead == 'S') ADVANCE(443);
+      if (lookahead == '{') ADVANCE(449);
+      if (lookahead == '|') ADVANCE(302);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(302);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '\n') ADVANCE(476);
       END_STATE();
     case 441:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'c') ADVANCE(447);
+      if (lookahead == 'D') ADVANCE(460);
+      if (lookahead == 'U') ADVANCE(461);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 442:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'e') ADVANCE(449);
+      if (lookahead == 'F') ADVANCE(445);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 443:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'e') ADVANCE(433);
+      if (lookahead == 'H') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 444:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'e') ADVANCE(454);
+      if (lookahead == 'I') ADVANCE(442);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 445:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'e') ADVANCE(439);
+      if (lookahead == 'T') ADVANCE(436);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 446:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'g') ADVANCE(443);
+      if (lookahead == 'a') ADVANCE(454);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 447:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'h') ADVANCE(440);
+      if (lookahead == 'a') ADVANCE(456);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 448:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'k') ADVANCE(468);
+      if (lookahead == 'a') ADVANCE(463);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 449:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'l') ADVANCE(468);
+      if (lookahead == 'c') ADVANCE(455);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 450:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'n') ADVANCE(468);
+      if (lookahead == 'e') ADVANCE(457);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 451:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'n') ADVANCE(457);
+      if (lookahead == 'e') ADVANCE(441);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 452:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'o') ADVANCE(459);
+      if (lookahead == 'e') ADVANCE(462);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 453:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'p') ADVANCE(468);
+      if (lookahead == 'e') ADVANCE(447);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 454:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'r') ADVANCE(458);
+      if (lookahead == 'g') ADVANCE(451);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 455:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'r') ADVANCE(465);
+      if (lookahead == 'h') ADVANCE(448);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 456:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'r') ADVANCE(445);
+      if (lookahead == 'k') ADVANCE(476);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 457:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 's') ADVANCE(444);
+      if (lookahead == 'l') ADVANCE(476);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 458:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 't') ADVANCE(468);
+      if (lookahead == 'n') ADVANCE(476);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 459:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'w') ADVANCE(450);
+      if (lookahead == 'n') ADVANCE(465);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 460:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '{') ADVANCE(460);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(467);
+      if (lookahead == 'o') ADVANCE(467);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 461:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '|') ADVANCE(334);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(334);
+      if (lookahead == 'p') ADVANCE(476);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(468);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 462:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '|') ADVANCE(330);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(330);
+      if (lookahead == 'r') ADVANCE(466);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(468);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 463:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '|') ADVANCE(398);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(468);
+      if (lookahead == 'r') ADVANCE(473);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(463);
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 464:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '|') ADVANCE(322);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(322);
+      if (lookahead == 'r') ADVANCE(453);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(468);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 465:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '}') ADVANCE(468);
+      if (lookahead == 's') ADVANCE(452);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 466:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'A' ||
-          lookahead == 'C' ||
-          lookahead == 'D' ||
-          lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(427);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(429);
+      if (lookahead == 't') ADVANCE(476);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 467:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(467);
+      if (lookahead == 'w') ADVANCE(458);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 468:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '{') ADVANCE(468);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(475);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(476);
+      END_STATE();
+    case 469:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '|') ADVANCE(341);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(341);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(476);
+      END_STATE();
+    case 470:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '|') ADVANCE(337);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(337);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(476);
+      END_STATE();
+    case 471:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '|') ADVANCE(406);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(476);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(471);
+      END_STATE();
+    case 472:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '|') ADVANCE(329);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(329);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(476);
+      END_STATE();
+    case 473:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '}') ADVANCE(476);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(476);
+      END_STATE();
+    case 474:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'A' ||
+          lookahead == 'C' ||
+          lookahead == 'D' ||
+          lookahead == 'M' ||
+          lookahead == 'S') ADVANCE(435);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(437);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(476);
+      END_STATE();
+    case 475:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(475);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(476);
+      END_STATE();
+    case 476:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
-      END_STATE();
-    case 469:
-      ACCEPT_TOKEN(anon_sym_LBRACE2);
-      if (lookahead == '{') ADVANCE(267);
-      if (lookahead == '}') ADVANCE(262);
-      END_STATE();
-    case 470:
-      ACCEPT_TOKEN(anon_sym_LBRACE2);
-      if (lookahead == '{') ADVANCE(460);
-      if (lookahead == '}') ADVANCE(264);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
-      END_STATE();
-    case 471:
-      ACCEPT_TOKEN(anon_sym_RBRACE2);
-      END_STATE();
-    case 472:
-      ACCEPT_TOKEN(anon_sym_RBRACE2);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
-      END_STATE();
-    case 473:
-      ACCEPT_TOKEN(anon_sym_LPAREN2);
-      END_STATE();
-    case 474:
-      ACCEPT_TOKEN(anon_sym_LPAREN2);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
-      END_STATE();
-    case 475:
-      ACCEPT_TOKEN(anon_sym_RPAREN);
-      END_STATE();
-    case 476:
-      ACCEPT_TOKEN(anon_sym_RPAREN);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
     case 477:
-      ACCEPT_TOKEN(anon_sym_BQUOTE);
+      ACCEPT_TOKEN(anon_sym_LBRACE2);
+      if (lookahead == '{') ADVANCE(274);
+      if (lookahead == '}') ADVANCE(269);
       END_STATE();
     case 478:
+      ACCEPT_TOKEN(anon_sym_LBRACE2);
+      if (lookahead == '{') ADVANCE(468);
+      if (lookahead == '}') ADVANCE(271);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(476);
+      END_STATE();
+    case 479:
+      ACCEPT_TOKEN(anon_sym_RBRACE2);
+      END_STATE();
+    case 480:
+      ACCEPT_TOKEN(anon_sym_RBRACE2);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(476);
+      END_STATE();
+    case 481:
+      ACCEPT_TOKEN(anon_sym_LPAREN2);
+      END_STATE();
+    case 482:
+      ACCEPT_TOKEN(anon_sym_LPAREN2);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(476);
+      END_STATE();
+    case 483:
+      ACCEPT_TOKEN(anon_sym_RPAREN);
+      END_STATE();
+    case 484:
+      ACCEPT_TOKEN(anon_sym_RPAREN);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(476);
+      END_STATE();
+    case 485:
+      ACCEPT_TOKEN(anon_sym_BQUOTE);
+      END_STATE();
+    case 486:
       ACCEPT_TOKEN(anon_sym_BQUOTE);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(468);
+          lookahead != '|') ADVANCE(476);
       END_STATE();
-    case 479:
+    case 487:
       ACCEPT_TOKEN(anon_sym_PIPE2);
       END_STATE();
-    case 480:
+    case 488:
       ACCEPT_TOKEN(anon_sym_BQUOTE2);
       END_STATE();
-    case 481:
+    case 489:
       ACCEPT_TOKEN(anon_sym_BQUOTE2);
-      if (lookahead == '\n') ADVANCE(386);
+      if (lookahead == '\n') ADVANCE(394);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(137);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(144);
       END_STATE();
-    case 482:
+    case 490:
       ACCEPT_TOKEN(anon_sym_BQUOTE2);
-      if (lookahead == ' ') ADVANCE(540);
+      if (lookahead == ' ') ADVANCE(548);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
-    case 483:
+    case 491:
       ACCEPT_TOKEN(anon_sym_BQUOTE2);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(244);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
       END_STATE();
-    case 484:
+    case 492:
       ACCEPT_TOKEN(aux_sym_codespan_token1);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '`') ADVANCE(484);
-      END_STATE();
-    case 485:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '\t') ADVANCE(254);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
-      END_STATE();
-    case 486:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '\t') ADVANCE(26);
-      if (lookahead == ' ') ADVANCE(539);
-      if (lookahead == '>') ADVANCE(511);
-      if (lookahead == '{' ||
-          lookahead == '}') ADVANCE(58);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(510);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(511);
-      END_STATE();
-    case 487:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '\t') ADVANCE(334);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '{' ||
-          lookahead == '}') ADVANCE(334);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(538);
-      END_STATE();
-    case 488:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '\t') ADVANCE(295);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 'B') ADVANCE(531);
-      if (lookahead == 'D') ADVANCE(519);
-      if (lookahead == 'I') ADVANCE(527);
-      if (lookahead == 'P') ADVANCE(517);
-      if (lookahead == 'S') ADVANCE(514);
-      if (lookahead == '{') ADVANCE(310);
-      if (lookahead == '}') ADVANCE(295);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(538);
-      END_STATE();
-    case 489:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '\t') ADVANCE(330);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '{' ||
-          lookahead == '}') ADVANCE(330);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(538);
-      END_STATE();
-    case 490:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '\t') ADVANCE(322);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '{' ||
-          lookahead == '}') ADVANCE(322);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(538);
-      END_STATE();
-    case 491:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '(') ADVANCE(538);
-      if (lookahead == '-') ADVANCE(487);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(507);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
-      END_STATE();
-    case 492:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '(') ADVANCE(538);
-      if (lookahead == '-') ADVANCE(488);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(507);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '`') ADVANCE(492);
       END_STATE();
     case 493:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '(') ADVANCE(538);
-      if (lookahead == '-') ADVANCE(489);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(507);
+      if (lookahead == '\t') ADVANCE(261);
+      if (lookahead == ' ') ADVANCE(548);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 494:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '(') ADVANCE(538);
-      if (lookahead == ':') ADVANCE(536);
-      if (lookahead == 's') ADVANCE(495);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(507);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
-      END_STATE();
-    case 495:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '(') ADVANCE(538);
-      if (lookahead == ':') ADVANCE(536);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(507);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
-      END_STATE();
-    case 496:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '(') ADVANCE(538);
-      if (lookahead == 'A') ADVANCE(493);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(507);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
-      END_STATE();
-    case 497:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '(') ADVANCE(538);
-      if (lookahead == 'E') ADVANCE(503);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(507);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
-      END_STATE();
-    case 498:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '(') ADVANCE(538);
-      if (lookahead == 'L') ADVANCE(502);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(507);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
-      END_STATE();
-    case 499:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '(') ADVANCE(538);
-      if (lookahead == 'L') ADVANCE(492);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(507);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
-      END_STATE();
-    case 500:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '(') ADVANCE(538);
-      if (lookahead == 'R') ADVANCE(499);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(507);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
-      END_STATE();
-    case 501:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '(') ADVANCE(538);
-      if (lookahead == 'T') ADVANCE(500);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(507);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
-      END_STATE();
-    case 502:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '(') ADVANCE(538);
-      if (lookahead == 'T') ADVANCE(491);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(507);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
-      END_STATE();
-    case 503:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '(') ADVANCE(538);
-      if (lookahead == 'T') ADVANCE(496);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(507);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
-      END_STATE();
-    case 504:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '(') ADVANCE(538);
-      if (lookahead == 'p') ADVANCE(494);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(507);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
-      END_STATE();
-    case 505:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '(') ADVANCE(538);
-      if (lookahead == 't') ADVANCE(504);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(507);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
-      END_STATE();
-    case 506:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '(') ADVANCE(538);
-      if (lookahead == 't') ADVANCE(505);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(507);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
-      END_STATE();
-    case 507:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '(') ADVANCE(538);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(507);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
-      END_STATE();
-    case 508:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '-') ADVANCE(486);
-      if (lookahead == '>') ADVANCE(538);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(510);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
-      END_STATE();
-    case 509:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '-') ADVANCE(490);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
-      END_STATE();
-    case 510:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '>') ADVANCE(538);
+      if (lookahead == '\t') ADVANCE(27);
+      if (lookahead == ' ') ADVANCE(547);
+      if (lookahead == '>') ADVANCE(519);
+      if (lookahead == '{' ||
+          lookahead == '}') ADVANCE(65);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(510);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(518);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(519);
+      END_STATE();
+    case 495:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '\t') ADVANCE(341);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '{' ||
+          lookahead == '}') ADVANCE(341);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(546);
+      END_STATE();
+    case 496:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '\t') ADVANCE(302);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'B') ADVANCE(539);
+      if (lookahead == 'D') ADVANCE(527);
+      if (lookahead == 'I') ADVANCE(535);
+      if (lookahead == 'P') ADVANCE(525);
+      if (lookahead == 'S') ADVANCE(522);
+      if (lookahead == '{') ADVANCE(317);
+      if (lookahead == '}') ADVANCE(302);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(546);
+      END_STATE();
+    case 497:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '\t') ADVANCE(337);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '{' ||
+          lookahead == '}') ADVANCE(337);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(546);
+      END_STATE();
+    case 498:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '\t') ADVANCE(329);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '{' ||
+          lookahead == '}') ADVANCE(329);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(546);
+      END_STATE();
+    case 499:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '(') ADVANCE(546);
+      if (lookahead == '-') ADVANCE(495);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
+      END_STATE();
+    case 500:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '(') ADVANCE(546);
+      if (lookahead == '-') ADVANCE(496);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(546);
+      END_STATE();
+    case 501:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '(') ADVANCE(546);
+      if (lookahead == '-') ADVANCE(497);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(546);
+      END_STATE();
+    case 502:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '(') ADVANCE(546);
+      if (lookahead == ':') ADVANCE(544);
+      if (lookahead == 's') ADVANCE(503);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(546);
+      END_STATE();
+    case 503:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '(') ADVANCE(546);
+      if (lookahead == ':') ADVANCE(544);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(546);
+      END_STATE();
+    case 504:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '(') ADVANCE(546);
+      if (lookahead == 'A') ADVANCE(501);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(546);
+      END_STATE();
+    case 505:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '(') ADVANCE(546);
+      if (lookahead == 'E') ADVANCE(511);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(546);
+      END_STATE();
+    case 506:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '(') ADVANCE(546);
+      if (lookahead == 'L') ADVANCE(510);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(546);
+      END_STATE();
+    case 507:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '(') ADVANCE(546);
+      if (lookahead == 'L') ADVANCE(500);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(546);
+      END_STATE();
+    case 508:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '(') ADVANCE(546);
+      if (lookahead == 'R') ADVANCE(507);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(546);
+      END_STATE();
+    case 509:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '(') ADVANCE(546);
+      if (lookahead == 'T') ADVANCE(508);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(546);
+      END_STATE();
+    case 510:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '(') ADVANCE(546);
+      if (lookahead == 'T') ADVANCE(499);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 511:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '>') ADVANCE(538);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '(') ADVANCE(546);
+      if (lookahead == 'T') ADVANCE(504);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 512:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 'D') ADVANCE(528);
-      if (lookahead == 'U') ADVANCE(529);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '(') ADVANCE(546);
+      if (lookahead == 'p') ADVANCE(502);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 513:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 'F') ADVANCE(516);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '(') ADVANCE(546);
+      if (lookahead == 't') ADVANCE(512);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 514:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 'H') ADVANCE(515);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '(') ADVANCE(546);
+      if (lookahead == 't') ADVANCE(513);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 515:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 'I') ADVANCE(513);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '(') ADVANCE(546);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 516:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 'T') ADVANCE(509);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '-') ADVANCE(494);
+      if (lookahead == '>') ADVANCE(546);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(518);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 517:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 'a') ADVANCE(523);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '-') ADVANCE(498);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 518:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 'a') ADVANCE(524);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '>') ADVANCE(546);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(518);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 519:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 'e') ADVANCE(525);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '>') ADVANCE(546);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 520:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 'e') ADVANCE(512);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'D') ADVANCE(536);
+      if (lookahead == 'U') ADVANCE(537);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 521:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 'e') ADVANCE(530);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'F') ADVANCE(524);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 522:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 'e') ADVANCE(518);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'H') ADVANCE(523);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 523:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 'g') ADVANCE(520);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'I') ADVANCE(521);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 524:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 'k') ADVANCE(538);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'T') ADVANCE(517);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 525:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 'l') ADVANCE(538);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'a') ADVANCE(531);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 526:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 'n') ADVANCE(538);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'a') ADVANCE(532);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 527:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 'n') ADVANCE(532);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'e') ADVANCE(533);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 528:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 'o') ADVANCE(534);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'e') ADVANCE(520);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 529:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 'p') ADVANCE(538);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'e') ADVANCE(538);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 530:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 'r') ADVANCE(533);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'e') ADVANCE(526);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 531:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 'r') ADVANCE(522);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'g') ADVANCE(528);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 532:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 's') ADVANCE(521);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'k') ADVANCE(546);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 533:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 't') ADVANCE(538);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'l') ADVANCE(546);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 534:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == 'w') ADVANCE(526);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'n') ADVANCE(546);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 535:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == '|') ADVANCE(535);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'n') ADVANCE(540);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          (lookahead < '{' || '}' < lookahead)) ADVANCE(538);
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 536:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(538);
-      if (lookahead == '{' ||
-          lookahead == '}') ADVANCE(398);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'o') ADVANCE(542);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(536);
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(546);
       END_STATE();
     case 537:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'p') ADVANCE(546);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(546);
+      END_STATE();
+    case 538:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'r') ADVANCE(541);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(546);
+      END_STATE();
+    case 539:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'r') ADVANCE(530);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(546);
+      END_STATE();
+    case 540:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 's') ADVANCE(529);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(546);
+      END_STATE();
+    case 541:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 't') ADVANCE(546);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(546);
+      END_STATE();
+    case 542:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'w') ADVANCE(534);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(546);
+      END_STATE();
+    case 543:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '|') ADVANCE(543);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          (lookahead < '{' || '}' < lookahead)) ADVANCE(546);
+      END_STATE();
+    case 544:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(546);
+      if (lookahead == '{' ||
+          lookahead == '}') ADVANCE(406);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n') ADVANCE(544);
+      END_STATE();
+    case 545:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(548);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(508);
+          lookahead == 'S') ADVANCE(516);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(510);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(518);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
-    case 538:
+    case 546:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(540);
+      if (lookahead == ' ') ADVANCE(548);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(538);
+          lookahead != '}') ADVANCE(546);
       END_STATE();
-    case 539:
+    case 547:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '>') ADVANCE(540);
+      if (lookahead == '>') ADVANCE(548);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(540);
+          lookahead != '}') ADVANCE(548);
       END_STATE();
-    case 540:
+    case 548:
       ACCEPT_TOKEN(aux_sym_argument_token1);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(540);
+          lookahead != '}') ADVANCE(548);
       END_STATE();
     default:
       return false;
@@ -6206,109 +6335,111 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 30},
-  [2] = {.lex_state = 30},
-  [3] = {.lex_state = 30},
-  [4] = {.lex_state = 30},
-  [5] = {.lex_state = 30},
-  [6] = {.lex_state = 30},
-  [7] = {.lex_state = 30},
-  [8] = {.lex_state = 10},
-  [9] = {.lex_state = 10},
-  [10] = {.lex_state = 10},
-  [11] = {.lex_state = 10},
-  [12] = {.lex_state = 10},
-  [13] = {.lex_state = 10},
-  [14] = {.lex_state = 10},
-  [15] = {.lex_state = 10},
-  [16] = {.lex_state = 10},
-  [17] = {.lex_state = 7},
-  [18] = {.lex_state = 7},
-  [19] = {.lex_state = 7},
-  [20] = {.lex_state = 7},
-  [21] = {.lex_state = 7},
-  [22] = {.lex_state = 7},
-  [23] = {.lex_state = 7},
-  [24] = {.lex_state = 7},
-  [25] = {.lex_state = 7},
-  [26] = {.lex_state = 7},
-  [27] = {.lex_state = 7},
-  [28] = {.lex_state = 7},
-  [29] = {.lex_state = 7},
-  [30] = {.lex_state = 7},
-  [31] = {.lex_state = 7},
-  [32] = {.lex_state = 30},
-  [33] = {.lex_state = 30},
-  [34] = {.lex_state = 30},
-  [35] = {.lex_state = 9},
-  [36] = {.lex_state = 30},
-  [37] = {.lex_state = 30},
-  [38] = {.lex_state = 30},
-  [39] = {.lex_state = 30},
-  [40] = {.lex_state = 30},
-  [41] = {.lex_state = 9},
-  [42] = {.lex_state = 30},
-  [43] = {.lex_state = 30},
-  [44] = {.lex_state = 30},
-  [45] = {.lex_state = 30},
-  [46] = {.lex_state = 11},
-  [47] = {.lex_state = 11},
-  [48] = {.lex_state = 15},
-  [49] = {.lex_state = 30},
-  [50] = {.lex_state = 9},
-  [51] = {.lex_state = 30},
-  [52] = {.lex_state = 30},
-  [53] = {.lex_state = 30},
-  [54] = {.lex_state = 30},
-  [55] = {.lex_state = 30},
-  [56] = {.lex_state = 30},
-  [57] = {.lex_state = 30},
-  [58] = {.lex_state = 30},
-  [59] = {.lex_state = 30},
-  [60] = {.lex_state = 30},
-  [61] = {.lex_state = 11},
-  [62] = {.lex_state = 10},
+  [1] = {.lex_state = 31},
+  [2] = {.lex_state = 31},
+  [3] = {.lex_state = 31},
+  [4] = {.lex_state = 31},
+  [5] = {.lex_state = 31},
+  [6] = {.lex_state = 31},
+  [7] = {.lex_state = 31},
+  [8] = {.lex_state = 11},
+  [9] = {.lex_state = 11},
+  [10] = {.lex_state = 11},
+  [11] = {.lex_state = 11},
+  [12] = {.lex_state = 11},
+  [13] = {.lex_state = 11},
+  [14] = {.lex_state = 11},
+  [15] = {.lex_state = 11},
+  [16] = {.lex_state = 11},
+  [17] = {.lex_state = 8},
+  [18] = {.lex_state = 8},
+  [19] = {.lex_state = 8},
+  [20] = {.lex_state = 8},
+  [21] = {.lex_state = 8},
+  [22] = {.lex_state = 8},
+  [23] = {.lex_state = 8},
+  [24] = {.lex_state = 8},
+  [25] = {.lex_state = 8},
+  [26] = {.lex_state = 8},
+  [27] = {.lex_state = 8},
+  [28] = {.lex_state = 8},
+  [29] = {.lex_state = 8},
+  [30] = {.lex_state = 8},
+  [31] = {.lex_state = 8},
+  [32] = {.lex_state = 31},
+  [33] = {.lex_state = 31},
+  [34] = {.lex_state = 10},
+  [35] = {.lex_state = 10},
+  [36] = {.lex_state = 31},
+  [37] = {.lex_state = 31},
+  [38] = {.lex_state = 31},
+  [39] = {.lex_state = 31},
+  [40] = {.lex_state = 31},
+  [41] = {.lex_state = 31},
+  [42] = {.lex_state = 31},
+  [43] = {.lex_state = 31},
+  [44] = {.lex_state = 31},
+  [45] = {.lex_state = 12},
+  [46] = {.lex_state = 31},
+  [47] = {.lex_state = 31},
+  [48] = {.lex_state = 10},
+  [49] = {.lex_state = 10},
+  [50] = {.lex_state = 12},
+  [51] = {.lex_state = 16},
+  [52] = {.lex_state = 31},
+  [53] = {.lex_state = 31},
+  [54] = {.lex_state = 31},
+  [55] = {.lex_state = 31},
+  [56] = {.lex_state = 31},
+  [57] = {.lex_state = 31},
+  [58] = {.lex_state = 31},
+  [59] = {.lex_state = 31},
+  [60] = {.lex_state = 31},
+  [61] = {.lex_state = 31},
+  [62] = {.lex_state = 12},
   [63] = {.lex_state = 12},
-  [64] = {.lex_state = 10},
-  [65] = {.lex_state = 10},
-  [66] = {.lex_state = 13},
-  [67] = {.lex_state = 13},
-  [68] = {.lex_state = 13},
-  [69] = {.lex_state = 13},
-  [70] = {.lex_state = 13},
-  [71] = {.lex_state = 5},
-  [72] = {.lex_state = 13},
-  [73] = {.lex_state = 5},
-  [74] = {.lex_state = 16},
+  [64] = {.lex_state = 11},
+  [65] = {.lex_state = 13},
+  [66] = {.lex_state = 11},
+  [67] = {.lex_state = 11},
+  [68] = {.lex_state = 6},
+  [69] = {.lex_state = 14},
+  [70] = {.lex_state = 14},
+  [71] = {.lex_state = 14},
+  [72] = {.lex_state = 14},
+  [73] = {.lex_state = 14},
+  [74] = {.lex_state = 6},
   [75] = {.lex_state = 5},
-  [76] = {.lex_state = 5},
-  [77] = {.lex_state = 6},
-  [78] = {.lex_state = 7},
-  [79] = {.lex_state = 7},
-  [80] = {.lex_state = 7},
-  [81] = {.lex_state = 7},
-  [82] = {.lex_state = 7},
-  [83] = {.lex_state = 7},
-  [84] = {.lex_state = 7},
-  [85] = {.lex_state = 7},
-  [86] = {.lex_state = 7},
-  [87] = {.lex_state = 7},
-  [88] = {.lex_state = 7},
-  [89] = {.lex_state = 17},
-  [90] = {.lex_state = 17},
-  [91] = {.lex_state = 17},
-  [92] = {.lex_state = 9},
-  [93] = {.lex_state = 9},
-  [94] = {.lex_state = 30},
-  [95] = {.lex_state = 0},
-  [96] = {.lex_state = 17},
-  [97] = {.lex_state = 25},
-  [98] = {.lex_state = 27},
-  [99] = {.lex_state = 17},
-  [100] = {.lex_state = 17},
-  [101] = {.lex_state = 30},
-  [102] = {.lex_state = 6},
-  [103] = {.lex_state = 25},
+  [76] = {.lex_state = 7},
+  [77] = {.lex_state = 17},
+  [78] = {.lex_state = 5},
+  [79] = {.lex_state = 14},
+  [80] = {.lex_state = 8},
+  [81] = {.lex_state = 8},
+  [82] = {.lex_state = 8},
+  [83] = {.lex_state = 8},
+  [84] = {.lex_state = 8},
+  [85] = {.lex_state = 8},
+  [86] = {.lex_state = 8},
+  [87] = {.lex_state = 8},
+  [88] = {.lex_state = 8},
+  [89] = {.lex_state = 8},
+  [90] = {.lex_state = 8},
+  [91] = {.lex_state = 18},
+  [92] = {.lex_state = 18},
+  [93] = {.lex_state = 18},
+  [94] = {.lex_state = 10},
+  [95] = {.lex_state = 10},
+  [96] = {.lex_state = 31},
+  [97] = {.lex_state = 0},
+  [98] = {.lex_state = 7},
+  [99] = {.lex_state = 31},
+  [100] = {.lex_state = 18},
+  [101] = {.lex_state = 26},
+  [102] = {.lex_state = 28},
+  [103] = {.lex_state = 26},
+  [104] = {.lex_state = 18},
+  [105] = {.lex_state = 18},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -6355,24 +6486,24 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_BQUOTE2] = ACTIONS(1),
   },
   [1] = {
-    [sym_help_file] = STATE(95),
+    [sym_help_file] = STATE(97),
     [sym__atom_noli] = STATE(18),
     [sym_word_noli] = STATE(18),
     [sym__atom_common] = STATE(18),
-    [sym__word_common] = STATE(88),
+    [sym__word_common] = STATE(80),
     [sym_keycode] = STATE(18),
-    [sym_uppercase_name] = STATE(94),
+    [sym_uppercase_name] = STATE(96),
     [sym__uppercase_words] = STATE(18),
     [sym_block] = STATE(5),
-    [sym_codeblock] = STATE(52),
-    [sym__blank] = STATE(45),
+    [sym_codeblock] = STATE(58),
+    [sym__blank] = STATE(46),
     [sym_line] = STATE(6),
-    [sym_line_li] = STATE(90),
-    [sym__line_noli] = STATE(52),
-    [sym_column_heading] = STATE(52),
-    [sym_h1] = STATE(52),
-    [sym_h2] = STATE(52),
-    [sym_h3] = STATE(52),
+    [sym_line_li] = STATE(92),
+    [sym__line_noli] = STATE(58),
+    [sym_column_heading] = STATE(58),
+    [sym_h1] = STATE(58),
+    [sym_h2] = STATE(58),
+    [sym_h3] = STATE(58),
     [sym_tag] = STATE(18),
     [sym_url] = STATE(18),
     [sym_optionlink] = STATE(18),
@@ -6382,7 +6513,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_help_file_repeat1] = STATE(2),
     [aux_sym_help_file_repeat2] = STATE(5),
     [aux_sym_block_repeat1] = STATE(6),
-    [aux_sym_block_repeat2] = STATE(90),
+    [aux_sym_block_repeat2] = STATE(92),
     [ts_builtin_sym_end] = ACTIONS(3),
     [aux_sym_word_noli_token1] = ACTIONS(5),
     [aux_sym_word_noli_token2] = ACTIONS(5),
@@ -6420,30 +6551,30 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym__atom_noli] = STATE(18),
     [sym_word_noli] = STATE(18),
     [sym__atom_common] = STATE(18),
-    [sym__word_common] = STATE(88),
+    [sym__word_common] = STATE(80),
     [sym_keycode] = STATE(18),
-    [sym_uppercase_name] = STATE(94),
+    [sym_uppercase_name] = STATE(96),
     [sym__uppercase_words] = STATE(18),
     [sym_block] = STATE(4),
-    [sym_codeblock] = STATE(52),
-    [sym__blank] = STATE(45),
+    [sym_codeblock] = STATE(58),
+    [sym__blank] = STATE(46),
     [sym_line] = STATE(6),
-    [sym_line_li] = STATE(90),
-    [sym__line_noli] = STATE(52),
-    [sym_column_heading] = STATE(52),
-    [sym_h1] = STATE(52),
-    [sym_h2] = STATE(52),
-    [sym_h3] = STATE(52),
+    [sym_line_li] = STATE(92),
+    [sym__line_noli] = STATE(58),
+    [sym_column_heading] = STATE(58),
+    [sym_h1] = STATE(58),
+    [sym_h2] = STATE(58),
+    [sym_h3] = STATE(58),
     [sym_tag] = STATE(18),
     [sym_url] = STATE(18),
     [sym_optionlink] = STATE(18),
     [sym_taglink] = STATE(18),
     [sym_codespan] = STATE(18),
     [sym_argument] = STATE(18),
-    [aux_sym_help_file_repeat1] = STATE(42),
+    [aux_sym_help_file_repeat1] = STATE(43),
     [aux_sym_help_file_repeat2] = STATE(4),
     [aux_sym_block_repeat1] = STATE(6),
-    [aux_sym_block_repeat2] = STATE(90),
+    [aux_sym_block_repeat2] = STATE(92),
     [ts_builtin_sym_end] = ACTIONS(39),
     [aux_sym_word_noli_token1] = ACTIONS(5),
     [aux_sym_word_noli_token2] = ACTIONS(5),
@@ -6481,19 +6612,19 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym__atom_noli] = STATE(18),
     [sym_word_noli] = STATE(18),
     [sym__atom_common] = STATE(18),
-    [sym__word_common] = STATE(88),
+    [sym__word_common] = STATE(80),
     [sym_keycode] = STATE(18),
-    [sym_uppercase_name] = STATE(94),
+    [sym_uppercase_name] = STATE(96),
     [sym__uppercase_words] = STATE(18),
     [sym_block] = STATE(3),
-    [sym_codeblock] = STATE(52),
+    [sym_codeblock] = STATE(58),
     [sym_line] = STATE(6),
-    [sym_line_li] = STATE(90),
-    [sym__line_noli] = STATE(52),
-    [sym_column_heading] = STATE(52),
-    [sym_h1] = STATE(52),
-    [sym_h2] = STATE(52),
-    [sym_h3] = STATE(52),
+    [sym_line_li] = STATE(92),
+    [sym__line_noli] = STATE(58),
+    [sym_column_heading] = STATE(58),
+    [sym_h1] = STATE(58),
+    [sym_h2] = STATE(58),
+    [sym_h3] = STATE(58),
     [sym_tag] = STATE(18),
     [sym_url] = STATE(18),
     [sym_optionlink] = STATE(18),
@@ -6502,7 +6633,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_argument] = STATE(18),
     [aux_sym_help_file_repeat2] = STATE(3),
     [aux_sym_block_repeat1] = STATE(6),
-    [aux_sym_block_repeat2] = STATE(90),
+    [aux_sym_block_repeat2] = STATE(92),
     [ts_builtin_sym_end] = ACTIONS(41),
     [aux_sym_word_noli_token1] = ACTIONS(43),
     [aux_sym_word_noli_token2] = ACTIONS(43),
@@ -6539,19 +6670,19 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym__atom_noli] = STATE(18),
     [sym_word_noli] = STATE(18),
     [sym__atom_common] = STATE(18),
-    [sym__word_common] = STATE(88),
+    [sym__word_common] = STATE(80),
     [sym_keycode] = STATE(18),
-    [sym_uppercase_name] = STATE(94),
+    [sym_uppercase_name] = STATE(96),
     [sym__uppercase_words] = STATE(18),
     [sym_block] = STATE(3),
-    [sym_codeblock] = STATE(52),
+    [sym_codeblock] = STATE(58),
     [sym_line] = STATE(6),
-    [sym_line_li] = STATE(90),
-    [sym__line_noli] = STATE(52),
-    [sym_column_heading] = STATE(52),
-    [sym_h1] = STATE(52),
-    [sym_h2] = STATE(52),
-    [sym_h3] = STATE(52),
+    [sym_line_li] = STATE(92),
+    [sym__line_noli] = STATE(58),
+    [sym_column_heading] = STATE(58),
+    [sym_h1] = STATE(58),
+    [sym_h2] = STATE(58),
+    [sym_h3] = STATE(58),
     [sym_tag] = STATE(18),
     [sym_url] = STATE(18),
     [sym_optionlink] = STATE(18),
@@ -6560,7 +6691,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_argument] = STATE(18),
     [aux_sym_help_file_repeat2] = STATE(3),
     [aux_sym_block_repeat1] = STATE(6),
-    [aux_sym_block_repeat2] = STATE(90),
+    [aux_sym_block_repeat2] = STATE(92),
     [ts_builtin_sym_end] = ACTIONS(91),
     [aux_sym_word_noli_token1] = ACTIONS(5),
     [aux_sym_word_noli_token2] = ACTIONS(5),
@@ -6597,19 +6728,19 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym__atom_noli] = STATE(18),
     [sym_word_noli] = STATE(18),
     [sym__atom_common] = STATE(18),
-    [sym__word_common] = STATE(88),
+    [sym__word_common] = STATE(80),
     [sym_keycode] = STATE(18),
-    [sym_uppercase_name] = STATE(94),
+    [sym_uppercase_name] = STATE(96),
     [sym__uppercase_words] = STATE(18),
     [sym_block] = STATE(3),
-    [sym_codeblock] = STATE(52),
+    [sym_codeblock] = STATE(58),
     [sym_line] = STATE(6),
-    [sym_line_li] = STATE(90),
-    [sym__line_noli] = STATE(52),
-    [sym_column_heading] = STATE(52),
-    [sym_h1] = STATE(52),
-    [sym_h2] = STATE(52),
-    [sym_h3] = STATE(52),
+    [sym_line_li] = STATE(92),
+    [sym__line_noli] = STATE(58),
+    [sym_column_heading] = STATE(58),
+    [sym_h1] = STATE(58),
+    [sym_h2] = STATE(58),
+    [sym_h3] = STATE(58),
     [sym_tag] = STATE(18),
     [sym_url] = STATE(18),
     [sym_optionlink] = STATE(18),
@@ -6618,7 +6749,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_argument] = STATE(18),
     [aux_sym_help_file_repeat2] = STATE(3),
     [aux_sym_block_repeat1] = STATE(6),
-    [aux_sym_block_repeat2] = STATE(90),
+    [aux_sym_block_repeat2] = STATE(92),
     [ts_builtin_sym_end] = ACTIONS(93),
     [aux_sym_word_noli_token1] = ACTIONS(5),
     [aux_sym_word_noli_token2] = ACTIONS(5),
@@ -6655,19 +6786,19 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym__atom_noli] = STATE(18),
     [sym_word_noli] = STATE(18),
     [sym__atom_common] = STATE(18),
-    [sym__word_common] = STATE(88),
+    [sym__word_common] = STATE(80),
     [sym_keycode] = STATE(18),
-    [sym_uppercase_name] = STATE(94),
+    [sym_uppercase_name] = STATE(96),
     [sym__uppercase_words] = STATE(18),
-    [sym_codeblock] = STATE(52),
-    [sym__blank] = STATE(44),
+    [sym_codeblock] = STATE(58),
+    [sym__blank] = STATE(41),
     [sym_line] = STATE(7),
-    [sym_line_li] = STATE(89),
-    [sym__line_noli] = STATE(52),
-    [sym_column_heading] = STATE(52),
-    [sym_h1] = STATE(52),
-    [sym_h2] = STATE(52),
-    [sym_h3] = STATE(52),
+    [sym_line_li] = STATE(91),
+    [sym__line_noli] = STATE(58),
+    [sym_column_heading] = STATE(58),
+    [sym_h1] = STATE(58),
+    [sym_h2] = STATE(58),
+    [sym_h3] = STATE(58),
     [sym_tag] = STATE(18),
     [sym_url] = STATE(18),
     [sym_optionlink] = STATE(18),
@@ -6675,7 +6806,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_codespan] = STATE(18),
     [sym_argument] = STATE(18),
     [aux_sym_block_repeat1] = STATE(7),
-    [aux_sym_block_repeat2] = STATE(89),
+    [aux_sym_block_repeat2] = STATE(91),
     [aux_sym_word_noli_token1] = ACTIONS(5),
     [aux_sym_word_noli_token2] = ACTIONS(5),
     [anon_sym_SQUOTE] = ACTIONS(7),
@@ -6712,17 +6843,17 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym__atom_noli] = STATE(18),
     [sym_word_noli] = STATE(18),
     [sym__atom_common] = STATE(18),
-    [sym__word_common] = STATE(88),
+    [sym__word_common] = STATE(80),
     [sym_keycode] = STATE(18),
-    [sym_uppercase_name] = STATE(94),
+    [sym_uppercase_name] = STATE(96),
     [sym__uppercase_words] = STATE(18),
-    [sym_codeblock] = STATE(52),
+    [sym_codeblock] = STATE(58),
     [sym_line] = STATE(7),
-    [sym__line_noli] = STATE(52),
-    [sym_column_heading] = STATE(52),
-    [sym_h1] = STATE(52),
-    [sym_h2] = STATE(52),
-    [sym_h3] = STATE(52),
+    [sym__line_noli] = STATE(58),
+    [sym_column_heading] = STATE(58),
+    [sym_h1] = STATE(58),
+    [sym_h2] = STATE(58),
+    [sym_h3] = STATE(58),
     [sym_tag] = STATE(18),
     [sym_url] = STATE(18),
     [sym_optionlink] = STATE(18),
@@ -6784,9 +6915,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_BQUOTE2,
     STATE(8), 1,
       aux_sym_line_li_repeat2,
-    STATE(65), 1,
+    STATE(67), 1,
       sym__line_noli,
-    STATE(88), 1,
+    STATE(80), 1,
       sym__word_common,
     ACTIONS(161), 2,
       aux_sym_keycode_token5,
@@ -6845,9 +6976,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     STATE(8), 1,
       aux_sym_line_li_repeat2,
-    STATE(65), 1,
+    STATE(67), 1,
       sym__line_noli,
-    STATE(88), 1,
+    STATE(80), 1,
       sym__word_common,
     ACTIONS(19), 2,
       aux_sym_keycode_token5,
@@ -6906,9 +7037,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     STATE(8), 1,
       aux_sym_line_li_repeat2,
-    STATE(65), 1,
+    STATE(67), 1,
       sym__line_noli,
-    STATE(88), 1,
+    STATE(80), 1,
       sym__word_common,
     ACTIONS(19), 2,
       aux_sym_keycode_token5,
@@ -6967,9 +7098,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     STATE(8), 1,
       aux_sym_line_li_repeat2,
-    STATE(65), 1,
+    STATE(67), 1,
       sym__line_noli,
-    STATE(88), 1,
+    STATE(80), 1,
       sym__word_common,
     ACTIONS(19), 2,
       aux_sym_keycode_token5,
@@ -7028,9 +7159,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     STATE(8), 1,
       aux_sym_line_li_repeat2,
-    STATE(65), 1,
+    STATE(67), 1,
       sym__line_noli,
-    STATE(88), 1,
+    STATE(80), 1,
       sym__word_common,
     ACTIONS(19), 2,
       aux_sym_keycode_token5,
@@ -7089,9 +7220,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     STATE(9), 1,
       aux_sym_line_li_repeat2,
-    STATE(65), 1,
+    STATE(67), 1,
       sym__line_noli,
-    STATE(88), 1,
+    STATE(80), 1,
       sym__word_common,
     ACTIONS(19), 2,
       aux_sym_keycode_token5,
@@ -7150,9 +7281,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     STATE(10), 1,
       aux_sym_line_li_repeat2,
-    STATE(65), 1,
+    STATE(67), 1,
       sym__line_noli,
-    STATE(88), 1,
+    STATE(80), 1,
       sym__word_common,
     ACTIONS(19), 2,
       aux_sym_keycode_token5,
@@ -7211,9 +7342,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     STATE(11), 1,
       aux_sym_line_li_repeat2,
-    STATE(65), 1,
+    STATE(67), 1,
       sym__line_noli,
-    STATE(88), 1,
+    STATE(80), 1,
       sym__word_common,
     ACTIONS(19), 2,
       aux_sym_keycode_token5,
@@ -7272,9 +7403,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     STATE(12), 1,
       aux_sym_line_li_repeat2,
-    STATE(65), 1,
+    STATE(67), 1,
       sym__line_noli,
-    STATE(88), 1,
+    STATE(80), 1,
       sym__word_common,
     ACTIONS(19), 2,
       aux_sym_keycode_token5,
@@ -7333,9 +7464,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
     STATE(20), 1,
       aux_sym_line_li_repeat1,
-    STATE(62), 1,
+    STATE(66), 1,
       sym_codeblock,
-    STATE(80), 1,
+    STATE(82), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
@@ -7359,7 +7490,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
-    STATE(78), 10,
+    STATE(84), 10,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -7391,9 +7522,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LF2,
     STATE(22), 1,
       aux_sym_line_li_repeat1,
-    STATE(53), 1,
+    STATE(54), 1,
       sym_codeblock,
-    STATE(80), 1,
+    STATE(82), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
@@ -7416,7 +7547,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
       aux_sym__word_common_token6,
-    STATE(78), 10,
+    STATE(84), 10,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -7448,7 +7579,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_codeblock,
     STATE(23), 1,
       aux_sym_line_li_repeat1,
-    STATE(80), 1,
+    STATE(82), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
@@ -7472,7 +7603,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
-    STATE(78), 10,
+    STATE(84), 10,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -7504,7 +7635,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_li_repeat1,
     STATE(64), 1,
       sym_codeblock,
-    STATE(80), 1,
+    STATE(82), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
@@ -7528,7 +7659,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
-    STATE(78), 10,
+    STATE(84), 10,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -7560,7 +7691,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_codeblock,
     STATE(23), 1,
       aux_sym_line_li_repeat1,
-    STATE(80), 1,
+    STATE(82), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
@@ -7584,7 +7715,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
-    STATE(78), 10,
+    STATE(84), 10,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -7616,9 +7747,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LF2,
     STATE(23), 1,
       aux_sym_line_li_repeat1,
-    STATE(56), 1,
+    STATE(52), 1,
       sym_codeblock,
-    STATE(80), 1,
+    STATE(82), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
@@ -7641,7 +7772,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
       aux_sym__word_common_token6,
-    STATE(78), 10,
+    STATE(84), 10,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -7669,7 +7800,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_BQUOTE2,
     STATE(23), 1,
       aux_sym_line_li_repeat1,
-    STATE(80), 1,
+    STATE(82), 1,
       sym__word_common,
     ACTIONS(238), 2,
       aux_sym_word_token1,
@@ -7694,7 +7825,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
-    STATE(78), 10,
+    STATE(84), 10,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -7722,7 +7853,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LF2,
     STATE(23), 1,
       aux_sym_line_li_repeat1,
-    STATE(80), 1,
+    STATE(82), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
@@ -7747,7 +7878,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
-    STATE(78), 10,
+    STATE(84), 10,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -7775,7 +7906,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LF2,
     STATE(24), 1,
       aux_sym_line_li_repeat1,
-    STATE(80), 1,
+    STATE(82), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
@@ -7800,7 +7931,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
-    STATE(78), 10,
+    STATE(84), 10,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -7828,7 +7959,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LF2,
     STATE(23), 1,
       aux_sym_line_li_repeat1,
-    STATE(80), 1,
+    STATE(82), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
@@ -7853,7 +7984,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
-    STATE(78), 10,
+    STATE(84), 10,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -7881,7 +8012,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LF2,
     STATE(23), 1,
       aux_sym_line_li_repeat1,
-    STATE(80), 1,
+    STATE(82), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
@@ -7906,7 +8037,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
-    STATE(78), 10,
+    STATE(84), 10,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -7932,7 +8063,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
     STATE(27), 1,
       aux_sym_line_li_repeat1,
-    STATE(80), 1,
+    STATE(82), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
@@ -7957,7 +8088,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
-    STATE(78), 10,
+    STATE(84), 10,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -7983,7 +8114,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
     STATE(26), 1,
       aux_sym_line_li_repeat1,
-    STATE(80), 1,
+    STATE(82), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
@@ -8008,7 +8139,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
-    STATE(78), 10,
+    STATE(84), 10,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -8034,7 +8165,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
     STATE(19), 1,
       aux_sym_line_li_repeat1,
-    STATE(80), 1,
+    STATE(82), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
@@ -8059,7 +8190,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
-    STATE(78), 10,
+    STATE(84), 10,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -8085,7 +8216,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
     STATE(21), 1,
       aux_sym_line_li_repeat1,
-    STATE(80), 1,
+    STATE(82), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
@@ -8110,7 +8241,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
-    STATE(78), 10,
+    STATE(84), 10,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -8121,13 +8252,31 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1729] = 5,
+  [1729] = 6,
     ACTIONS(25), 1,
       anon_sym_LF2,
+    ACTIONS(282), 1,
+      aux_sym_line_li_token1,
     STATE(33), 1,
       aux_sym_help_file_repeat1,
-    STATE(45), 1,
+    STATE(46), 1,
       sym__blank,
+    ACTIONS(278), 15,
+      ts_builtin_sym_end,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE2,
     ACTIONS(280), 15,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
@@ -8144,31 +8293,14 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(278), 16,
-      ts_builtin_sym_end,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_line_li_token1,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [1774] = 5,
+  [1776] = 5,
     ACTIONS(25), 1,
       anon_sym_LF2,
-    STATE(42), 1,
+    STATE(43), 1,
       aux_sym_help_file_repeat1,
-    STATE(45), 1,
+    STATE(46), 1,
       sym__blank,
-    ACTIONS(284), 15,
+    ACTIONS(286), 15,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
@@ -8184,7 +8316,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(282), 16,
+    ACTIONS(284), 16,
       ts_builtin_sym_end,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -8201,58 +8333,19 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [1819] = 5,
-    ACTIONS(25), 1,
+  [1821] = 6,
+    ACTIONS(290), 1,
       anon_sym_LF2,
-    STATE(42), 1,
-      aux_sym_help_file_repeat1,
-    STATE(45), 1,
-      sym__blank,
-    ACTIONS(288), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-    ACTIONS(286), 16,
-      ts_builtin_sym_end,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_line_li_token1,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [1864] = 5,
     ACTIONS(292), 1,
-      anon_sym_LF2,
-    ACTIONS(295), 1,
       aux_sym_line_code_token1,
-    ACTIONS(298), 2,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-    STATE(35), 2,
-      sym_line_code,
+    STATE(35), 1,
       aux_sym_codeblock_repeat1,
-    ACTIONS(290), 28,
+    STATE(48), 1,
+      sym_line_code,
+    ACTIONS(294), 2,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+    ACTIONS(288), 28,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_SQUOTE,
@@ -8281,14 +8374,55 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [1909] = 5,
+  [1868] = 6,
+    ACTIONS(298), 1,
+      anon_sym_LF2,
+    ACTIONS(301), 1,
+      aux_sym_line_code_token1,
+    STATE(35), 1,
+      aux_sym_codeblock_repeat1,
+    STATE(48), 1,
+      sym_line_code,
+    ACTIONS(304), 2,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+    ACTIONS(296), 28,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_PIPE,
+      aux_sym__word_common_token4,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_keycode_token8,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+      aux_sym_line_li_token1,
+      anon_sym_STAR,
+      sym_url_word,
+      anon_sym_BQUOTE2,
+  [1915] = 5,
     ACTIONS(25), 1,
       anon_sym_LF2,
-    STATE(42), 1,
+    STATE(43), 1,
       aux_sym_help_file_repeat1,
-    STATE(45), 1,
+    STATE(46), 1,
       sym__blank,
-    ACTIONS(302), 15,
+    ACTIONS(308), 15,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
@@ -8304,7 +8438,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(300), 16,
+    ACTIONS(306), 16,
       ts_builtin_sym_end,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -8321,133 +8455,12 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [1954] = 6,
+  [1960] = 5,
     ACTIONS(25), 1,
       anon_sym_LF2,
-    ACTIONS(308), 1,
-      aux_sym_line_li_token1,
-    STATE(34), 1,
+    STATE(39), 1,
       aux_sym_help_file_repeat1,
-    STATE(45), 1,
-      sym__blank,
-    ACTIONS(304), 15,
-      ts_builtin_sym_end,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-    ACTIONS(306), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-  [2001] = 5,
-    ACTIONS(25), 1,
-      anon_sym_LF2,
-    STATE(42), 1,
-      aux_sym_help_file_repeat1,
-    STATE(45), 1,
-      sym__blank,
-    ACTIONS(302), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-    ACTIONS(300), 16,
-      ts_builtin_sym_end,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_line_li_token1,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [2046] = 5,
-    ACTIONS(25), 1,
-      anon_sym_LF2,
-    STATE(42), 1,
-      aux_sym_help_file_repeat1,
-    STATE(45), 1,
-      sym__blank,
-    ACTIONS(280), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-    ACTIONS(278), 16,
-      ts_builtin_sym_end,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_line_li_token1,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [2091] = 5,
-    ACTIONS(25), 1,
-      anon_sym_LF2,
-    STATE(36), 1,
-      aux_sym_help_file_repeat1,
-    STATE(45), 1,
+    STATE(46), 1,
       sym__blank,
     ACTIONS(312), 15,
       aux_sym_word_noli_token1,
@@ -8482,53 +8495,191 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2136] = 5,
-    ACTIONS(316), 1,
+  [2005] = 5,
+    ACTIONS(25), 1,
       anon_sym_LF2,
-    ACTIONS(318), 1,
-      aux_sym_line_code_token1,
-    ACTIONS(320), 2,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-    STATE(35), 2,
-      sym_line_code,
-      aux_sym_codeblock_repeat1,
-    ACTIONS(314), 28,
+    STATE(43), 1,
+      aux_sym_help_file_repeat1,
+    STATE(46), 1,
+      sym__blank,
+    ACTIONS(316), 15,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
       anon_sym_PIPE,
-      aux_sym__word_common_token4,
       anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
       anon_sym_LPAREN,
       aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-      aux_sym_line_li_token1,
       anon_sym_STAR,
+    ACTIONS(314), 16,
+      ts_builtin_sym_end,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
+      aux_sym_line_li_token1,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2181] = 5,
-    ACTIONS(326), 1,
+  [2050] = 5,
+    ACTIONS(25), 1,
       anon_sym_LF2,
-    STATE(42), 1,
+    STATE(43), 1,
       aux_sym_help_file_repeat1,
-    STATE(45), 1,
+    STATE(46), 1,
       sym__blank,
+    ACTIONS(320), 15,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token6,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token7,
+      aux_sym_keycode_token8,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+      anon_sym_STAR,
+    ACTIONS(318), 16,
+      ts_builtin_sym_end,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
+      aux_sym_line_li_token1,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE2,
+  [2095] = 5,
+    ACTIONS(25), 1,
+      anon_sym_LF2,
+    STATE(36), 1,
+      aux_sym_help_file_repeat1,
+    STATE(46), 1,
+      sym__blank,
+    ACTIONS(316), 15,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token6,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token7,
+      aux_sym_keycode_token8,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+      anon_sym_STAR,
+    ACTIONS(314), 16,
+      ts_builtin_sym_end,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
+      aux_sym_line_li_token1,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE2,
+  [2140] = 5,
+    ACTIONS(25), 1,
+      anon_sym_LF2,
+    STATE(44), 1,
+      aux_sym_help_file_repeat1,
+    STATE(46), 1,
+      sym__blank,
+    ACTIONS(312), 15,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token6,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token7,
+      aux_sym_keycode_token8,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+      anon_sym_STAR,
+    ACTIONS(310), 16,
+      ts_builtin_sym_end,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
+      aux_sym_line_li_token1,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE2,
+  [2185] = 6,
+    ACTIONS(25), 1,
+      anon_sym_LF2,
+    ACTIONS(282), 1,
+      aux_sym_line_li_token1,
+    STATE(38), 1,
+      aux_sym_help_file_repeat1,
+    STATE(46), 1,
+      sym__blank,
+    ACTIONS(322), 15,
+      ts_builtin_sym_end,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE2,
     ACTIONS(324), 15,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
@@ -8545,7 +8696,30 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(322), 16,
+  [2232] = 5,
+    ACTIONS(330), 1,
+      anon_sym_LF2,
+    STATE(43), 1,
+      aux_sym_help_file_repeat1,
+    STATE(46), 1,
+      sym__blank,
+    ACTIONS(328), 15,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token6,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token7,
+      aux_sym_keycode_token8,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+      anon_sym_STAR,
+    ACTIONS(326), 16,
       ts_builtin_sym_end,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -8562,32 +8736,14 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2226] = 6,
+  [2277] = 5,
     ACTIONS(25), 1,
       anon_sym_LF2,
-    ACTIONS(308), 1,
-      aux_sym_line_li_token1,
-    STATE(39), 1,
+    STATE(43), 1,
       aux_sym_help_file_repeat1,
-    STATE(45), 1,
+    STATE(46), 1,
       sym__blank,
-    ACTIONS(329), 15,
-      ts_builtin_sym_end,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-    ACTIONS(331), 15,
+    ACTIONS(320), 15,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
@@ -8603,30 +8759,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-  [2273] = 5,
-    ACTIONS(25), 1,
-      anon_sym_LF2,
-    STATE(38), 1,
-      aux_sym_help_file_repeat1,
-    STATE(45), 1,
-      sym__blank,
-    ACTIONS(312), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-    ACTIONS(310), 16,
+    ACTIONS(318), 16,
       ts_builtin_sym_end,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -8643,50 +8776,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2318] = 2,
-    ACTIONS(335), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-    ACTIONS(333), 17,
-      ts_builtin_sym_end,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
+  [2322] = 5,
+    ACTIONS(333), 1,
       anon_sym_LF2,
-      aux_sym_line_li_token1,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [2355] = 4,
-    ACTIONS(337), 1,
-      anon_sym_LF2,
-    ACTIONS(340), 1,
+    ACTIONS(335), 1,
       aux_sym_line_code_token1,
-    STATE(46), 2,
-      sym_line_code,
+    STATE(50), 1,
       aux_sym_codeblock_repeat1,
-    ACTIONS(290), 28,
+    STATE(62), 1,
+      sym_line_code,
+    ACTIONS(288), 28,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_SQUOTE,
@@ -8715,15 +8814,156 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2396] = 4,
-    ACTIONS(343), 1,
+  [2365] = 2,
+    ACTIONS(339), 15,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token6,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token7,
+      aux_sym_keycode_token8,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+      anon_sym_STAR,
+    ACTIONS(337), 17,
+      ts_builtin_sym_end,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
       anon_sym_LF2,
-    ACTIONS(345), 1,
+      aux_sym_line_li_token1,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE2,
+  [2402] = 2,
+    ACTIONS(343), 15,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token6,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token7,
+      aux_sym_keycode_token8,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+      anon_sym_STAR,
+    ACTIONS(341), 17,
+      ts_builtin_sym_end,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
+      anon_sym_LF2,
+      aux_sym_line_li_token1,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE2,
+  [2439] = 2,
+    ACTIONS(347), 3,
+      anon_sym_LF2,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+    ACTIONS(345), 29,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_PIPE,
+      aux_sym__word_common_token4,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_keycode_token8,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+      aux_sym_line_li_token1,
       aux_sym_line_code_token1,
-    STATE(46), 2,
-      sym_line_code,
+      anon_sym_STAR,
+      sym_url_word,
+      anon_sym_BQUOTE2,
+  [2476] = 2,
+    ACTIONS(351), 3,
+      anon_sym_LF2,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+    ACTIONS(349), 29,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_PIPE,
+      aux_sym__word_common_token4,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_keycode_token8,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+      aux_sym_line_li_token1,
+      aux_sym_line_code_token1,
+      anon_sym_STAR,
+      sym_url_word,
+      anon_sym_BQUOTE2,
+  [2513] = 5,
+    ACTIONS(353), 1,
+      anon_sym_LF2,
+    ACTIONS(356), 1,
+      aux_sym_line_code_token1,
+    STATE(50), 1,
       aux_sym_codeblock_repeat1,
-    ACTIONS(314), 28,
+    STATE(62), 1,
+      sym_line_code,
+    ACTIONS(296), 28,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_SQUOTE,
@@ -8752,19 +8992,19 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2437] = 3,
-    ACTIONS(349), 3,
+  [2556] = 3,
+    ACTIONS(361), 3,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
       anon_sym_LF2,
-    ACTIONS(351), 6,
+    ACTIONS(363), 6,
       aux_sym_taglink_token1,
       anon_sym_LBRACE2,
       anon_sym_RBRACE2,
       anon_sym_LPAREN2,
       anon_sym_RPAREN,
       anon_sym_BQUOTE,
-    ACTIONS(347), 23,
+    ACTIONS(359), 23,
       aux_sym_word_token1,
       aux_sym_word_token2,
       anon_sym_SQUOTE,
@@ -8788,111 +9028,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2476] = 2,
-    ACTIONS(355), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-    ACTIONS(353), 17,
-      ts_builtin_sym_end,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [2513] = 2,
-    ACTIONS(359), 3,
-      anon_sym_LF2,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-    ACTIONS(357), 29,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_PIPE,
-      aux_sym__word_common_token4,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      aux_sym_line_li_token1,
-      aux_sym_line_code_token1,
-      anon_sym_STAR,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [2550] = 2,
-    ACTIONS(361), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-    ACTIONS(363), 16,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [2586] = 2,
+  [2595] = 2,
     ACTIONS(365), 15,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
@@ -8926,7 +9062,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2622] = 2,
+  [2631] = 2,
     ACTIONS(369), 15,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
@@ -8960,7 +9096,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2658] = 2,
+  [2667] = 2,
     ACTIONS(373), 15,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
@@ -8994,7 +9130,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2694] = 2,
+  [2703] = 2,
     ACTIONS(377), 15,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
@@ -9028,7 +9164,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2730] = 2,
+  [2739] = 2,
     ACTIONS(381), 15,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
@@ -9062,7 +9198,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2766] = 2,
+  [2775] = 2,
     ACTIONS(385), 15,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
@@ -9096,7 +9232,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2802] = 2,
+  [2811] = 2,
     ACTIONS(389), 15,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
@@ -9130,7 +9266,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2838] = 2,
+  [2847] = 2,
     ACTIONS(393), 15,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
@@ -9164,7 +9300,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2874] = 2,
+  [2883] = 2,
     ACTIONS(397), 15,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
@@ -9198,10 +9334,44 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2910] = 2,
-    ACTIONS(359), 1,
+  [2919] = 2,
+    ACTIONS(401), 15,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token6,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token7,
+      aux_sym_keycode_token8,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+      anon_sym_STAR,
+    ACTIONS(403), 16,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
       anon_sym_LF2,
-    ACTIONS(357), 29,
+      aux_sym_line_li_token1,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE2,
+  [2955] = 2,
+    ACTIONS(347), 1,
+      anon_sym_LF2,
+    ACTIONS(345), 29,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_SQUOTE,
@@ -9231,8 +9401,41 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2945] = 2,
-    ACTIONS(371), 14,
+  [2990] = 2,
+    ACTIONS(351), 1,
+      anon_sym_LF2,
+    ACTIONS(349), 29,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_PIPE,
+      aux_sym__word_common_token4,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_keycode_token8,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+      aux_sym_line_li_token1,
+      aux_sym_line_code_token1,
+      anon_sym_STAR,
+      sym_url_word,
+      anon_sym_BQUOTE2,
+  [3025] = 2,
+    ACTIONS(367), 14,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -9247,7 +9450,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_li_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-    ACTIONS(369), 15,
+    ACTIONS(365), 15,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
@@ -9263,13 +9466,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-  [2979] = 4,
-    ACTIONS(403), 1,
+  [3059] = 4,
+    ACTIONS(407), 1,
       aux_sym_optionlink_token1,
-    ACTIONS(401), 2,
+    ACTIONS(405), 2,
       aux_sym__word_common_token1,
       aux_sym__word_common_token2,
-    ACTIONS(349), 11,
+    ACTIONS(361), 11,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -9281,7 +9484,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
       anon_sym_LF2,
-    ACTIONS(347), 15,
+    ACTIONS(359), 15,
       aux_sym_word_token1,
       aux_sym_word_token2,
       anon_sym_PIPE,
@@ -9297,8 +9500,8 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3017] = 2,
-    ACTIONS(383), 14,
+  [3097] = 2,
+    ACTIONS(375), 14,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -9313,7 +9516,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_li_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-    ACTIONS(381), 15,
+    ACTIONS(373), 15,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
@@ -9329,56 +9532,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-  [3051] = 2,
-    ACTIONS(407), 14,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-    ACTIONS(405), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-  [3085] = 4,
-    ACTIONS(413), 1,
-      aux_sym_uppercase_name_token2,
-    STATE(66), 1,
-      aux_sym_uppercase_name_repeat1,
-    ACTIONS(409), 12,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
+  [3131] = 2,
     ACTIONS(411), 14,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -9391,15 +9545,63 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       anon_sym_LF2,
+      aux_sym_line_li_token1,
+      sym_url_word,
+      anon_sym_BQUOTE2,
+    ACTIONS(409), 15,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token6,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token7,
+      aux_sym_keycode_token8,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+      anon_sym_STAR,
+  [3165] = 3,
+    ACTIONS(413), 2,
+      aux_sym_codeblock_token1,
+      anon_sym_LF,
+    ACTIONS(359), 8,
+      aux_sym_word_token1,
+      aux_sym_word_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      anon_sym_LF2,
+    ACTIONS(361), 18,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_keycode_token8,
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3122] = 4,
-    ACTIONS(420), 1,
+  [3200] = 4,
+    ACTIONS(419), 1,
       aux_sym_uppercase_name_token2,
-    STATE(66), 1,
+    STATE(69), 1,
       aux_sym_uppercase_name_repeat1,
-    ACTIONS(416), 12,
+    ACTIONS(415), 12,
       aux_sym_word_token1,
       aux_sym_word_token2,
       anon_sym_PIPE,
@@ -9412,7 +9614,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token4,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
-    ACTIONS(418), 14,
+    ACTIONS(417), 14,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -9427,12 +9629,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3159] = 5,
-    ACTIONS(420), 1,
+  [3237] = 5,
+    ACTIONS(426), 1,
       aux_sym_uppercase_name_token2,
-    STATE(70), 1,
+    STATE(73), 1,
       aux_sym_uppercase_name_repeat1,
-    ACTIONS(426), 2,
+    ACTIONS(428), 2,
       anon_sym_LF2,
       anon_sym_STAR,
     ACTIONS(422), 12,
@@ -9461,10 +9663,10 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token6,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3198] = 4,
-    ACTIONS(420), 1,
+  [3276] = 4,
+    ACTIONS(426), 1,
       aux_sym_uppercase_name_token2,
-    STATE(67), 1,
+    STATE(72), 1,
       aux_sym_uppercase_name_repeat1,
     ACTIONS(422), 12,
       aux_sym_word_token1,
@@ -9494,15 +9696,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3235] = 5,
-    ACTIONS(420), 1,
+  [3313] = 4,
+    ACTIONS(426), 1,
       aux_sym_uppercase_name_token2,
-    STATE(66), 1,
+    STATE(69), 1,
       aux_sym_uppercase_name_repeat1,
-    ACTIONS(428), 2,
-      anon_sym_LF2,
-      anon_sym_STAR,
-    ACTIONS(416), 12,
+    ACTIONS(430), 12,
       aux_sym_word_token1,
       aux_sym_word_token2,
       anon_sym_PIPE,
@@ -9515,7 +9714,43 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token4,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
-    ACTIONS(418), 12,
+    ACTIONS(432), 14,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
+      anon_sym_LF2,
+      anon_sym_STAR,
+      sym_url_word,
+      anon_sym_BQUOTE2,
+  [3350] = 5,
+    ACTIONS(426), 1,
+      aux_sym_uppercase_name_token2,
+    STATE(69), 1,
+      aux_sym_uppercase_name_repeat1,
+    ACTIONS(434), 2,
+      anon_sym_LF2,
+      anon_sym_STAR,
+    ACTIONS(430), 12,
+      aux_sym_word_token1,
+      aux_sym_word_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token6,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token7,
+      aux_sym_keycode_token8,
+    ACTIONS(432), 12,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -9528,10 +9763,11 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token6,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3274] = 3,
-    ACTIONS(430), 1,
+  [3389] = 3,
+    ACTIONS(436), 2,
+      aux_sym_codeblock_token1,
       anon_sym_LF,
-    ACTIONS(347), 8,
+    ACTIONS(359), 8,
       aux_sym_word_token1,
       aux_sym_word_token2,
       anon_sym_PIPE,
@@ -9540,7 +9776,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       anon_sym_LF2,
-    ACTIONS(349), 18,
+    ACTIONS(361), 18,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -9559,8 +9795,132 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3308] = 2,
-    ACTIONS(432), 13,
+  [3424] = 3,
+    ACTIONS(438), 1,
+      anon_sym_LF,
+    ACTIONS(359), 8,
+      aux_sym_word_token1,
+      aux_sym_word_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      anon_sym_LF2,
+    ACTIONS(361), 18,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_keycode_token8,
+      anon_sym_STAR,
+      sym_url_word,
+      anon_sym_BQUOTE2,
+  [3458] = 3,
+    ACTIONS(442), 1,
+      anon_sym_SQUOTE2,
+    ACTIONS(440), 8,
+      aux_sym_word_token1,
+      aux_sym_word_token2,
+      anon_sym_SQUOTE,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+    ACTIONS(444), 18,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_keycode_token8,
+      anon_sym_LF2,
+      anon_sym_STAR,
+      sym_url_word,
+      anon_sym_BQUOTE2,
+  [3492] = 3,
+    ACTIONS(446), 1,
+      aux_sym_argument_token1,
+    ACTIONS(361), 6,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      aux_sym_keycode_token6,
+      anon_sym_LF2,
+    ACTIONS(359), 20,
+      aux_sym_word_token1,
+      aux_sym_word_token2,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token7,
+      aux_sym_keycode_token8,
+      anon_sym_STAR,
+      sym_url_word,
+      anon_sym_BQUOTE2,
+  [3526] = 3,
+    ACTIONS(448), 1,
+      anon_sym_LF,
+    ACTIONS(359), 8,
+      aux_sym_word_token1,
+      aux_sym_word_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      anon_sym_LF2,
+    ACTIONS(361), 18,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_keycode_token8,
+      anon_sym_STAR,
+      sym_url_word,
+      anon_sym_BQUOTE2,
+  [3560] = 2,
+    ACTIONS(450), 13,
       aux_sym_word_token1,
       aux_sym_word_token2,
       anon_sym_PIPE,
@@ -9574,7 +9934,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
       aux_sym_uppercase_name_token2,
-    ACTIONS(434), 14,
+    ACTIONS(452), 14,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -9589,191 +9949,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3340] = 3,
-    ACTIONS(436), 1,
-      anon_sym_LF,
-    ACTIONS(347), 8,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      anon_sym_LF2,
-    ACTIONS(349), 18,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      anon_sym_STAR,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [3374] = 3,
-    ACTIONS(438), 1,
-      aux_sym_argument_token1,
-    ACTIONS(349), 6,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      aux_sym_keycode_token6,
-      anon_sym_LF2,
-    ACTIONS(347), 20,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      anon_sym_STAR,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [3408] = 3,
-    ACTIONS(440), 1,
-      anon_sym_LF,
-    ACTIONS(347), 8,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      anon_sym_LF2,
-    ACTIONS(349), 18,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      anon_sym_STAR,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [3442] = 3,
-    ACTIONS(442), 1,
-      anon_sym_LF,
-    ACTIONS(347), 8,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      anon_sym_LF2,
-    ACTIONS(349), 18,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      anon_sym_STAR,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [3476] = 3,
-    ACTIONS(446), 1,
-      anon_sym_SQUOTE2,
-    ACTIONS(444), 8,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
-      anon_sym_SQUOTE,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-    ACTIONS(448), 18,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      anon_sym_LF2,
-      anon_sym_STAR,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [3510] = 2,
-    ACTIONS(450), 7,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-    ACTIONS(452), 19,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      anon_sym_LF2,
-      anon_sym_STAR,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [3541] = 2,
+  [3592] = 2,
     ACTIONS(454), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -9802,7 +9978,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3572] = 2,
+  [3623] = 2,
     ACTIONS(458), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -9831,7 +10007,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3603] = 2,
+  [3654] = 2,
     ACTIONS(462), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -9860,7 +10036,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3634] = 2,
+  [3685] = 2,
     ACTIONS(466), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -9889,7 +10065,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3665] = 2,
+  [3716] = 2,
     ACTIONS(470), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -9918,7 +10094,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3696] = 2,
+  [3747] = 2,
     ACTIONS(474), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -9947,7 +10123,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3727] = 2,
+  [3778] = 2,
     ACTIONS(478), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -9976,7 +10152,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3758] = 2,
+  [3809] = 2,
     ACTIONS(482), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -10005,7 +10181,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3789] = 2,
+  [3840] = 2,
     ACTIONS(486), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -10034,7 +10210,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3820] = 2,
+  [3871] = 2,
     ACTIONS(490), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -10063,90 +10239,121 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3851] = 5,
+  [3902] = 2,
+    ACTIONS(494), 7,
+      aux_sym_word_token1,
+      aux_sym_word_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+    ACTIONS(496), 19,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_keycode_token8,
+      anon_sym_LF2,
+      anon_sym_STAR,
+      sym_url_word,
+      anon_sym_BQUOTE2,
+  [3933] = 5,
     ACTIONS(25), 1,
       anon_sym_LF2,
     ACTIONS(27), 1,
       aux_sym_line_li_token1,
-    ACTIONS(494), 1,
-      anon_sym_LT,
-    STATE(32), 1,
-      sym__blank,
-    STATE(91), 2,
-      sym_line_li,
-      aux_sym_block_repeat2,
-  [3868] = 5,
-    ACTIONS(25), 1,
-      anon_sym_LF2,
-    ACTIONS(27), 1,
-      aux_sym_line_li_token1,
-    ACTIONS(496), 1,
+    ACTIONS(498), 1,
       anon_sym_LT,
     STATE(40), 1,
       sym__blank,
-    STATE(91), 2,
+    STATE(93), 2,
       sym_line_li,
       aux_sym_block_repeat2,
-  [3885] = 4,
-    ACTIONS(498), 1,
-      anon_sym_LT,
-    ACTIONS(501), 1,
+  [3950] = 5,
+    ACTIONS(25), 1,
       anon_sym_LF2,
-    ACTIONS(503), 1,
+    ACTIONS(27), 1,
       aux_sym_line_li_token1,
-    STATE(91), 2,
+    ACTIONS(500), 1,
+      anon_sym_LT,
+    STATE(37), 1,
+      sym__blank,
+    STATE(93), 2,
       sym_line_li,
       aux_sym_block_repeat2,
-  [3899] = 3,
-    ACTIONS(316), 1,
+  [3967] = 4,
+    ACTIONS(502), 1,
+      anon_sym_LT,
+    ACTIONS(505), 1,
       anon_sym_LF2,
-    ACTIONS(318), 1,
-      aux_sym_line_code_token1,
-    STATE(41), 2,
-      sym_line_code,
-      aux_sym_codeblock_repeat1,
-  [3910] = 3,
-    ACTIONS(343), 1,
+    ACTIONS(507), 1,
+      aux_sym_line_li_token1,
+    STATE(93), 2,
+      sym_line_li,
+      aux_sym_block_repeat2,
+  [3981] = 4,
+    ACTIONS(290), 1,
       anon_sym_LF2,
-    ACTIONS(345), 1,
+    ACTIONS(292), 1,
       aux_sym_line_code_token1,
-    STATE(47), 2,
-      sym_line_code,
+    STATE(34), 1,
       aux_sym_codeblock_repeat1,
-  [3921] = 3,
+    STATE(48), 1,
+      sym_line_code,
+  [3994] = 4,
+    ACTIONS(333), 1,
+      anon_sym_LF2,
+    ACTIONS(335), 1,
+      aux_sym_line_code_token1,
+    STATE(45), 1,
+      aux_sym_codeblock_repeat1,
+    STATE(62), 1,
+      sym_line_code,
+  [4007] = 3,
     ACTIONS(222), 1,
       anon_sym_STAR,
-    ACTIONS(506), 1,
+    ACTIONS(510), 1,
       anon_sym_LF2,
     STATE(25), 1,
       sym_tag,
-  [3931] = 1,
-    ACTIONS(508), 1,
-      ts_builtin_sym_end,
-  [3935] = 1,
-    ACTIONS(510), 1,
-      anon_sym_RBRACE2,
-  [3939] = 1,
+  [4017] = 1,
     ACTIONS(512), 1,
-      aux_sym_tag_token1,
-  [3943] = 1,
+      ts_builtin_sym_end,
+  [4021] = 1,
     ACTIONS(514), 1,
-      aux_sym_codespan_token1,
-  [3947] = 1,
+      anon_sym_SQUOTE2,
+  [4025] = 1,
+    ACTIONS(282), 1,
+      aux_sym_line_li_token1,
+  [4029] = 1,
     ACTIONS(516), 1,
       anon_sym_BQUOTE,
-  [3951] = 1,
+  [4033] = 1,
     ACTIONS(518), 1,
-      anon_sym_PIPE2,
-  [3955] = 1,
-    ACTIONS(308), 1,
-      aux_sym_line_li_token1,
-  [3959] = 1,
-    ACTIONS(520), 1,
-      anon_sym_SQUOTE2,
-  [3963] = 1,
-    ACTIONS(522), 1,
       anon_sym_STAR2,
+  [4037] = 1,
+    ACTIONS(520), 1,
+      aux_sym_codespan_token1,
+  [4041] = 1,
+    ACTIONS(522), 1,
+      aux_sym_tag_token1,
+  [4045] = 1,
+    ACTIONS(524), 1,
+      anon_sym_RBRACE2,
+  [4049] = 1,
+    ACTIONS(526), 1,
+      anon_sym_PIPE2,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
@@ -10175,313 +10382,317 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(30)] = 1601,
   [SMALL_STATE(31)] = 1665,
   [SMALL_STATE(32)] = 1729,
-  [SMALL_STATE(33)] = 1774,
-  [SMALL_STATE(34)] = 1819,
-  [SMALL_STATE(35)] = 1864,
-  [SMALL_STATE(36)] = 1909,
-  [SMALL_STATE(37)] = 1954,
-  [SMALL_STATE(38)] = 2001,
-  [SMALL_STATE(39)] = 2046,
-  [SMALL_STATE(40)] = 2091,
-  [SMALL_STATE(41)] = 2136,
-  [SMALL_STATE(42)] = 2181,
-  [SMALL_STATE(43)] = 2226,
-  [SMALL_STATE(44)] = 2273,
-  [SMALL_STATE(45)] = 2318,
-  [SMALL_STATE(46)] = 2355,
-  [SMALL_STATE(47)] = 2396,
-  [SMALL_STATE(48)] = 2437,
+  [SMALL_STATE(33)] = 1776,
+  [SMALL_STATE(34)] = 1821,
+  [SMALL_STATE(35)] = 1868,
+  [SMALL_STATE(36)] = 1915,
+  [SMALL_STATE(37)] = 1960,
+  [SMALL_STATE(38)] = 2005,
+  [SMALL_STATE(39)] = 2050,
+  [SMALL_STATE(40)] = 2095,
+  [SMALL_STATE(41)] = 2140,
+  [SMALL_STATE(42)] = 2185,
+  [SMALL_STATE(43)] = 2232,
+  [SMALL_STATE(44)] = 2277,
+  [SMALL_STATE(45)] = 2322,
+  [SMALL_STATE(46)] = 2365,
+  [SMALL_STATE(47)] = 2402,
+  [SMALL_STATE(48)] = 2439,
   [SMALL_STATE(49)] = 2476,
   [SMALL_STATE(50)] = 2513,
-  [SMALL_STATE(51)] = 2550,
-  [SMALL_STATE(52)] = 2586,
-  [SMALL_STATE(53)] = 2622,
-  [SMALL_STATE(54)] = 2658,
-  [SMALL_STATE(55)] = 2694,
-  [SMALL_STATE(56)] = 2730,
-  [SMALL_STATE(57)] = 2766,
-  [SMALL_STATE(58)] = 2802,
-  [SMALL_STATE(59)] = 2838,
-  [SMALL_STATE(60)] = 2874,
-  [SMALL_STATE(61)] = 2910,
-  [SMALL_STATE(62)] = 2945,
-  [SMALL_STATE(63)] = 2979,
-  [SMALL_STATE(64)] = 3017,
-  [SMALL_STATE(65)] = 3051,
-  [SMALL_STATE(66)] = 3085,
-  [SMALL_STATE(67)] = 3122,
-  [SMALL_STATE(68)] = 3159,
-  [SMALL_STATE(69)] = 3198,
-  [SMALL_STATE(70)] = 3235,
-  [SMALL_STATE(71)] = 3274,
-  [SMALL_STATE(72)] = 3308,
-  [SMALL_STATE(73)] = 3340,
-  [SMALL_STATE(74)] = 3374,
-  [SMALL_STATE(75)] = 3408,
-  [SMALL_STATE(76)] = 3442,
-  [SMALL_STATE(77)] = 3476,
-  [SMALL_STATE(78)] = 3510,
-  [SMALL_STATE(79)] = 3541,
-  [SMALL_STATE(80)] = 3572,
-  [SMALL_STATE(81)] = 3603,
-  [SMALL_STATE(82)] = 3634,
-  [SMALL_STATE(83)] = 3665,
-  [SMALL_STATE(84)] = 3696,
-  [SMALL_STATE(85)] = 3727,
-  [SMALL_STATE(86)] = 3758,
-  [SMALL_STATE(87)] = 3789,
-  [SMALL_STATE(88)] = 3820,
-  [SMALL_STATE(89)] = 3851,
-  [SMALL_STATE(90)] = 3868,
-  [SMALL_STATE(91)] = 3885,
-  [SMALL_STATE(92)] = 3899,
-  [SMALL_STATE(93)] = 3910,
-  [SMALL_STATE(94)] = 3921,
-  [SMALL_STATE(95)] = 3931,
-  [SMALL_STATE(96)] = 3935,
-  [SMALL_STATE(97)] = 3939,
-  [SMALL_STATE(98)] = 3943,
-  [SMALL_STATE(99)] = 3947,
-  [SMALL_STATE(100)] = 3951,
-  [SMALL_STATE(101)] = 3955,
-  [SMALL_STATE(102)] = 3959,
-  [SMALL_STATE(103)] = 3963,
+  [SMALL_STATE(51)] = 2556,
+  [SMALL_STATE(52)] = 2595,
+  [SMALL_STATE(53)] = 2631,
+  [SMALL_STATE(54)] = 2667,
+  [SMALL_STATE(55)] = 2703,
+  [SMALL_STATE(56)] = 2739,
+  [SMALL_STATE(57)] = 2775,
+  [SMALL_STATE(58)] = 2811,
+  [SMALL_STATE(59)] = 2847,
+  [SMALL_STATE(60)] = 2883,
+  [SMALL_STATE(61)] = 2919,
+  [SMALL_STATE(62)] = 2955,
+  [SMALL_STATE(63)] = 2990,
+  [SMALL_STATE(64)] = 3025,
+  [SMALL_STATE(65)] = 3059,
+  [SMALL_STATE(66)] = 3097,
+  [SMALL_STATE(67)] = 3131,
+  [SMALL_STATE(68)] = 3165,
+  [SMALL_STATE(69)] = 3200,
+  [SMALL_STATE(70)] = 3237,
+  [SMALL_STATE(71)] = 3276,
+  [SMALL_STATE(72)] = 3313,
+  [SMALL_STATE(73)] = 3350,
+  [SMALL_STATE(74)] = 3389,
+  [SMALL_STATE(75)] = 3424,
+  [SMALL_STATE(76)] = 3458,
+  [SMALL_STATE(77)] = 3492,
+  [SMALL_STATE(78)] = 3526,
+  [SMALL_STATE(79)] = 3560,
+  [SMALL_STATE(80)] = 3592,
+  [SMALL_STATE(81)] = 3623,
+  [SMALL_STATE(82)] = 3654,
+  [SMALL_STATE(83)] = 3685,
+  [SMALL_STATE(84)] = 3716,
+  [SMALL_STATE(85)] = 3747,
+  [SMALL_STATE(86)] = 3778,
+  [SMALL_STATE(87)] = 3809,
+  [SMALL_STATE(88)] = 3840,
+  [SMALL_STATE(89)] = 3871,
+  [SMALL_STATE(90)] = 3902,
+  [SMALL_STATE(91)] = 3933,
+  [SMALL_STATE(92)] = 3950,
+  [SMALL_STATE(93)] = 3967,
+  [SMALL_STATE(94)] = 3981,
+  [SMALL_STATE(95)] = 3994,
+  [SMALL_STATE(96)] = 4007,
+  [SMALL_STATE(97)] = 4017,
+  [SMALL_STATE(98)] = 4021,
+  [SMALL_STATE(99)] = 4025,
+  [SMALL_STATE(100)] = 4029,
+  [SMALL_STATE(101)] = 4033,
+  [SMALL_STATE(102)] = 4037,
+  [SMALL_STATE(103)] = 4041,
+  [SMALL_STATE(104)] = 4045,
+  [SMALL_STATE(105)] = 4049,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_help_file, 0),
-  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(88),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
-  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
-  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(74),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
-  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(85),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
-  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(68),
-  [23] = {.entry = {.count = 1, .reusable = false}}, SHIFT(101),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(80),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
+  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(51),
+  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(77),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
+  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(88),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
+  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(70),
+  [23] = {.entry = {.count = 1, .reusable = false}}, SHIFT(99),
+  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
   [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
   [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
   [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(97),
-  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
-  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
+  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(103),
+  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
+  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(102),
   [39] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_help_file, 1, .production_id = 4),
   [41] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2),
-  [43] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(88),
-  [46] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(63),
-  [49] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(88),
-  [52] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(48),
-  [55] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(74),
-  [58] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(71),
-  [61] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(85),
-  [64] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(85),
-  [67] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(68),
-  [70] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(101),
+  [43] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(80),
+  [46] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(65),
+  [49] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(80),
+  [52] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(51),
+  [55] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(77),
+  [58] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(68),
+  [61] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(88),
+  [64] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(88),
+  [67] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(70),
+  [70] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(99),
   [73] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(31),
   [76] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(29),
   [79] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(28),
-  [82] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(97),
-  [85] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(81),
-  [88] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(98),
+  [82] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(103),
+  [85] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(86),
+  [88] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(102),
   [91] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_help_file, 2, .production_id = 4),
   [93] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_help_file, 1),
-  [95] = {.entry = {.count = 1, .reusable = false}}, SHIFT(43),
-  [97] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(88),
-  [100] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(63),
-  [103] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(88),
-  [106] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(48),
-  [109] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(74),
-  [112] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(71),
-  [115] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(85),
-  [118] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(85),
-  [121] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(68),
+  [95] = {.entry = {.count = 1, .reusable = false}}, SHIFT(42),
+  [97] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(80),
+  [100] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(65),
+  [103] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(80),
+  [106] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(51),
+  [109] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(77),
+  [112] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(68),
+  [115] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(88),
+  [118] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(88),
+  [121] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(70),
   [124] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2),
   [126] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2),
   [128] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(29),
   [131] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(28),
-  [134] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(97),
-  [137] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(81),
-  [140] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(98),
-  [143] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(88),
-  [146] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(63),
-  [149] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(88),
-  [152] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(48),
-  [155] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(74),
-  [158] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(85),
-  [161] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(85),
-  [164] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(69),
+  [134] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(103),
+  [137] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(86),
+  [140] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(102),
+  [143] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(80),
+  [146] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(65),
+  [149] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(80),
+  [152] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(51),
+  [155] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(77),
+  [158] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(88),
+  [161] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(88),
+  [164] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(71),
   [167] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2),
   [169] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2),
-  [171] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(97),
-  [174] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(81),
-  [177] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(98),
-  [180] = {.entry = {.count = 1, .reusable = false}}, SHIFT(69),
-  [182] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 5, .production_id = 16),
-  [184] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 5, .production_id = 16),
-  [186] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 5, .production_id = 15),
-  [188] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 5, .production_id = 15),
-  [190] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, .production_id = 12),
-  [192] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, .production_id = 12),
-  [194] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, .production_id = 11),
-  [196] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, .production_id = 11),
-  [198] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, .production_id = 16),
-  [200] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, .production_id = 16),
-  [202] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, .production_id = 15),
-  [204] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, .production_id = 15),
-  [206] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 3, .production_id = 12),
-  [208] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 3, .production_id = 12),
-  [210] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 3, .production_id = 11),
-  [212] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 3, .production_id = 11),
-  [214] = {.entry = {.count = 1, .reusable = false}}, SHIFT(80),
-  [216] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
-  [218] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
-  [220] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
-  [222] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
-  [224] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
-  [226] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [171] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(103),
+  [174] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(86),
+  [177] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(102),
+  [180] = {.entry = {.count = 1, .reusable = false}}, SHIFT(71),
+  [182] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 5, .production_id = 17),
+  [184] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 5, .production_id = 17),
+  [186] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 5, .production_id = 16),
+  [188] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 5, .production_id = 16),
+  [190] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, .production_id = 13),
+  [192] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, .production_id = 13),
+  [194] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, .production_id = 12),
+  [196] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, .production_id = 12),
+  [198] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, .production_id = 17),
+  [200] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, .production_id = 17),
+  [202] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, .production_id = 16),
+  [204] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, .production_id = 16),
+  [206] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 3, .production_id = 13),
+  [208] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 3, .production_id = 13),
+  [210] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 3, .production_id = 12),
+  [212] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 3, .production_id = 12),
+  [214] = {.entry = {.count = 1, .reusable = false}}, SHIFT(82),
+  [216] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
+  [218] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
+  [220] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
+  [222] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
+  [224] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
+  [226] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
   [228] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
   [230] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
   [232] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
   [234] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
-  [236] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [238] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(80),
-  [241] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(63),
-  [244] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(80),
-  [247] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(48),
-  [250] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(74),
-  [253] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(85),
-  [256] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(85),
+  [236] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [238] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(82),
+  [241] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(65),
+  [244] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(82),
+  [247] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(51),
+  [250] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(77),
+  [253] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(88),
+  [256] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(88),
   [259] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2),
-  [261] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(97),
-  [264] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(81),
-  [267] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(98),
-  [270] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
-  [272] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
+  [261] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(103),
+  [264] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(86),
+  [267] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(102),
+  [270] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [272] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
   [274] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
-  [276] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
-  [278] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 3, .production_id = 13),
-  [280] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 3, .production_id = 13),
-  [282] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 4, .production_id = 20),
-  [284] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 4, .production_id = 20),
-  [286] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 4, .production_id = 19),
-  [288] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 4, .production_id = 19),
-  [290] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 2),
-  [292] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 2), SHIFT_REPEAT(50),
-  [295] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 2), SHIFT_REPEAT(50),
-  [298] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 2),
-  [300] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 3, .production_id = 14),
-  [302] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 3, .production_id = 14),
-  [304] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 3),
-  [306] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 3),
-  [308] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [276] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
+  [278] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 3),
+  [280] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 3),
+  [282] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [284] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 4, .production_id = 20),
+  [286] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 4, .production_id = 20),
+  [288] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_codeblock, 3, .production_id = 11),
+  [290] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [292] = {.entry = {.count = 1, .reusable = false}}, SHIFT(49),
+  [294] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_codeblock, 3, .production_id = 11),
+  [296] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 2),
+  [298] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 2), SHIFT_REPEAT(49),
+  [301] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 2), SHIFT_REPEAT(49),
+  [304] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 2),
+  [306] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 4, .production_id = 21),
+  [308] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 4, .production_id = 21),
   [310] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 2, .production_id = 8),
   [312] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 2, .production_id = 8),
-  [314] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_codeblock, 3),
-  [316] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
-  [318] = {.entry = {.count = 1, .reusable = false}}, SHIFT(50),
-  [320] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_codeblock, 3),
-  [322] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_help_file_repeat1, 2, .production_id = 7),
-  [324] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_help_file_repeat1, 2, .production_id = 7),
-  [326] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat1, 2, .production_id = 7), SHIFT_REPEAT(49),
-  [329] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 2),
-  [331] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 2),
-  [333] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_help_file_repeat1, 1, .production_id = 4),
-  [335] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_help_file_repeat1, 1, .production_id = 4),
-  [337] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 2), SHIFT_REPEAT(61),
-  [340] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 2), SHIFT_REPEAT(61),
-  [343] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
-  [345] = {.entry = {.count = 1, .reusable = false}}, SHIFT(61),
-  [347] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__word_common, 1),
-  [349] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__word_common, 1),
-  [351] = {.entry = {.count = 1, .reusable = false}}, SHIFT(100),
-  [353] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__blank, 1, .production_id = 2),
-  [355] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__blank, 1, .production_id = 2),
-  [357] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_code, 1),
-  [359] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_code, 1),
-  [361] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h2, 3),
-  [363] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h2, 3),
-  [365] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line, 1),
-  [367] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line, 1),
-  [369] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__line_noli, 2),
-  [371] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__line_noli, 2),
-  [373] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h3, 2, .production_id = 6),
-  [375] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h3, 2, .production_id = 6),
-  [377] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h3, 3, .production_id = 6),
-  [379] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h3, 3, .production_id = 6),
-  [381] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__line_noli, 3),
-  [383] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__line_noli, 3),
-  [385] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_column_heading, 3, .production_id = 6),
-  [387] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_column_heading, 3, .production_id = 6),
-  [389] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_column_heading, 4, .production_id = 18),
-  [391] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_column_heading, 4, .production_id = 18),
-  [393] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h3, 4, .production_id = 6),
-  [395] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h3, 4, .production_id = 6),
+  [314] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 3, .production_id = 14),
+  [316] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 3, .production_id = 14),
+  [318] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 3, .production_id = 15),
+  [320] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 3, .production_id = 15),
+  [322] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 2),
+  [324] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 2),
+  [326] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_help_file_repeat1, 2, .production_id = 7),
+  [328] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_help_file_repeat1, 2, .production_id = 7),
+  [330] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat1, 2, .production_id = 7), SHIFT_REPEAT(47),
+  [333] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
+  [335] = {.entry = {.count = 1, .reusable = false}}, SHIFT(63),
+  [337] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_help_file_repeat1, 1, .production_id = 4),
+  [339] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_help_file_repeat1, 1, .production_id = 4),
+  [341] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__blank, 1, .production_id = 2),
+  [343] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__blank, 1, .production_id = 2),
+  [345] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 1),
+  [347] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 1),
+  [349] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_code, 1),
+  [351] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_code, 1),
+  [353] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 2), SHIFT_REPEAT(63),
+  [356] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 2), SHIFT_REPEAT(63),
+  [359] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__word_common, 1),
+  [361] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__word_common, 1),
+  [363] = {.entry = {.count = 1, .reusable = false}}, SHIFT(105),
+  [365] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__line_noli, 3),
+  [367] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__line_noli, 3),
+  [369] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h3, 3, .production_id = 6),
+  [371] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h3, 3, .production_id = 6),
+  [373] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__line_noli, 2),
+  [375] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__line_noli, 2),
+  [377] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_column_heading, 3, .production_id = 6),
+  [379] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_column_heading, 3, .production_id = 6),
+  [381] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h3, 4, .production_id = 6),
+  [383] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h3, 4, .production_id = 6),
+  [385] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h3, 2, .production_id = 6),
+  [387] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h3, 2, .production_id = 6),
+  [389] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line, 1),
+  [391] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line, 1),
+  [393] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_column_heading, 4, .production_id = 19),
+  [395] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_column_heading, 4, .production_id = 19),
   [397] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h1, 3),
   [399] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h1, 3),
-  [401] = {.entry = {.count = 1, .reusable = false}}, SHIFT(77),
-  [403] = {.entry = {.count = 1, .reusable = false}}, SHIFT(102),
-  [405] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 1, .production_id = 17),
-  [407] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 1, .production_id = 17),
-  [409] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_uppercase_name_repeat1, 2),
-  [411] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_uppercase_name_repeat1, 2),
-  [413] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_uppercase_name_repeat1, 2), SHIFT_REPEAT(72),
-  [416] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__uppercase_words, 2, .production_id = 5),
-  [418] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__uppercase_words, 2, .production_id = 5),
-  [420] = {.entry = {.count = 1, .reusable = false}}, SHIFT(72),
+  [401] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h2, 3),
+  [403] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h2, 3),
+  [405] = {.entry = {.count = 1, .reusable = false}}, SHIFT(76),
+  [407] = {.entry = {.count = 1, .reusable = false}}, SHIFT(98),
+  [409] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 1, .production_id = 18),
+  [411] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 1, .production_id = 18),
+  [413] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
+  [415] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_uppercase_name_repeat1, 2),
+  [417] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_uppercase_name_repeat1, 2),
+  [419] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_uppercase_name_repeat1, 2), SHIFT_REPEAT(79),
   [422] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__uppercase_words, 1, .production_id = 1),
   [424] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__uppercase_words, 1, .production_id = 1),
-  [426] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_uppercase_name, 1),
-  [428] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_uppercase_name, 2),
-  [430] = {.entry = {.count = 1, .reusable = true}}, SHIFT(92),
-  [432] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_uppercase_name_repeat1, 1),
-  [434] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_uppercase_name_repeat1, 1),
-  [436] = {.entry = {.count = 1, .reusable = true}}, SHIFT(93),
-  [438] = {.entry = {.count = 1, .reusable = false}}, SHIFT(96),
-  [440] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
-  [442] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
-  [444] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__word_common, 2),
-  [446] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
-  [448] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__word_common, 2),
-  [450] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 1),
-  [452] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 1),
-  [454] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_argument, 3, .production_id = 9),
-  [456] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument, 3, .production_id = 9),
-  [458] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_word, 1),
-  [460] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_word, 1),
-  [462] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_url, 1, .production_id = 3),
-  [464] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_url, 1, .production_id = 3),
-  [466] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__word_common, 3),
-  [468] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__word_common, 3),
-  [470] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_optionlink, 3, .production_id = 9),
-  [472] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_optionlink, 3, .production_id = 9),
-  [474] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_taglink, 3, .production_id = 10),
-  [476] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_taglink, 3, .production_id = 10),
-  [478] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keycode, 1),
-  [480] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keycode, 1),
-  [482] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_codespan, 3, .production_id = 9),
-  [484] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_codespan, 3, .production_id = 9),
-  [486] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 3, .production_id = 9),
-  [488] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 3, .production_id = 9),
-  [490] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_word_noli, 1),
-  [492] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_word_noli, 1),
-  [494] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [496] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
-  [498] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat2, 2), SHIFT_REPEAT(101),
-  [501] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_block_repeat2, 2),
-  [503] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat2, 2), SHIFT_REPEAT(31),
-  [506] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
-  [508] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [510] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
-  [512] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
-  [514] = {.entry = {.count = 1, .reusable = true}}, SHIFT(99),
-  [516] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
-  [518] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
-  [520] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
-  [522] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
+  [426] = {.entry = {.count = 1, .reusable = false}}, SHIFT(79),
+  [428] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_uppercase_name, 1),
+  [430] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__uppercase_words, 2, .production_id = 5),
+  [432] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__uppercase_words, 2, .production_id = 5),
+  [434] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_uppercase_name, 2),
+  [436] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
+  [438] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [440] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__word_common, 2),
+  [442] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
+  [444] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__word_common, 2),
+  [446] = {.entry = {.count = 1, .reusable = false}}, SHIFT(104),
+  [448] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
+  [450] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_uppercase_name_repeat1, 1),
+  [452] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_uppercase_name_repeat1, 1),
+  [454] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_word_noli, 1),
+  [456] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_word_noli, 1),
+  [458] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_optionlink, 3, .production_id = 9),
+  [460] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_optionlink, 3, .production_id = 9),
+  [462] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_word, 1),
+  [464] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_word, 1),
+  [466] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_codespan, 3, .production_id = 9),
+  [468] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_codespan, 3, .production_id = 9),
+  [470] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 1),
+  [472] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 1),
+  [474] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__word_common, 3),
+  [476] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__word_common, 3),
+  [478] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_url, 1, .production_id = 3),
+  [480] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_url, 1, .production_id = 3),
+  [482] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 3, .production_id = 9),
+  [484] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 3, .production_id = 9),
+  [486] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keycode, 1),
+  [488] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keycode, 1),
+  [490] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_taglink, 3, .production_id = 10),
+  [492] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_taglink, 3, .production_id = 10),
+  [494] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_argument, 3, .production_id = 9),
+  [496] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument, 3, .production_id = 9),
+  [498] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [500] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
+  [502] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat2, 2), SHIFT_REPEAT(99),
+  [505] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_block_repeat2, 2),
+  [507] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat2, 2), SHIFT_REPEAT(31),
+  [510] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [512] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [514] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
+  [516] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
+  [518] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
+  [520] = {.entry = {.count = 1, .reusable = true}}, SHIFT(100),
+  [522] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
+  [524] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
+  [526] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
```
This is a Lua block: >lua
    local foo = 'bar'

This is a Vimscript block: >vim
    au FileType lua setl sw=2

This is a C block: >c
    int *p = get_local_errno(); *p = EINVAL
<
This is a standard block: >
    $ nvim --clean +'q'
<
```
<img width="367" alt="image" src="https://user-images.githubusercontent.com/2361214/200119947-cbcb2871-da9b-4767-831e-82dc4734c26b.png">

Note that the alternative syntax `lua>` is much trickier, since the rule for the language marker `lua` conflicts with normal text rule for the word `lua`. In either case, the added markers are trivial (and necessary) to add to the legacy syntax file.

Closes #2 