### PR TITLE
fix: add .gitattributes for generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+src/keywords.h linguist-generated
+src/parser.c linguist-generated
+src/grammar.json linguist-generated
+src/node-types.json linguist-generated
+src/tree_sitter/** linguist-generated
+package-lock.json linguist-generated
+binding.gyp linguist-generated
+bindings/** linguist-generated


### PR DESCRIPTION
Problem: parser updates generate huge meaningless diffs for generated
files.

Solution: mark them as "generated" in `.gitattributes` so commit views
don't show these diffs by default.
