### PR TITLE
feat!: support only "-", "•" as listitem, constrain (argument) definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Overview
   - contains headings (`h1`, `h2`, `h3`, `column_heading`) because `codeblock`
     terminated by "implicit stop" (no terminating `<`) consumes blank lines, so
     `block` has no way to end.
-- `line_li` ("list item")
+- `line_li` ("listitem")
+  - lines starting with `-`/`•` (_not_ `+`/`*`) are listitems.
   - consumes lines until blank line, codeblock, or next listitem.
   - nesting is ignored: indented listitems are parsed as siblings.
 - `codeblock`:
@@ -48,7 +49,7 @@ Known issues
 - `url` doesn't handle _nested_ parens. E.g. `(https://example.com/(foo)#yay)`
 - `column_heading` currently only recognizes tilde `~` preceded by space (i.e.
   `foo ~` not `foo~`). This covers 99% of :help files.
-- `column_heading` children should be plaintext. Currently its children are parsed as `$._atom`.
+- `column_heading` children should be plaintext, but currently are parsed as `$._atom`.
 
 TODO
 ----

--- a/corpus/arguments.txt
+++ b/corpus/arguments.txt
@@ -2,8 +2,8 @@
 argument
 ================================================================================
 argument: {arg}
-argument: {arg arg}
-CTRL-R CTRL-R {register CTRL-F}
+tuple: {arg,arg}
+keycode: CTRL-R {CTRL-R} {register CTRL-F}
 list of { uri:string, name: string } tables
 
 
@@ -23,7 +23,12 @@ list of { uri:string, name: string } tables
       (word)
       (keycode)
       (argument
-        (word)))
+        (word))
+      (word)
+      (ERROR
+        (word))
+      (keycode)
+      (word))
     (line
       (word)
       (word)
@@ -71,6 +76,7 @@ argument in parentheses
 ================================================================================
 NOT an argument
 ================================================================================
+a '{' '}' block
 {foo "{bar}" `{baz}` |{baz| } {}
 foo { bar 
 { {} foo{{ foo{{{
@@ -92,11 +98,19 @@ EXTERNAL *netrw-externapp* {{{2
 (help_file
   (block
     (line
-      (argument
-        (word)
-        (ERROR
-          (word)
-          (word)))
+      (word)
+      (word)
+      (word)
+      (ERROR
+        (word))
+      (word)
+      (word)
+      (word)
+      (word))
+    (line
+      (word)
+      (ERROR
+        (word))
       (word)
       (codespan
         (word))

--- a/corpus/arguments.txt
+++ b/corpus/arguments.txt
@@ -101,8 +101,7 @@ EXTERNAL *netrw-externapp* {{{2
       (word)
       (word)
       (word)
-      (ERROR
-        (word))
+      (word)
       (word)
       (word)
       (word)

--- a/corpus/heading3-column_heading.txt
+++ b/corpus/heading3-column_heading.txt
@@ -271,11 +271,13 @@ buffer-diagram
       (word))
     (line
       (word)
-      (word)
+      (ERROR
+        (word))
       (word))
     (line
       (word)
-      (word)
+      (ERROR
+        (word))
       (word))
     (line
       (taglink

--- a/corpus/line_block.txt
+++ b/corpus/line_block.txt
@@ -130,7 +130,9 @@ li continues
     (line_li
       (line
         (word)
-        (word)
+        (word
+          (ERROR
+            (word)))
         (word)
         (word)
         (word))
@@ -147,7 +149,9 @@ li continues
   (block
     (line_li
       (line
-        (word)
+        (word
+          (ERROR
+            (word)))
         (word)
         (word))
       (line))

--- a/corpus/line_block.txt
+++ b/corpus/line_block.txt
@@ -130,9 +130,7 @@ li continues
     (line_li
       (line
         (word)
-        (word
-          (ERROR
-            (word)))
+        (word)
         (word)
         (word)
         (word))
@@ -149,9 +147,7 @@ li continues
   (block
     (line_li
       (line
-        (word
-          (ERROR
-            (word)))
+        (word)
         (word)
         (word))
       (line))

--- a/corpus/line_block.txt
+++ b/corpus/line_block.txt
@@ -80,19 +80,19 @@ block2 text text
 ================================================================================
 listitems
 ================================================================================
-* list1.a item1
-  * - •
+- list1.a item1
+  - - •
   • word,
     !foo! ~bar. word word
     'item' line3 |foo|
-* x 'list1.a' ~/foo/bar.txt
+- x 'list1.a' ~/foo/bar.txt
 li continues
-  * {nested} here
+  - {nested} here
 
-* 'list2' item w3
-  * *nested_li* word *tag2*
-* list2 item w3
-  * nested_li-2
+• 'list2' item w3
+  - *nested_li* word *tag2*
+• list2 item w3
+  - nested_li-2
     foo
     foo
 
@@ -178,16 +178,16 @@ li continues
 listitem with codeblock
 ================================================================================
 
-* list1.a item1 >
+• list1.a item1 >
   foo
-< * list1.b item1
-* w1 w2
+< • list1.b item1
+• w1 w2
   w3 >
   code1 {
     code2
   }
-<* w1
-* w2 w3
+<• w1
+• w2 w3
     `item2` line2
     {item2} line3
 
@@ -291,3 +291,48 @@ listitems + lines without blank lines
         (argument
           (word))
         (word)))))
+
+================================================================================
+listitem tricky
+================================================================================
+
+- x - x
+
+-x -x
+
+- - x -x
+- -x - x
+- -
+
+
+--------------------------------------------------------------------------------
+
+(help_file
+  (block
+    (line_li
+      (line
+        (word)
+        (word)
+        (word))
+      (line)))
+  (block
+    (line
+      (word)
+      (word)))
+  (block
+    (line_li
+      (line
+        (word)
+        (word)
+        (word))
+      (line))
+    (line_li
+      (line
+        (word)
+        (word)
+        (word))
+      (line))
+    (line_li
+      (line
+        (word))
+      (line))))

--- a/corpus/optionlink.txt
+++ b/corpus/optionlink.txt
@@ -109,9 +109,7 @@ Regular	  /	:help /[
       (word)
       (word)
       (word)
-      (word
-        (ERROR
-          (word))))
+      (word))
     (line
       (word)
       (word)

--- a/corpus/optionlink.txt
+++ b/corpus/optionlink.txt
@@ -33,7 +33,6 @@ NOT optionlink: ' or 'x
 ================================================================================
 'fillchars'
 stl		' ' or '^'	statusline
-wbr		' '		windowbar
 tricky:	' 'yes'  's foo
 
 
@@ -54,11 +53,6 @@ tricky:	' 'yes'  's foo
     (line
       (word)
       (word)
-      (word)
-      (word))
-    (line
-      (word)
-      (word)
       (optionlink
         (word))
       (word)
@@ -72,9 +66,8 @@ no! ','sqlKeyword'
 single-char '-' 'g' '보'
 non-ascii: '\"' '%)' '-bang' '.*\\.log' '.gitignore' '@{${\"foo\"}}'
 number: '04' 'ISO-10646-1' 'python3'
-
-	Option	  '	:help 'textwidth'
-	Regular	  /	:help /[
+Option	  '	:help 'textwidth'
+Regular	  /	:help /[
 
 
 --------------------------------------------------------------------------------
@@ -101,16 +94,13 @@ number: '04' 'ISO-10646-1' 'python3'
       (word)
       (word)
       (word)
-      (tag
-        (word)
-        (MISSING "*"))
+      (word)
+      (ERROR
+        (word))
       (word)
       (word)
       (argument
-        (word)
-        (ERROR
-          (word)
-          (word)))
+        (word))
       (word)
       (word))
     (line
@@ -119,8 +109,9 @@ number: '04' 'ISO-10646-1' 'python3'
       (word)
       (word)
       (word)
-      (word)))
-  (block
+      (word
+        (ERROR
+          (word))))
     (line
       (word)
       (word)

--- a/corpus/taglink.txt
+++ b/corpus/taglink.txt
@@ -150,7 +150,8 @@ Note: ":autocmd" can...
     (line
       (word)
       (word)
-      (word)
+      (ERROR
+        (word))
       (word))
     (line
       (word)

--- a/corpus/tags.txt
+++ b/corpus/tags.txt
@@ -78,10 +78,9 @@ NOT a tag
 ================================================================================
 * bullet1
   * bullet2 bullet2
-  * bullet3
-    bullet3 bullet3
-* bullet4
 
+0 \* escaped
+0 (paren *)
 1	"*" not
 2   * 	not
 3this *not no
@@ -93,26 +92,13 @@ NOT a tag
 
 (help_file
   (block
-    (line_li
-      (line
-        (word))
-      (line))
-    (line_li
-      (line
-        (word)
-        (word))
-      (line))
-    (line_li
-      (line
-        (word))
-      (line)
-      (line
-        (word)
-        (word)))
-    (line_li
-      (line
-        (word))
-      (line)))
+    (line
+      (word)
+      (word))
+    (line
+      (word)
+      (word)
+      (word)))
   (block
     (line
       (word)
@@ -120,7 +106,18 @@ NOT a tag
       (word))
     (line
       (word)
-      (ERROR)
+      (word)
+      (word)
+      (tag
+        (word)
+        (MISSING "*")))
+    (line
+      (word)
+      (word)
+      (word))
+    (line
+      (word)
+      (word)
       (word))
     (line
       (word)

--- a/corpus/tags.txt
+++ b/corpus/tags.txt
@@ -108,9 +108,9 @@ NOT a tag
       (word)
       (word)
       (word)
-      (tag
-        (word)
-        (MISSING "*")))
+      (word)
+      (ERROR
+        (word)))
     (line
       (word)
       (word)
@@ -121,16 +121,16 @@ NOT a tag
       (word))
     (line
       (word)
-      (tag
-        (word)
-        (MISSING "*"))
+      (word)
+      (ERROR
+        (word))
       (word)))
   (block
     (line
       (word)
-      (tag
-        (word)
-        (MISSING "*"))
+      (word)
+      (ERROR
+        (word))
       (word)
       (word)
       (word))))

--- a/grammar.js
+++ b/grammar.js
@@ -92,7 +92,7 @@ module.exports = grammar({
       /CTRL-./,
       /CTRL-SHIFT-./,
       /CTRL-(Break|PageUp|PageDown|Insert|Del)/,
-      /CTRL-\{char\}/,
+      'CTRL-{char}',
       /META-./,
       /ALT-./,
     ),
@@ -207,16 +207,7 @@ module.exports = grammar({
     // Link to option: 'foo'. Lowercase non-digit ASCII, minimum 2 chars. #14
     optionlink: ($) => _word($, /[a-z][a-z]+/, "'", "'"),
     // Link to tag: |foo|
-    taglink: ($) => _word($, prec(1, choice(
-        /[^|\n\t ]+/,
-        // Special cases: |(| |{| …
-        '{',
-        '}',
-        '(',
-        ')',
-        '`',
-      )),
-      '|', '|'),
+    taglink: ($) => _word($, prec(1, /[^|\n\t ]+/), '|', '|'),
     // Inline code (may contain whitespace!): `foo bar`
     codespan: ($) => _word($, /[^``\n]+/, '`', '`'),
     // Argument: {arg} (no whitespace allowed)
@@ -228,8 +219,6 @@ module.exports = grammar({
 // `rule` can be a rule function or regex. It is aliased to "word" because they are
 // semantically the same: atoms of captured plain text.
 function _word($, rule, c1, c2, fname) {
-  // rule = rule.test ? token.immediate(rule) : rule
-  // rule = token.immediate(rule)
   fname = fname ?? 'text';
   return seq(c1, field(fname, alias(token.immediate(rule), $.word)), token.immediate(c2));
 }

--- a/grammar.js
+++ b/grammar.js
@@ -62,7 +62,7 @@ module.exports = grammar({
     // Explicit special cases: these are plaintext, not errors.
     _word_common: () => choice(
       // NOT tag: isolated "*".
-      /\*[\n\t ]/,
+      '*',
       // NOT optionlink: '
       "'",
       // NOT optionlink: 'x
@@ -208,18 +208,19 @@ module.exports = grammar({
     optionlink: ($) => _word($, /[a-z][a-z]+/, "'", "'"),
     // Link to tag: |foo|
     taglink: ($) => _word($, choice(
-          token.immediate(/[^|\n\t ]+/),
-          // Special cases: |(| |{| …
-          token.immediate('{'),
-          token.immediate('}'),
-          token.immediate('('),
-          token.immediate(')'),
-          token.immediate('`'),
-    ), '|', '|'),
+        /[^|\n\t ]+/,
+        // Special cases: |(| |{| …
+        '{',
+        '}',
+        '(',
+        ')',
+        '`',
+      ),
+      '|', '|'),
     // Inline code (may contain whitespace!): `foo bar`
     codespan: ($) => _word($, /[^``\n]+/, '`', '`'),
-    // Argument: {arg}
-    argument: ($) => _word($, /[^{}\n\t ][^{}\n\t]*/, '{', '}'),
+    // Argument: {arg} (no whitespace allowed)
+    argument: ($) => _word($, /[^}\n\t ]+/, '{', '}'),
   },
 });
 
@@ -227,7 +228,8 @@ module.exports = grammar({
 // `rule` can be a rule function or regex. It is aliased to "word" because they are
 // semantically the same: atoms of captured plain text.
 function _word($, rule, c1, c2, fname) {
-  rule = rule.test !== undefined ? token.immediate(rule) : rule
+  // rule = rule.test ? token.immediate(rule) : rule
+  // rule = token.immediate(rule)
   fname = fname ?? 'text';
-  return seq(c1, field(fname, alias(rule, $.word)), token.immediate(c2));
+  return seq(c1, field(fname, alias(token.immediate(prec(1, rule)), $.word)), token.immediate(c2));
 }

--- a/grammar.js
+++ b/grammar.js
@@ -34,7 +34,7 @@ module.exports = grammar({
       // "foo({a})" parse as "(word) (argument)" instead of "(word)".
       token(prec(-1, /[^\n\t{ ][^\n\t ]*/)),
       token(prec(-2, /[^\n\t ]+/)),
-      choice($._word_common),
+      $._word_common,
     ),
 
     _atom_noli: ($) => prec(1, choice(
@@ -45,7 +45,7 @@ module.exports = grammar({
       // Lines contained by line_li must not start with a listitem symbol.
       token(prec(-1, /[^-*+•\n\t ][^\n\t ]*/)),
       token(prec(-1, /[-*+•][^\n\t ]+/)),
-      choice($._word_common),
+      $._word_common,
     )),
 
     _atom_common: ($) =>
@@ -72,8 +72,6 @@ module.exports = grammar({
       // NOT taglink: "||", "|"
       /\|\|+/,
       '|',
-      // NOT listitem: "-" or "•" followed by tab.
-      /[-•]\t/,
       // NOT argument:
       '{',
       '}',

--- a/grammar.js
+++ b/grammar.js
@@ -8,7 +8,7 @@
 // - Rules starting with underscore are hidden in the syntax tree.
 
 const _uppercase_word = /[A-Z0-9.()][-A-Z0-9.()_]+/;
-const _li_token = /[-*+•][ ]+/;
+const _li_token = /[-•][ ]+/;
 
 module.exports = grammar({
   name: 'vimdoc',
@@ -27,7 +27,7 @@ module.exports = grammar({
 
     _atom: ($) => choice(
       $.word,
-      $._atom_common
+      $._atom_common,
     ),
     word: ($) => choice(
       // Try the more-restrictive pattern at higher relative precedence, so that things like
@@ -39,12 +39,12 @@ module.exports = grammar({
 
     _atom_noli: ($) => prec(1, choice(
       alias($.word_noli, $.word),
-      $._atom_common
+      $._atom_common,
     )),
     word_noli: ($) => prec(1, choice(
       // Lines contained by line_li must not start with a listitem symbol.
-      token(prec(-1, /[^-*+•\n\t ][^\n\t ]*/)),
-      token(prec(-1, /[-*+•][^\n\t ]+/)),
+      token(prec(-1, /[^-•\n\t ][^\n\t ]*/)),
+      token(prec(-1, /[-•][^\n\t ]+/)),
       $._word_common,
     )),
 
@@ -61,13 +61,15 @@ module.exports = grammar({
 
     // Explicit special cases: these are plaintext, not errors.
     _word_common: () => choice(
+      // NOT tag: isolated "*".
+      /\*[\n\t ]/,
       // NOT optionlink: '
       "'",
       // NOT optionlink: 'x
       seq("'", token.immediate(/[^'\n\t ]/)),
-      // NOT optionlink: followed by non-lowercase char.
+      // NOT optionlink: 'X (non-lowercase char).
       seq("'", token.immediate(/[a-z]*[^'a-z\n\t ][a-z]*/), optional(token.immediate("'"))),
-      // NOT optionlink: single char surrounded by "'".
+      // NOT optionlink: 'x' (single char).
       seq("'", token.immediate(/[^'\n\t ]/), token.immediate("'")),
       // NOT taglink: "||", "|"
       /\|\|+/,

--- a/grammar.js
+++ b/grammar.js
@@ -37,16 +37,16 @@ module.exports = grammar({
       $._word_common,
     ),
 
-    _atom_noli: ($) => prec(1, choice(
+    _atom_noli: ($) => choice(
       alias($.word_noli, $.word),
       $._atom_common,
-    )),
-    word_noli: ($) => prec(1, choice(
+    ),
+    word_noli: ($) => choice(
       // Lines contained by line_li must not start with a listitem symbol.
       token(prec(-1, /[^-•\n\t ][^\n\t ]*/)),
       token(prec(-1, /[-•][^\n\t ]+/)),
       $._word_common,
-    )),
+    ),
 
     _atom_common: ($) =>
       choice(
@@ -193,7 +193,7 @@ module.exports = grammar({
       ),
 
     tag: ($) => _word($,
-      /[^*\n\t ]+/,  // Tag text without surrounding "*".
+      prec(1, /[^*\n\t ]+/),  // Tag text without surrounding "*".
       '*', '*'),
 
     // URL without surrounding (), [], etc.
@@ -207,7 +207,7 @@ module.exports = grammar({
     // Link to option: 'foo'. Lowercase non-digit ASCII, minimum 2 chars. #14
     optionlink: ($) => _word($, /[a-z][a-z]+/, "'", "'"),
     // Link to tag: |foo|
-    taglink: ($) => _word($, choice(
+    taglink: ($) => _word($, prec(1, choice(
         /[^|\n\t ]+/,
         // Special cases: |(| |{| …
         '{',
@@ -215,7 +215,7 @@ module.exports = grammar({
         '(',
         ')',
         '`',
-      ),
+      )),
       '|', '|'),
     // Inline code (may contain whitespace!): `foo bar`
     codespan: ($) => _word($, /[^``\n]+/, '`', '`'),
@@ -231,5 +231,5 @@ function _word($, rule, c1, c2, fname) {
   // rule = rule.test ? token.immediate(rule) : rule
   // rule = token.immediate(rule)
   fname = fname ?? 'text';
-  return seq(c1, field(fname, alias(token.immediate(prec(1, rule)), $.word)), token.immediate(c2));
+  return seq(c1, field(fname, alias(token.immediate(rule), $.word)), token.immediate(c2));
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -59,77 +59,59 @@
           }
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_word_common"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_word_common"
         }
       ]
     },
     "_atom_noli": {
-      "type": "PREC",
-      "value": 1,
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "word_noli"
-            },
-            "named": true,
-            "value": "word"
-          },
-          {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
             "type": "SYMBOL",
-            "name": "_atom_common"
-          }
-        ]
-      }
+            "name": "word_noli"
+          },
+          "named": true,
+          "value": "word"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_atom_common"
+        }
+      ]
     },
     "word_noli": {
-      "type": "PREC",
-      "value": 1,
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "TOKEN",
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "PREC",
+            "value": -1,
             "content": {
-              "type": "PREC",
-              "value": -1,
-              "content": {
-                "type": "PATTERN",
-                "value": "[^-*+•\\n\\t ][^\\n\\t ]*"
-              }
+              "type": "PATTERN",
+              "value": "[^-•\\n\\t ][^\\n\\t ]*"
             }
-          },
-          {
-            "type": "TOKEN",
-            "content": {
-              "type": "PREC",
-              "value": -1,
-              "content": {
-                "type": "PATTERN",
-                "value": "[-*+•][^\\n\\t ]+"
-              }
-            }
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_word_common"
-              }
-            ]
           }
-        ]
-      }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "PREC",
+            "value": -1,
+            "content": {
+              "type": "PATTERN",
+              "value": "[-•][^\\n\\t ]+"
+            }
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_word_common"
+        }
+      ]
     },
     "_atom_common": {
       "type": "CHOICE",
@@ -167,6 +149,10 @@
     "_word_common": {
       "type": "CHOICE",
       "members": [
+        {
+          "type": "STRING",
+          "value": "*"
+        },
         {
           "type": "STRING",
           "value": "'"
@@ -250,10 +236,6 @@
           "value": "|"
         },
         {
-          "type": "PATTERN",
-          "value": "[-•]\\t"
-        },
-        {
           "type": "STRING",
           "value": "{"
         },
@@ -311,8 +293,8 @@
           "value": "CTRL-(Break|PageUp|PageDown|Insert|Del)"
         },
         {
-          "type": "PATTERN",
-          "value": "CTRL-\\{char\\}"
+          "type": "STRING",
+          "value": "CTRL-{char}"
         },
         {
           "type": "PATTERN",
@@ -556,7 +538,7 @@
           },
           {
             "type": "PATTERN",
-            "value": "[-*+•][ ]+"
+            "value": "[-•][ ]+"
           },
           {
             "type": "CHOICE",
@@ -826,8 +808,12 @@
             "content": {
               "type": "IMMEDIATE_TOKEN",
               "content": {
-                "type": "PATTERN",
-                "value": "[^*\\n\\t ]+"
+                "type": "PREC",
+                "value": 1,
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^*\\n\\t ]+"
+                }
               }
             },
             "named": true,
@@ -910,51 +896,15 @@
           "content": {
             "type": "ALIAS",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "IMMEDIATE_TOKEN",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[^|\\n\\t ]+"
-                  }
-                },
-                {
-                  "type": "IMMEDIATE_TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": "{"
-                  }
-                },
-                {
-                  "type": "IMMEDIATE_TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": "}"
-                  }
-                },
-                {
-                  "type": "IMMEDIATE_TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": "("
-                  }
-                },
-                {
-                  "type": "IMMEDIATE_TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": ")"
-                  }
-                },
-                {
-                  "type": "IMMEDIATE_TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": "`"
-                  }
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "PREC",
+                "value": 1,
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^|\\n\\t ]+"
                 }
-              ]
+              }
             },
             "named": true,
             "value": "word"
@@ -1017,7 +967,7 @@
               "type": "IMMEDIATE_TOKEN",
               "content": {
                 "type": "PATTERN",
-                "value": "[^{}\\n\\t ][^{}\\n\\t]*"
+                "value": "[^}\\n\\t ]+"
               }
             },
             "named": true,

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -491,6 +491,10 @@
     "named": false
   },
   {
+    "type": "CTRL-{char}",
+    "named": false
+  },
+  {
     "type": "`",
     "named": false
   },

--- a/src/parser.c
+++ b/src/parser.c
@@ -14,34 +14,34 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 106
+#define STATE_COUNT 107
 #define LARGE_STATE_COUNT 8
-#define SYMBOL_COUNT 88
+#define SYMBOL_COUNT 84
 #define ALIAS_COUNT 1
-#define TOKEN_COUNT 53
+#define TOKEN_COUNT 49
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 3
 #define MAX_ALIAS_SEQUENCE_LENGTH 5
-#define PRODUCTION_ID_COUNT 22
+#define PRODUCTION_ID_COUNT 21
 
 enum {
   aux_sym_word_token1 = 1,
   aux_sym_word_token2 = 2,
   aux_sym_word_noli_token1 = 3,
   aux_sym_word_noli_token2 = 4,
-  anon_sym_SQUOTE = 5,
-  aux_sym__word_common_token1 = 6,
-  aux_sym__word_common_token2 = 7,
-  anon_sym_SQUOTE2 = 8,
-  aux_sym__word_common_token3 = 9,
-  anon_sym_PIPE = 10,
-  aux_sym__word_common_token4 = 11,
+  anon_sym_STAR = 5,
+  anon_sym_SQUOTE = 6,
+  aux_sym__word_common_token1 = 7,
+  aux_sym__word_common_token2 = 8,
+  anon_sym_SQUOTE2 = 9,
+  aux_sym__word_common_token3 = 10,
+  anon_sym_PIPE = 11,
   anon_sym_LBRACE = 12,
   anon_sym_RBRACE = 13,
   anon_sym_LBRACE_RBRACE = 14,
-  aux_sym__word_common_token5 = 15,
+  aux_sym__word_common_token4 = 15,
   anon_sym_LPAREN = 16,
-  aux_sym__word_common_token6 = 17,
+  aux_sym__word_common_token5 = 17,
   anon_sym_TILDE = 18,
   anon_sym_GT = 19,
   aux_sym_keycode_token1 = 20,
@@ -49,9 +49,9 @@ enum {
   aux_sym_keycode_token3 = 22,
   aux_sym_keycode_token4 = 23,
   aux_sym_keycode_token5 = 24,
-  aux_sym_keycode_token6 = 25,
-  aux_sym_keycode_token7 = 26,
-  aux_sym_keycode_token8 = 27,
+  anon_sym_CTRL_DASH_LBRACEchar_RBRACE = 25,
+  aux_sym_keycode_token6 = 26,
+  aux_sym_keycode_token7 = 27,
   aux_sym_uppercase_name_token1 = 28,
   aux_sym_uppercase_name_token2 = 29,
   anon_sym_LT = 30,
@@ -62,57 +62,53 @@ enum {
   aux_sym_line_code_token1 = 35,
   aux_sym_h1_token1 = 36,
   aux_sym_h2_token1 = 37,
-  anon_sym_STAR = 38,
-  aux_sym_tag_token1 = 39,
-  anon_sym_STAR2 = 40,
-  sym_url_word = 41,
-  aux_sym_optionlink_token1 = 42,
-  aux_sym_taglink_token1 = 43,
-  anon_sym_LBRACE2 = 44,
-  anon_sym_RBRACE2 = 45,
-  anon_sym_LPAREN2 = 46,
-  anon_sym_RPAREN = 47,
-  anon_sym_BQUOTE = 48,
-  anon_sym_PIPE2 = 49,
-  anon_sym_BQUOTE2 = 50,
-  aux_sym_codespan_token1 = 51,
-  aux_sym_argument_token1 = 52,
-  sym_help_file = 53,
-  sym__atom = 54,
-  sym_word = 55,
-  sym__atom_noli = 56,
-  sym_word_noli = 57,
-  sym__atom_common = 58,
-  sym__word_common = 59,
-  sym_keycode = 60,
-  sym_uppercase_name = 61,
-  sym__uppercase_words = 62,
-  sym_block = 63,
-  sym_codeblock = 64,
-  sym__blank = 65,
-  sym_line = 66,
-  sym_line_li = 67,
-  sym_line_code = 68,
-  sym__line_noli = 69,
-  sym_column_heading = 70,
-  sym_h1 = 71,
-  sym_h2 = 72,
-  sym_h3 = 73,
-  sym_tag = 74,
-  sym_url = 75,
-  sym_optionlink = 76,
-  sym_taglink = 77,
-  sym_codespan = 78,
-  sym_argument = 79,
-  aux_sym_help_file_repeat1 = 80,
-  aux_sym_help_file_repeat2 = 81,
-  aux_sym_uppercase_name_repeat1 = 82,
-  aux_sym_block_repeat1 = 83,
-  aux_sym_block_repeat2 = 84,
-  aux_sym_codeblock_repeat1 = 85,
-  aux_sym_line_li_repeat1 = 86,
-  aux_sym_line_li_repeat2 = 87,
-  alias_sym_code = 88,
+  aux_sym_tag_token1 = 38,
+  anon_sym_STAR2 = 39,
+  sym_url_word = 40,
+  aux_sym_optionlink_token1 = 41,
+  aux_sym_taglink_token1 = 42,
+  anon_sym_PIPE2 = 43,
+  anon_sym_BQUOTE = 44,
+  aux_sym_codespan_token1 = 45,
+  anon_sym_BQUOTE2 = 46,
+  aux_sym_argument_token1 = 47,
+  anon_sym_RBRACE2 = 48,
+  sym_help_file = 49,
+  sym__atom = 50,
+  sym_word = 51,
+  sym__atom_noli = 52,
+  sym_word_noli = 53,
+  sym__atom_common = 54,
+  sym__word_common = 55,
+  sym_keycode = 56,
+  sym_uppercase_name = 57,
+  sym__uppercase_words = 58,
+  sym_block = 59,
+  sym_codeblock = 60,
+  sym__blank = 61,
+  sym_line = 62,
+  sym_line_li = 63,
+  sym_line_code = 64,
+  sym__line_noli = 65,
+  sym_column_heading = 66,
+  sym_h1 = 67,
+  sym_h2 = 68,
+  sym_h3 = 69,
+  sym_tag = 70,
+  sym_url = 71,
+  sym_optionlink = 72,
+  sym_taglink = 73,
+  sym_codespan = 74,
+  sym_argument = 75,
+  aux_sym_help_file_repeat1 = 76,
+  aux_sym_help_file_repeat2 = 77,
+  aux_sym_uppercase_name_repeat1 = 78,
+  aux_sym_block_repeat1 = 79,
+  aux_sym_block_repeat2 = 80,
+  aux_sym_codeblock_repeat1 = 81,
+  aux_sym_line_li_repeat1 = 82,
+  aux_sym_line_li_repeat2 = 83,
+  alias_sym_code = 84,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -121,19 +117,19 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_word_token2] = "word_token2",
   [aux_sym_word_noli_token1] = "word_noli_token1",
   [aux_sym_word_noli_token2] = "word_noli_token2",
+  [anon_sym_STAR] = "*",
   [anon_sym_SQUOTE] = "'",
   [aux_sym__word_common_token1] = "_word_common_token1",
   [aux_sym__word_common_token2] = "_word_common_token2",
   [anon_sym_SQUOTE2] = "'",
   [aux_sym__word_common_token3] = "_word_common_token3",
   [anon_sym_PIPE] = "|",
-  [aux_sym__word_common_token4] = "_word_common_token4",
   [anon_sym_LBRACE] = "{",
   [anon_sym_RBRACE] = "}",
   [anon_sym_LBRACE_RBRACE] = "{}",
-  [aux_sym__word_common_token5] = "_word_common_token5",
+  [aux_sym__word_common_token4] = "_word_common_token4",
   [anon_sym_LPAREN] = "(",
-  [aux_sym__word_common_token6] = "_word_common_token6",
+  [aux_sym__word_common_token5] = "_word_common_token5",
   [anon_sym_TILDE] = "~",
   [anon_sym_GT] = ">",
   [aux_sym_keycode_token1] = "keycode_token1",
@@ -141,9 +137,9 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_keycode_token3] = "keycode_token3",
   [aux_sym_keycode_token4] = "keycode_token4",
   [aux_sym_keycode_token5] = "keycode_token5",
+  [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = "CTRL-{char}",
   [aux_sym_keycode_token6] = "keycode_token6",
   [aux_sym_keycode_token7] = "keycode_token7",
-  [aux_sym_keycode_token8] = "keycode_token8",
   [aux_sym_uppercase_name_token1] = "uppercase_name_token1",
   [aux_sym_uppercase_name_token2] = "uppercase_name_token2",
   [anon_sym_LT] = "<",
@@ -154,21 +150,17 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_line_code_token1] = "line_code_token1",
   [aux_sym_h1_token1] = "h1_token1",
   [aux_sym_h2_token1] = "h2_token1",
-  [anon_sym_STAR] = "*",
   [aux_sym_tag_token1] = "word",
   [anon_sym_STAR2] = "*",
   [sym_url_word] = "word",
   [aux_sym_optionlink_token1] = "word",
   [aux_sym_taglink_token1] = "word",
-  [anon_sym_LBRACE2] = "word",
-  [anon_sym_RBRACE2] = "}",
-  [anon_sym_LPAREN2] = "word",
-  [anon_sym_RPAREN] = "word",
-  [anon_sym_BQUOTE] = "`",
   [anon_sym_PIPE2] = "|",
-  [anon_sym_BQUOTE2] = "`",
+  [anon_sym_BQUOTE] = "`",
   [aux_sym_codespan_token1] = "word",
+  [anon_sym_BQUOTE2] = "`",
   [aux_sym_argument_token1] = "word",
+  [anon_sym_RBRACE2] = "}",
   [sym_help_file] = "help_file",
   [sym__atom] = "_atom",
   [sym_word] = "word",
@@ -213,19 +205,19 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_word_token2] = aux_sym_word_token2,
   [aux_sym_word_noli_token1] = aux_sym_word_noli_token1,
   [aux_sym_word_noli_token2] = aux_sym_word_noli_token2,
+  [anon_sym_STAR] = anon_sym_STAR,
   [anon_sym_SQUOTE] = anon_sym_SQUOTE,
   [aux_sym__word_common_token1] = aux_sym__word_common_token1,
   [aux_sym__word_common_token2] = aux_sym__word_common_token2,
   [anon_sym_SQUOTE2] = anon_sym_SQUOTE,
   [aux_sym__word_common_token3] = aux_sym__word_common_token3,
   [anon_sym_PIPE] = anon_sym_PIPE,
-  [aux_sym__word_common_token4] = aux_sym__word_common_token4,
   [anon_sym_LBRACE] = anon_sym_LBRACE,
   [anon_sym_RBRACE] = anon_sym_RBRACE,
   [anon_sym_LBRACE_RBRACE] = anon_sym_LBRACE_RBRACE,
-  [aux_sym__word_common_token5] = aux_sym__word_common_token5,
+  [aux_sym__word_common_token4] = aux_sym__word_common_token4,
   [anon_sym_LPAREN] = anon_sym_LPAREN,
-  [aux_sym__word_common_token6] = aux_sym__word_common_token6,
+  [aux_sym__word_common_token5] = aux_sym__word_common_token5,
   [anon_sym_TILDE] = anon_sym_TILDE,
   [anon_sym_GT] = anon_sym_GT,
   [aux_sym_keycode_token1] = aux_sym_keycode_token1,
@@ -233,9 +225,9 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_keycode_token3] = aux_sym_keycode_token3,
   [aux_sym_keycode_token4] = aux_sym_keycode_token4,
   [aux_sym_keycode_token5] = aux_sym_keycode_token5,
+  [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
   [aux_sym_keycode_token6] = aux_sym_keycode_token6,
   [aux_sym_keycode_token7] = aux_sym_keycode_token7,
-  [aux_sym_keycode_token8] = aux_sym_keycode_token8,
   [aux_sym_uppercase_name_token1] = aux_sym_uppercase_name_token1,
   [aux_sym_uppercase_name_token2] = aux_sym_uppercase_name_token2,
   [anon_sym_LT] = anon_sym_LT,
@@ -246,21 +238,17 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_line_code_token1] = aux_sym_line_code_token1,
   [aux_sym_h1_token1] = aux_sym_h1_token1,
   [aux_sym_h2_token1] = aux_sym_h2_token1,
-  [anon_sym_STAR] = anon_sym_STAR,
   [aux_sym_tag_token1] = sym_word,
   [anon_sym_STAR2] = anon_sym_STAR,
   [sym_url_word] = sym_word,
   [aux_sym_optionlink_token1] = sym_word,
   [aux_sym_taglink_token1] = sym_word,
-  [anon_sym_LBRACE2] = sym_word,
-  [anon_sym_RBRACE2] = anon_sym_RBRACE,
-  [anon_sym_LPAREN2] = sym_word,
-  [anon_sym_RPAREN] = sym_word,
-  [anon_sym_BQUOTE] = anon_sym_BQUOTE,
   [anon_sym_PIPE2] = anon_sym_PIPE,
-  [anon_sym_BQUOTE2] = anon_sym_BQUOTE,
+  [anon_sym_BQUOTE] = anon_sym_BQUOTE,
   [aux_sym_codespan_token1] = sym_word,
+  [anon_sym_BQUOTE2] = anon_sym_BQUOTE,
   [aux_sym_argument_token1] = sym_word,
+  [anon_sym_RBRACE2] = anon_sym_RBRACE,
   [sym_help_file] = sym_help_file,
   [sym__atom] = sym__atom,
   [sym_word] = sym_word,
@@ -320,6 +308,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
+  [anon_sym_STAR] = {
+    .visible = true,
+    .named = false,
+  },
   [anon_sym_SQUOTE] = {
     .visible = true,
     .named = false,
@@ -344,10 +336,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [aux_sym__word_common_token4] = {
-    .visible = false,
-    .named = false,
-  },
   [anon_sym_LBRACE] = {
     .visible = true,
     .named = false,
@@ -360,7 +348,7 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [aux_sym__word_common_token5] = {
+  [aux_sym__word_common_token4] = {
     .visible = false,
     .named = false,
   },
@@ -368,7 +356,7 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [aux_sym__word_common_token6] = {
+  [aux_sym__word_common_token5] = {
     .visible = false,
     .named = false,
   },
@@ -400,15 +388,15 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
+  [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = {
+    .visible = true,
+    .named = false,
+  },
   [aux_sym_keycode_token6] = {
     .visible = false,
     .named = false,
   },
   [aux_sym_keycode_token7] = {
-    .visible = false,
-    .named = false,
-  },
-  [aux_sym_keycode_token8] = {
     .visible = false,
     .named = false,
   },
@@ -452,10 +440,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
-  [anon_sym_STAR] = {
-    .visible = true,
-    .named = false,
-  },
   [aux_sym_tag_token1] = {
     .visible = true,
     .named = true,
@@ -476,31 +460,11 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [anon_sym_LBRACE2] = {
-    .visible = true,
-    .named = true,
-  },
-  [anon_sym_RBRACE2] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_LPAREN2] = {
-    .visible = true,
-    .named = true,
-  },
-  [anon_sym_RPAREN] = {
-    .visible = true,
-    .named = true,
-  },
-  [anon_sym_BQUOTE] = {
-    .visible = true,
-    .named = false,
-  },
   [anon_sym_PIPE2] = {
     .visible = true,
     .named = false,
   },
-  [anon_sym_BQUOTE2] = {
+  [anon_sym_BQUOTE] = {
     .visible = true,
     .named = false,
   },
@@ -508,9 +472,17 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [anon_sym_BQUOTE2] = {
+    .visible = true,
+    .named = false,
+  },
   [aux_sym_argument_token1] = {
     .visible = true,
     .named = true,
+  },
+  [anon_sym_RBRACE2] = {
+    .visible = true,
+    .named = false,
   },
   [sym_help_file] = {
     .visible = true,
@@ -679,12 +651,11 @@ static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
   [7] = {.index = 4, .length = 2},
   [8] = {.index = 6, .length = 1},
   [9] = {.index = 7, .length = 1},
-  [10] = {.index = 7, .length = 1},
-  [14] = {.index = 8, .length = 1},
-  [15] = {.index = 9, .length = 2},
-  [19] = {.index = 11, .length = 2},
-  [20] = {.index = 13, .length = 1},
-  [21] = {.index = 14, .length = 2},
+  [13] = {.index = 8, .length = 1},
+  [14] = {.index = 9, .length = 2},
+  [18] = {.index = 11, .length = 2},
+  [19] = {.index = 13, .length = 1},
+  [20] = {.index = 14, .length = 2},
 };
 
 static const TSFieldMapEntry ts_field_map_entries[] = {
@@ -728,26 +699,23 @@ static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE
     [1] = sym_word,
   },
   [10] = {
-    [1] = sym_word,
+    [2] = alias_sym_code,
   },
   [11] = {
-    [2] = alias_sym_code,
+    [1] = sym_line,
+    [2] = sym_line,
   },
   [12] = {
     [1] = sym_line,
-    [2] = sym_line,
   },
-  [13] = {
-    [1] = sym_line,
-  },
-  [16] = {
+  [15] = {
     [2] = sym_line,
     [3] = sym_line,
   },
-  [17] = {
+  [16] = {
     [2] = sym_line,
   },
-  [18] = {
+  [17] = {
     [0] = sym_line,
   },
 };
@@ -814,12 +782,12 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [42] = 42,
   [43] = 43,
   [44] = 44,
-  [45] = 34,
-  [46] = 46,
+  [45] = 36,
+  [46] = 42,
   [47] = 47,
   [48] = 48,
   [49] = 49,
-  [50] = 35,
+  [50] = 50,
   [51] = 51,
   [52] = 52,
   [53] = 53,
@@ -830,20 +798,20 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [58] = 58,
   [59] = 59,
   [60] = 60,
-  [61] = 61,
+  [61] = 49,
   [62] = 48,
-  [63] = 49,
-  [64] = 52,
+  [63] = 52,
+  [64] = 53,
   [65] = 65,
-  [66] = 54,
+  [66] = 66,
   [67] = 67,
   [68] = 68,
   [69] = 69,
   [70] = 70,
-  [71] = 71,
+  [71] = 69,
   [72] = 72,
   [73] = 73,
-  [74] = 68,
+  [74] = 74,
   [75] = 75,
   [76] = 76,
   [77] = 77,
@@ -864,8 +832,8 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [92] = 92,
   [93] = 93,
   [94] = 94,
-  [95] = 94,
-  [96] = 96,
+  [95] = 95,
+  [96] = 95,
   [97] = 97,
   [98] = 98,
   [99] = 99,
@@ -875,6 +843,7 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [103] = 103,
   [104] = 104,
   [105] = 105,
+  [106] = 106,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -882,1215 +851,1182 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(32);
-      if (lookahead == '\n') ADVANCE(390);
-      if (lookahead == '\'') ADVANCE(253);
-      if (lookahead == '(') ADVANCE(481);
-      if (lookahead == ')') ADVANCE(483);
-      if (lookahead == '*') ADVANCE(404);
-      if (lookahead == '+') ADVANCE(232);
-      if (lookahead == '<') ADVANCE(387);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(238);
-      if (lookahead == 'C') ADVANCE(240);
-      if (lookahead == 'M') ADVANCE(236);
-      if (lookahead == '`') ADVANCE(485);
-      if (lookahead == 'h') ADVANCE(241);
-      if (lookahead == '{') ADVANCE(477);
-      if (lookahead == '|') ADVANCE(487);
-      if (lookahead == '}') ADVANCE(479);
-      if (lookahead == '~') ADVANCE(285);
+      if (eof) ADVANCE(30);
+      if (lookahead == '\n') ADVANCE(376);
+      if (lookahead == '\'') ADVANCE(445);
+      if (lookahead == '(') ADVANCE(445);
+      if (lookahead == '*') ADVANCE(446);
+      if (lookahead == '<') ADVANCE(443);
+      if (lookahead == '>') ADVANCE(445);
+      if (lookahead == 'A') ADVANCE(391);
+      if (lookahead == 'C') ADVANCE(394);
+      if (lookahead == 'M') ADVANCE(390);
+      if (lookahead == '`') ADVANCE(445);
+      if (lookahead == 'h') ADVANCE(401);
+      if (lookahead == '{') ADVANCE(438);
+      if (lookahead == '|') ADVANCE(445);
+      if (lookahead == '}') ADVANCE(445);
+      if (lookahead == '~') ADVANCE(445);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(29)
+          lookahead == ' ') SKIP(27)
       if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(233);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
+          lookahead == 8226) ADVANCE(445);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(403);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(244);
-      if (lookahead != 0) ADVANCE(232);
+          lookahead == '_') ADVANCE(404);
+      if (lookahead != 0) ADVANCE(445);
       END_STATE();
     case 1:
-      if (lookahead == '\t') ADVANCE(261);
-      if (lookahead == ' ') ADVANCE(393);
-      if (lookahead == '-') ADVANCE(226);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(227);
+      if (lookahead == '\t') ADVANCE(21);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == ' ') ADVANCE(378);
+      if (lookahead != 0) ADVANCE(213);
       END_STATE();
     case 2:
-      if (lookahead == '\t') ADVANCE(261);
-      if (lookahead == ' ') ADVANCE(393);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(227);
+      if (lookahead == '\n') ADVANCE(376);
+      if (lookahead == '\'') ADVANCE(229);
+      if (lookahead == '(') ADVANCE(265);
+      if (lookahead == '*') ADVANCE(225);
+      if (lookahead == '<') ADVANCE(90);
+      if (lookahead == '>') ADVANCE(278);
+      if (lookahead == 'A') ADVANCE(44);
+      if (lookahead == 'C') ADVANCE(47);
+      if (lookahead == 'M') ADVANCE(43);
+      if (lookahead == '`') ADVANCE(511);
+      if (lookahead == 'h') ADVANCE(52);
+      if (lookahead == '{') ADVANCE(253);
+      if (lookahead == '|') ADVANCE(249);
+      if (lookahead == '}') ADVANCE(256);
+      if (lookahead == '~') ADVANCE(274);
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(5)
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+      if (lookahead != 0) ADVANCE(92);
       END_STATE();
     case 3:
-      if (lookahead == '\t') ADVANCE(23);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == ' ') ADVANCE(392);
-      if (lookahead != 0) ADVANCE(216);
+      if (lookahead == '\n') ADVANCE(376);
+      if (lookahead == '\'') ADVANCE(229);
+      if (lookahead == '(') ADVANCE(265);
+      if (lookahead == '*') ADVANCE(225);
+      if (lookahead == '<') ADVANCE(90);
+      if (lookahead == '>') ADVANCE(278);
+      if (lookahead == 'A') ADVANCE(44);
+      if (lookahead == 'C') ADVANCE(47);
+      if (lookahead == 'M') ADVANCE(43);
+      if (lookahead == '`') ADVANCE(511);
+      if (lookahead == 'h') ADVANCE(35);
+      if (lookahead == '{') ADVANCE(253);
+      if (lookahead == '|') ADVANCE(249);
+      if (lookahead == '}') ADVANCE(256);
+      if (lookahead == '~') ADVANCE(274);
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(5)
+      if (('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(53);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(36);
+      if (lookahead != 0) ADVANCE(92);
       END_STATE();
     case 4:
-      if (lookahead == '\t') ADVANCE(262);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == ' ') ADVANCE(392);
-      if (lookahead != 0) ADVANCE(216);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '\'') ADVANCE(445);
+      if (lookahead == '(') ADVANCE(445);
+      if (lookahead == '*') ADVANCE(225);
+      if (lookahead == '<') ADVANCE(443);
+      if (lookahead == '>') ADVANCE(445);
+      if (lookahead == 'A') ADVANCE(391);
+      if (lookahead == 'C') ADVANCE(394);
+      if (lookahead == 'M') ADVANCE(390);
+      if (lookahead == '`') ADVANCE(445);
+      if (lookahead == 'h') ADVANCE(402);
+      if (lookahead == '{') ADVANCE(438);
+      if (lookahead == '|') ADVANCE(440);
+      if (lookahead == '}') ADVANCE(445);
+      if (lookahead == '~') ADVANCE(445);
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(5)
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead != 0) ADVANCE(445);
       END_STATE();
     case 5:
-      if (lookahead == '\n') ADVANCE(390);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == '*') ADVANCE(397);
-      if (lookahead == '<') ADVANCE(93);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(47);
-      if (lookahead == 'C') ADVANCE(50);
-      if (lookahead == 'M') ADVANCE(46);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(55);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '\'') ADVANCE(229);
+      if (lookahead == '(') ADVANCE(265);
+      if (lookahead == '*') ADVANCE(225);
+      if (lookahead == '<') ADVANCE(90);
+      if (lookahead == '>') ADVANCE(278);
+      if (lookahead == 'A') ADVANCE(44);
+      if (lookahead == 'C') ADVANCE(47);
+      if (lookahead == 'M') ADVANCE(43);
+      if (lookahead == '`') ADVANCE(511);
+      if (lookahead == 'h') ADVANCE(52);
+      if (lookahead == '{') ADVANCE(253);
+      if (lookahead == '|') ADVANCE(249);
+      if (lookahead == '}') ADVANCE(256);
+      if (lookahead == '~') ADVANCE(274);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(8)
-      if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(33);
+          lookahead == ' ') SKIP(5)
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (lookahead != 0) ADVANCE(95);
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+      if (lookahead != 0) ADVANCE(92);
       END_STATE();
     case 6:
-      if (lookahead == '\n') ADVANCE(390);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == '*') ADVANCE(397);
-      if (lookahead == '<') ADVANCE(93);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(47);
-      if (lookahead == 'C') ADVANCE(50);
-      if (lookahead == 'M') ADVANCE(46);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(38);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '\'') ADVANCE(229);
+      if (lookahead == '(') ADVANCE(265);
+      if (lookahead == '*') ADVANCE(225);
+      if (lookahead == '<') ADVANCE(209);
+      if (lookahead == '>') ADVANCE(278);
+      if (lookahead == 'A') ADVANCE(152);
+      if (lookahead == 'C') ADVANCE(155);
+      if (lookahead == 'M') ADVANCE(151);
+      if (lookahead == '`') ADVANCE(511);
+      if (lookahead == 'h') ADVANCE(160);
+      if (lookahead == '{') ADVANCE(253);
+      if (lookahead == '|') ADVANCE(249);
+      if (lookahead == '}') ADVANCE(256);
+      if (lookahead == '~') ADVANCE(274);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(8)
+          lookahead == ' ') SKIP(6)
       if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(33);
-      if (('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == 8226) ADVANCE(24);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
-      if (lookahead != 0) ADVANCE(95);
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead != 0) ADVANCE(211);
       END_STATE();
     case 7:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(253);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == '*') ADVANCE(397);
-      if (lookahead == '<') ADVANCE(93);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(47);
-      if (lookahead == 'C') ADVANCE(50);
-      if (lookahead == 'M') ADVANCE(46);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(55);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '\'') ADVANCE(229);
+      if (lookahead == '(') ADVANCE(268);
+      if (lookahead == '*') ADVANCE(225);
+      if (lookahead == '-') ADVANCE(23);
+      if (lookahead == '<') ADVANCE(374);
+      if (lookahead == '=') ADVANCE(178);
+      if (lookahead == '>') ADVANCE(278);
+      if (lookahead == 'A') ADVANCE(163);
+      if (lookahead == 'C') ADVANCE(164);
+      if (lookahead == 'M') ADVANCE(162);
+      if (lookahead == '`') ADVANCE(511);
+      if (lookahead == 'h') ADVANCE(160);
+      if (lookahead == '{') ADVANCE(253);
+      if (lookahead == '|') ADVANCE(249);
+      if (lookahead == '}') ADVANCE(256);
+      if (lookahead == '~') ADVANCE(274);
+      if (lookahead == 8226) ADVANCE(24);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(8)
-      if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(33);
+          lookahead == ' ') ADVANCE(12);
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(210);
+      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(161);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (lookahead != 0) ADVANCE(95);
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(165);
+      if (lookahead != 0) ADVANCE(211);
       END_STATE();
     case 8:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == '*') ADVANCE(397);
-      if (lookahead == '<') ADVANCE(93);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(47);
-      if (lookahead == 'C') ADVANCE(50);
-      if (lookahead == 'M') ADVANCE(46);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(55);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '\'') ADVANCE(229);
+      if (lookahead == '(') ADVANCE(268);
+      if (lookahead == '*') ADVANCE(225);
+      if (lookahead == '<') ADVANCE(374);
+      if (lookahead == '>') ADVANCE(278);
+      if (lookahead == 'A') ADVANCE(163);
+      if (lookahead == 'C') ADVANCE(164);
+      if (lookahead == 'M') ADVANCE(162);
+      if (lookahead == '`') ADVANCE(511);
+      if (lookahead == 'h') ADVANCE(160);
+      if (lookahead == '{') ADVANCE(253);
+      if (lookahead == '|') ADVANCE(249);
+      if (lookahead == '}') ADVANCE(256);
+      if (lookahead == '~') ADVANCE(274);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(8)
+          lookahead == ' ') SKIP(6)
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(210);
       if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(33);
+          lookahead == 8226) ADVANCE(24);
+      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(161);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (lookahead != 0) ADVANCE(95);
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(165);
+      if (lookahead != 0) ADVANCE(211);
       END_STATE();
     case 9:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == '*') ADVANCE(399);
-      if (lookahead == '+') ADVANCE(25);
-      if (lookahead == '<') ADVANCE(212);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(155);
-      if (lookahead == 'C') ADVANCE(158);
-      if (lookahead == 'M') ADVANCE(154);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(163);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '\'') ADVANCE(229);
+      if (lookahead == '(') ADVANCE(268);
+      if (lookahead == '*') ADVANCE(225);
+      if (lookahead == '<') ADVANCE(374);
+      if (lookahead == '>') ADVANCE(278);
+      if (lookahead == 'A') ADVANCE(163);
+      if (lookahead == 'C') ADVANCE(164);
+      if (lookahead == 'M') ADVANCE(162);
+      if (lookahead == '`') ADVANCE(511);
+      if (lookahead == 'h') ADVANCE(160);
+      if (lookahead == '{') ADVANCE(253);
+      if (lookahead == '|') ADVANCE(249);
+      if (lookahead == '}') ADVANCE(256);
+      if (lookahead == '~') ADVANCE(274);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(9)
+          lookahead == ' ') ADVANCE(12);
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(210);
       if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(2);
+          lookahead == 8226) ADVANCE(24);
+      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(161);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0) ADVANCE(214);
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(165);
+      if (lookahead != 0) ADVANCE(211);
       END_STATE();
     case 10:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(280);
-      if (lookahead == '*') ADVANCE(399);
-      if (lookahead == '+') ADVANCE(25);
-      if (lookahead == '-') ADVANCE(1);
-      if (lookahead == '<') ADVANCE(388);
-      if (lookahead == '=') ADVANCE(181);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(166);
-      if (lookahead == 'C') ADVANCE(167);
-      if (lookahead == 'M') ADVANCE(165);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(163);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
-      if (lookahead == 8226) ADVANCE(2);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '\'') ADVANCE(229);
+      if (lookahead == '(') ADVANCE(267);
+      if (lookahead == '*') ADVANCE(227);
+      if (lookahead == '<') ADVANCE(238);
+      if (lookahead == '>') ADVANCE(280);
+      if (lookahead == 'A') ADVANCE(233);
+      if (lookahead == 'C') ADVANCE(234);
+      if (lookahead == 'M') ADVANCE(232);
+      if (lookahead == '`') ADVANCE(513);
+      if (lookahead == 'h') ADVANCE(236);
+      if (lookahead == '{') ADVANCE(254);
+      if (lookahead == '|') ADVANCE(250);
+      if (lookahead == '}') ADVANCE(258);
+      if (lookahead == '~') ADVANCE(276);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(15);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(213);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+          lookahead == ' ') SKIP(5)
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(237);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(168);
-      if (lookahead != 0) ADVANCE(214);
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(235);
+      if (lookahead != 0) ADVANCE(239);
       END_STATE();
     case 11:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(280);
-      if (lookahead == '*') ADVANCE(399);
-      if (lookahead == '+') ADVANCE(25);
-      if (lookahead == '<') ADVANCE(388);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(166);
-      if (lookahead == 'C') ADVANCE(167);
-      if (lookahead == 'M') ADVANCE(165);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(163);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '\'') ADVANCE(229);
+      if (lookahead == '(') ADVANCE(269);
+      if (lookahead == '*') ADVANCE(225);
+      if (lookahead == '<') ADVANCE(90);
+      if (lookahead == '>') ADVANCE(278);
+      if (lookahead == 'A') ADVANCE(55);
+      if (lookahead == 'C') ADVANCE(56);
+      if (lookahead == 'M') ADVANCE(54);
+      if (lookahead == '`') ADVANCE(511);
+      if (lookahead == 'h') ADVANCE(52);
+      if (lookahead == '{') ADVANCE(253);
+      if (lookahead == '|') ADVANCE(249);
+      if (lookahead == '}') ADVANCE(256);
+      if (lookahead == '~') ADVANCE(274);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(9)
+          lookahead == ' ') SKIP(11)
       if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(213);
-      if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(2);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+          lookahead == '.') ADVANCE(91);
+      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(53);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(168);
-      if (lookahead != 0) ADVANCE(214);
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(57);
+      if (lookahead != 0) ADVANCE(92);
       END_STATE();
     case 12:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(280);
-      if (lookahead == '*') ADVANCE(399);
-      if (lookahead == '+') ADVANCE(25);
-      if (lookahead == '<') ADVANCE(388);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(166);
-      if (lookahead == 'C') ADVANCE(167);
-      if (lookahead == 'M') ADVANCE(165);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(163);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '\'') ADVANCE(230);
+      if (lookahead == '(') ADVANCE(266);
+      if (lookahead == '*') ADVANCE(226);
+      if (lookahead == '<') ADVANCE(140);
+      if (lookahead == '>') ADVANCE(279);
+      if (lookahead == 'A') ADVANCE(101);
+      if (lookahead == 'C') ADVANCE(104);
+      if (lookahead == 'M') ADVANCE(100);
+      if (lookahead == '`') ADVANCE(512);
+      if (lookahead == 'h') ADVANCE(109);
+      if (lookahead == '{') ADVANCE(252);
+      if (lookahead == '|') ADVANCE(248);
+      if (lookahead == '}') ADVANCE(257);
+      if (lookahead == '~') ADVANCE(275);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(15);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(213);
+          lookahead == ' ') ADVANCE(12);
       if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(2);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+          lookahead == 8226) ADVANCE(1);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(168);
-      if (lookahead != 0) ADVANCE(214);
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(110);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 13:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(279);
-      if (lookahead == '*') ADVANCE(401);
-      if (lookahead == '<') ADVANCE(247);
-      if (lookahead == '>') ADVANCE(293);
-      if (lookahead == 'A') ADVANCE(237);
-      if (lookahead == 'C') ADVANCE(239);
-      if (lookahead == 'M') ADVANCE(235);
-      if (lookahead == '`') ADVANCE(491);
-      if (lookahead == 'h') ADVANCE(245);
-      if (lookahead == '{') ADVANCE(265);
-      if (lookahead == '|') ADVANCE(260);
-      if (lookahead == '}') ADVANCE(268);
-      if (lookahead == '~') ADVANCE(288);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '\'') ADVANCE(509);
+      if (lookahead == '(') ADVANCE(509);
+      if (lookahead == '*') ADVANCE(509);
+      if (lookahead == '<') ADVANCE(507);
+      if (lookahead == '>') ADVANCE(509);
+      if (lookahead == 'A') ADVANCE(460);
+      if (lookahead == 'C') ADVANCE(463);
+      if (lookahead == 'M') ADVANCE(459);
+      if (lookahead == '`') ADVANCE(509);
+      if (lookahead == 'h') ADVANCE(468);
+      if (lookahead == '{') ADVANCE(503);
+      if (lookahead == '|') ADVANCE(249);
+      if (lookahead == '}') ADVANCE(509);
+      if (lookahead == '~') ADVANCE(509);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(8)
-      if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(234);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(246);
+          lookahead == ' ') SKIP(5)
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(243);
-      if (lookahead != 0) ADVANCE(248);
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      if (lookahead != 0) ADVANCE(509);
       END_STATE();
     case 14:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(281);
-      if (lookahead == '*') ADVANCE(397);
-      if (lookahead == '<') ADVANCE(93);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(58);
-      if (lookahead == 'C') ADVANCE(59);
-      if (lookahead == 'M') ADVANCE(57);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(55);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '\'') ADVANCE(244);
+      if (lookahead == '(') ADVANCE(265);
+      if (lookahead == '*') ADVANCE(225);
+      if (lookahead == '<') ADVANCE(90);
+      if (lookahead == '>') ADVANCE(278);
+      if (lookahead == 'A') ADVANCE(44);
+      if (lookahead == 'C') ADVANCE(47);
+      if (lookahead == 'M') ADVANCE(43);
+      if (lookahead == '`') ADVANCE(511);
+      if (lookahead == 'h') ADVANCE(52);
+      if (lookahead == '{') ADVANCE(253);
+      if (lookahead == '|') ADVANCE(249);
+      if (lookahead == '}') ADVANCE(256);
+      if (lookahead == '~') ADVANCE(274);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(14)
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(94);
-      if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(33);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          lookahead == ' ') SKIP(5)
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(60);
-      if (lookahead != 0) ADVANCE(95);
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+      if (lookahead != 0) ADVANCE(92);
       END_STATE();
     case 15:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(229);
-      if (lookahead == '(') ADVANCE(277);
-      if (lookahead == '*') ADVANCE(398);
-      if (lookahead == '+') ADVANCE(3);
-      if (lookahead == '<') ADVANCE(143);
-      if (lookahead == '>') ADVANCE(291);
-      if (lookahead == 'A') ADVANCE(104);
-      if (lookahead == 'C') ADVANCE(107);
-      if (lookahead == 'M') ADVANCE(103);
-      if (lookahead == '`') ADVANCE(489);
-      if (lookahead == 'h') ADVANCE(112);
-      if (lookahead == '{') ADVANCE(263);
-      if (lookahead == '|') ADVANCE(257);
-      if (lookahead == '}') ADVANCE(267);
-      if (lookahead == '~') ADVANCE(286);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '\'') ADVANCE(231);
+      if (lookahead == '(') ADVANCE(270);
+      if (lookahead == '*') ADVANCE(228);
+      if (lookahead == '<') ADVANCE(574);
+      if (lookahead == '>') ADVANCE(281);
+      if (lookahead == 'A') ADVANCE(524);
+      if (lookahead == 'C') ADVANCE(527);
+      if (lookahead == 'M') ADVANCE(523);
+      if (lookahead == '`') ADVANCE(514);
+      if (lookahead == 'h') ADVANCE(532);
+      if (lookahead == '{') ADVANCE(255);
+      if (lookahead == '|') ADVANCE(251);
+      if (lookahead == '}') ADVANCE(256);
+      if (lookahead == '~') ADVANCE(277);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(15);
-      if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(4);
+          lookahead == ' ') SKIP(5)
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead != 0) ADVANCE(576);
       END_STATE();
     case 16:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(231);
-      if (lookahead == '(') ADVANCE(482);
-      if (lookahead == ')') ADVANCE(484);
-      if (lookahead == '*') ADVANCE(402);
-      if (lookahead == '<') ADVANCE(474);
-      if (lookahead == '>') ADVANCE(294);
-      if (lookahead == 'A') ADVANCE(425);
-      if (lookahead == 'C') ADVANCE(428);
-      if (lookahead == 'M') ADVANCE(424);
-      if (lookahead == '`') ADVANCE(486);
-      if (lookahead == 'h') ADVANCE(433);
-      if (lookahead == '{') ADVANCE(478);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(480);
-      if (lookahead == '~') ADVANCE(289);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '*') ADVANCE(446);
+      if (lookahead == '<') ADVANCE(373);
+      if (lookahead == '`') ADVANCE(516);
+      if (lookahead == '|') ADVANCE(510);
+      if (lookahead == '}') ADVANCE(577);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(8)
+          lookahead == ' ') SKIP(17)
       if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(417);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0) ADVANCE(476);
+          lookahead == 8226) ADVANCE(22);
       END_STATE();
     case 17:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(230);
-      if (lookahead == '(') ADVANCE(278);
-      if (lookahead == '*') ADVANCE(400);
-      if (lookahead == '<') ADVANCE(545);
-      if (lookahead == '>') ADVANCE(292);
-      if (lookahead == 'A') ADVANCE(506);
-      if (lookahead == 'C') ADVANCE(509);
-      if (lookahead == 'M') ADVANCE(505);
-      if (lookahead == '`') ADVANCE(490);
-      if (lookahead == 'h') ADVANCE(514);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(258);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(287);
+      if (lookahead == '\n') ADVANCE(377);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(8)
+          lookahead == ' ') SKIP(17)
       if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(493);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(515);
-      if (lookahead != 0) ADVANCE(546);
+          lookahead == 8226) ADVANCE(22);
       END_STATE();
     case 18:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '<') ADVANCE(386);
-      if (lookahead == '`') ADVANCE(485);
-      if (lookahead == '|') ADVANCE(487);
-      if (lookahead == '}') ADVANCE(479);
+      if (lookahead == '\n') ADVANCE(382);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(19)
-      if (lookahead == '*' ||
-          lookahead == '+' ||
-          lookahead == '-' ||
-          lookahead == 8226) ADVANCE(24);
+          lookahead == ' ') ADVANCE(18);
       END_STATE();
     case 19:
-      if (lookahead == '\n') ADVANCE(391);
+      if (lookahead == '\n') ADVANCE(381);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(19)
-      if (lookahead == '*' ||
-          lookahead == '+' ||
-          lookahead == '-' ||
-          lookahead == 8226) ADVANCE(24);
+          lookahead == ' ') ADVANCE(19);
       END_STATE();
     case 20:
-      if (lookahead == '\n') ADVANCE(396);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(20);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '>') ADVANCE(288);
+      if (lookahead != 0) ADVANCE(21);
       END_STATE();
     case 21:
-      if (lookahead == '\n') ADVANCE(395);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead != 0) ADVANCE(21);
       END_STATE();
     case 22:
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '>') ADVANCE(301);
-      if (lookahead != 0) ADVANCE(23);
+      if (lookahead == ' ') ADVANCE(379);
       END_STATE();
     case 23:
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead != 0) ADVANCE(23);
+      if (lookahead == ' ') ADVANCE(379);
+      if (lookahead == '-') ADVANCE(223);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n') ADVANCE(224);
       END_STATE();
     case 24:
-      if (lookahead == ' ') ADVANCE(393);
+      if (lookahead == ' ') ADVANCE(379);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n') ADVANCE(224);
       END_STATE();
     case 25:
-      if (lookahead == ' ') ADVANCE(393);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(227);
+      if (lookahead == '>') ADVANCE(286);
       END_STATE();
     case 26:
-      if (lookahead == '*') ADVANCE(404);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(403);
+          lookahead != '`') ADVANCE(515);
       END_STATE();
     case 27:
-      if (lookahead == '>') ADVANCE(299);
+      if (eof) ADVANCE(30);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '\'') ADVANCE(229);
+      if (lookahead == '(') ADVANCE(265);
+      if (lookahead == '*') ADVANCE(225);
+      if (lookahead == '<') ADVANCE(90);
+      if (lookahead == '>') ADVANCE(278);
+      if (lookahead == 'A') ADVANCE(44);
+      if (lookahead == 'C') ADVANCE(47);
+      if (lookahead == 'M') ADVANCE(43);
+      if (lookahead == '`') ADVANCE(511);
+      if (lookahead == 'h') ADVANCE(52);
+      if (lookahead == '{') ADVANCE(253);
+      if (lookahead == '|') ADVANCE(247);
+      if (lookahead == '}') ADVANCE(256);
+      if (lookahead == '~') ADVANCE(274);
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(27)
+      if (lookahead == '-' ||
+          lookahead == 8226) ADVANCE(92);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+      if (lookahead != 0) ADVANCE(92);
       END_STATE();
     case 28:
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '`') ADVANCE(492);
+      if (eof) ADVANCE(30);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '\'') ADVANCE(229);
+      if (lookahead == '(') ADVANCE(265);
+      if (lookahead == '*') ADVANCE(225);
+      if (lookahead == '<') ADVANCE(209);
+      if (lookahead == '>') ADVANCE(278);
+      if (lookahead == 'A') ADVANCE(152);
+      if (lookahead == 'C') ADVANCE(155);
+      if (lookahead == 'M') ADVANCE(151);
+      if (lookahead == '`') ADVANCE(511);
+      if (lookahead == 'h') ADVANCE(160);
+      if (lookahead == '{') ADVANCE(253);
+      if (lookahead == '|') ADVANCE(249);
+      if (lookahead == '}') ADVANCE(256);
+      if (lookahead == '~') ADVANCE(274);
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(28)
+      if (lookahead == '-' ||
+          lookahead == 8226) ADVANCE(24);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead != 0) ADVANCE(211);
       END_STATE();
     case 29:
-      if (eof) ADVANCE(32);
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == '*') ADVANCE(397);
-      if (lookahead == '+') ADVANCE(95);
-      if (lookahead == '<') ADVANCE(93);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(47);
-      if (lookahead == 'C') ADVANCE(50);
-      if (lookahead == 'M') ADVANCE(46);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(55);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(256);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
+      if (eof) ADVANCE(30);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '\'') ADVANCE(229);
+      if (lookahead == '(') ADVANCE(268);
+      if (lookahead == '*') ADVANCE(225);
+      if (lookahead == '-') ADVANCE(23);
+      if (lookahead == '<') ADVANCE(374);
+      if (lookahead == '=') ADVANCE(178);
+      if (lookahead == '>') ADVANCE(278);
+      if (lookahead == 'A') ADVANCE(163);
+      if (lookahead == 'C') ADVANCE(164);
+      if (lookahead == 'M') ADVANCE(162);
+      if (lookahead == '`') ADVANCE(511);
+      if (lookahead == 'h') ADVANCE(160);
+      if (lookahead == '{') ADVANCE(253);
+      if (lookahead == '|') ADVANCE(249);
+      if (lookahead == '}') ADVANCE(256);
+      if (lookahead == '~') ADVANCE(274);
+      if (lookahead == 8226) ADVANCE(24);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(29)
-      if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(33);
+          lookahead == ' ') SKIP(28)
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(210);
+      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(161);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (lookahead != 0) ADVANCE(95);
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(165);
+      if (lookahead != 0) ADVANCE(211);
       END_STATE();
     case 30:
-      if (eof) ADVANCE(32);
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == '*') ADVANCE(399);
-      if (lookahead == '+') ADVANCE(25);
-      if (lookahead == '<') ADVANCE(212);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(155);
-      if (lookahead == 'C') ADVANCE(158);
-      if (lookahead == 'M') ADVANCE(154);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(163);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
-      if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(30)
-      if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(2);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0) ADVANCE(214);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 31:
-      if (eof) ADVANCE(32);
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(280);
-      if (lookahead == '*') ADVANCE(399);
-      if (lookahead == '+') ADVANCE(25);
-      if (lookahead == '-') ADVANCE(1);
-      if (lookahead == '<') ADVANCE(388);
-      if (lookahead == '=') ADVANCE(181);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(166);
-      if (lookahead == 'C') ADVANCE(167);
-      if (lookahead == 'M') ADVANCE(165);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(163);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
-      if (lookahead == 8226) ADVANCE(2);
-      if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(30)
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(213);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '\n') ADVANCE(375);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == ':') ADVANCE(89);
+      if (lookahead == 's') ADVANCE(32);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(53);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(168);
-      if (lookahead != 0) ADVANCE(214);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(36);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 32:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '\n') ADVANCE(375);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == ':') ADVANCE(89);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(53);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(36);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 33:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\t') ADVANCE(261);
+      if (lookahead == '\n') ADVANCE(375);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 'p') ADVANCE(31);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(53);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(36);
       if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != '\t' &&
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 34:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(389);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == ':') ADVANCE(92);
-      if (lookahead == 's') ADVANCE(35);
+      if (lookahead == '\n') ADVANCE(375);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 't') ADVANCE(33);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(53);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(36);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 35:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(389);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == ':') ADVANCE(92);
+      if (lookahead == '\n') ADVANCE(375);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 't') ADVANCE(34);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(53);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(36);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 36:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(389);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'p') ADVANCE(34);
+      if (lookahead == '\n') ADVANCE(375);
+      if (lookahead == '(') ADVANCE(271);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(53);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(36);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 37:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(389);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 't') ADVANCE(36);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == '-') ADVANCE(86);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 38:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(389);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 't') ADVANCE(37);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == '-') ADVANCE(63);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 39:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(389);
-      if (lookahead == '(') ADVANCE(282);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == '-') ADVANCE(87);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 40:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == '-') ADVANCE(89);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == ':') ADVANCE(89);
+      if (lookahead == 's') ADVANCE(41);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 41:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == '-') ADVANCE(66);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == ':') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 42:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == '-') ADVANCE(90);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
-      END_STATE();
-    case 43:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == ':') ADVANCE(92);
-      if (lookahead == 's') ADVANCE(44);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
-      END_STATE();
-    case 44:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == ':') ADVANCE(92);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
-      END_STATE();
-    case 45:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'A') ADVANCE(42);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 'A') ADVANCE(39);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
+      END_STATE();
+    case 43:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 'E') ADVANCE(49);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(92);
+      END_STATE();
+    case 44:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 'L') ADVANCE(48);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(92);
+      END_STATE();
+    case 45:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 'L') ADVANCE(38);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 46:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'E') ADVANCE(52);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 'R') ADVANCE(45);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 47:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'L') ADVANCE(51);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 'T') ADVANCE(46);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 48:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'L') ADVANCE(41);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 'T') ADVANCE(37);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 49:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'R') ADVANCE(48);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 'T') ADVANCE(42);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 50:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'T') ADVANCE(49);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 'p') ADVANCE(40);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 51:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'T') ADVANCE(40);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 't') ADVANCE(50);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 52:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'T') ADVANCE(45);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 't') ADVANCE(51);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 53:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'p') ADVANCE(43);
+      if (lookahead == '(') ADVANCE(271);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 54:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 't') ADVANCE(53);
+      if (lookahead == '(') ADVANCE(273);
+      if (lookahead == 'E') ADVANCE(362);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(372);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          lookahead == '_') ADVANCE(363);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 55:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 't') ADVANCE(54);
+      if (lookahead == '(') ADVANCE(273);
+      if (lookahead == 'L') ADVANCE(361);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(372);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          lookahead == '_') ADVANCE(363);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 56:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == '(') ADVANCE(273);
+      if (lookahead == 'T') ADVANCE(360);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(372);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          lookahead == '_') ADVANCE(363);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 57:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == 'E') ADVANCE(375);
+      if (lookahead == '(') ADVANCE(273);
       if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          lookahead == '.') ADVANCE(372);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
+          lookahead == '_') ADVANCE(363);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 58:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == 'L') ADVANCE(374);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (lookahead == '-') ADVANCE(61);
+      if (lookahead == '>') ADVANCE(282);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 59:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == 'T') ADVANCE(373);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
+      if (lookahead == '-') ADVANCE(88);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 60:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '>') ADVANCE(282);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 61:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '-') ADVANCE(64);
-      if (lookahead == '>') ADVANCE(295);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '>') ADVANCE(285);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(25);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(63);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != '\n') ADVANCE(62);
       END_STATE();
     case 62:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '-') ADVANCE(91);
+      if (lookahead == '>') ADVANCE(286);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 63:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '>') ADVANCE(295);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(63);
+      if (lookahead == 'B') ADVANCE(312);
+      if (lookahead == 'D') ADVANCE(306);
+      if (lookahead == 'I') ADVANCE(309);
+      if (lookahead == 'P') ADVANCE(301);
+      if (lookahead == 'S') ADVANCE(298);
+      if (lookahead == '{') ADVANCE(304);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(289);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != '\n') ADVANCE(289);
       END_STATE();
     case 64:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '>') ADVANCE(298);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(27);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(63);
+      if (lookahead == 'D') ADVANCE(78);
+      if (lookahead == 'U') ADVANCE(79);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(65);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 65:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '>') ADVANCE(299);
+      if (lookahead == 'F') ADVANCE(67);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 66:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'B') ADVANCE(325);
-      if (lookahead == 'D') ADVANCE(319);
-      if (lookahead == 'I') ADVANCE(322);
-      if (lookahead == 'P') ADVANCE(314);
-      if (lookahead == 'S') ADVANCE(311);
-      if (lookahead == '{') ADVANCE(317);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(302);
+      if (lookahead == 'I') ADVANCE(65);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(302);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 67:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'D') ADVANCE(81);
-      if (lookahead == 'U') ADVANCE(82);
+      if (lookahead == 'T') ADVANCE(59);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 68:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'F') ADVANCE(70);
+      if (lookahead == 'a') ADVANCE(75);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 69:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'I') ADVANCE(68);
+      if (lookahead == 'a') ADVANCE(81);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 70:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'T') ADVANCE(62);
+      if (lookahead == 'e') ADVANCE(68);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 71:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'a') ADVANCE(78);
+      if (lookahead == 'e') ADVANCE(80);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 72:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'a') ADVANCE(84);
+      if (lookahead == 'e') ADVANCE(64);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 73:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'e') ADVANCE(71);
+      if (lookahead == 'g') ADVANCE(72);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 74:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'e') ADVANCE(83);
+      if (lookahead == 'h') ADVANCE(69);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 75:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'e') ADVANCE(67);
+      if (lookahead == 'k') ADVANCE(320);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 76:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'g') ADVANCE(75);
+      if (lookahead == 'l') ADVANCE(320);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 77:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'h') ADVANCE(72);
+      if (lookahead == 'n') ADVANCE(320);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 78:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'k') ADVANCE(333);
+      if (lookahead == 'o') ADVANCE(84);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 79:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'l') ADVANCE(333);
+      if (lookahead == 'p') ADVANCE(320);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 80:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'n') ADVANCE(333);
+      if (lookahead == 'r') ADVANCE(83);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 81:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'o') ADVANCE(87);
+      if (lookahead == 'r') ADVANCE(85);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 82:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'p') ADVANCE(333);
+      if (lookahead == 's') ADVANCE(71);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 83:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'r') ADVANCE(86);
+      if (lookahead == 't') ADVANCE(320);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 84:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'r') ADVANCE(88);
+      if (lookahead == 'w') ADVANCE(77);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 85:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 's') ADVANCE(74);
+      if (lookahead == '}') ADVANCE(322);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
     case 86:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 't') ADVANCE(333);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(328);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != '\n') ADVANCE(328);
       END_STATE();
     case 87:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'w') ADVANCE(80);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(324);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != '\n') ADVANCE(324);
       END_STATE();
     case 88:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '}') ADVANCE(335);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(316);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != '\n') ADVANCE(316);
       END_STATE();
     case 89:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(341);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(341);
-      END_STATE();
-    case 90:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(337);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(337);
-      END_STATE();
-    case 91:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(329);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(329);
-      END_STATE();
-    case 92:
-      ACCEPT_TOKEN(aux_sym_word_token1);
       if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(95);
+          lookahead == ']') ADVANCE(92);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(406);
+          lookahead != ' ') ADVANCE(448);
       END_STATE();
-    case 93:
+    case 90:
       ACCEPT_TOKEN(aux_sym_word_token1);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(61);
+          lookahead == 'S') ADVANCE(58);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(63);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
-    case 94:
+    case 91:
       ACCEPT_TOKEN(aux_sym_word_token1);
       if (lookahead == '(' ||
           lookahead == ')' ||
@@ -2098,859 +2034,883 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
+          lookahead == '_') ADVANCE(372);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
       END_STATE();
-    case 95:
+    case 92:
       ACCEPT_TOKEN(aux_sym_word_token1);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(92);
+      END_STATE();
+    case 93:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(381);
+      if (lookahead == '=') ADVANCE(93);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(19);
+      if (lookahead != 0) ADVANCE(211);
+      END_STATE();
+    case 94:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '(') ADVANCE(272);
+      if (lookahead == '-') ADVANCE(116);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
+      if (lookahead != 0) ADVANCE(141);
+      END_STATE();
+    case 95:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '(') ADVANCE(272);
+      if (lookahead == '-') ADVANCE(142);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 96:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(395);
-      if (lookahead == '=') ADVANCE(96);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '(') ADVANCE(272);
+      if (lookahead == '-') ADVANCE(143);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(214);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 97:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == '-') ADVANCE(119);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '(') ADVANCE(272);
+      if (lookahead == ':') ADVANCE(139);
+      if (lookahead == 's') ADVANCE(98);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
+          lookahead == ' ') ADVANCE(21);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 98:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == '-') ADVANCE(145);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '(') ADVANCE(272);
+      if (lookahead == ':') ADVANCE(139);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
+          lookahead == ' ') ADVANCE(21);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 99:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == '-') ADVANCE(146);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '(') ADVANCE(272);
+      if (lookahead == 'A') ADVANCE(96);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 100:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == ':') ADVANCE(142);
-      if (lookahead == 's') ADVANCE(101);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 101:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == ':') ADVANCE(142);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 102:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == 'A') ADVANCE(99);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
+          lookahead == ' ') ADVANCE(21);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
+      if (lookahead != 0) ADVANCE(141);
+      END_STATE();
+    case 100:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '(') ADVANCE(272);
+      if (lookahead == 'E') ADVANCE(106);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
+      if (lookahead != 0) ADVANCE(141);
+      END_STATE();
+    case 101:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '(') ADVANCE(272);
+      if (lookahead == 'L') ADVANCE(105);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
+      if (lookahead != 0) ADVANCE(141);
+      END_STATE();
+    case 102:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '(') ADVANCE(272);
+      if (lookahead == 'L') ADVANCE(94);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 103:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == 'E') ADVANCE(109);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '(') ADVANCE(272);
+      if (lookahead == 'R') ADVANCE(102);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
+          lookahead == ' ') ADVANCE(21);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 104:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == 'L') ADVANCE(108);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '(') ADVANCE(272);
+      if (lookahead == 'T') ADVANCE(103);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
+          lookahead == ' ') ADVANCE(21);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 105:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == 'L') ADVANCE(97);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '(') ADVANCE(272);
+      if (lookahead == 'T') ADVANCE(95);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
+          lookahead == ' ') ADVANCE(21);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 106:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == 'R') ADVANCE(105);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '(') ADVANCE(272);
+      if (lookahead == 'T') ADVANCE(99);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
+          lookahead == ' ') ADVANCE(21);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 107:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == 'T') ADVANCE(106);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '(') ADVANCE(272);
+      if (lookahead == 'p') ADVANCE(97);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
+          lookahead == ' ') ADVANCE(21);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 108:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == 'T') ADVANCE(98);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '(') ADVANCE(272);
+      if (lookahead == 't') ADVANCE(107);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
+          lookahead == ' ') ADVANCE(21);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 109:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == 'T') ADVANCE(102);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '(') ADVANCE(272);
+      if (lookahead == 't') ADVANCE(108);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
+          lookahead == ' ') ADVANCE(21);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 110:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == 'p') ADVANCE(100);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '(') ADVANCE(272);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
+          lookahead == ' ') ADVANCE(21);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 111:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == 't') ADVANCE(110);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '-') ADVANCE(114);
+      if (lookahead == '>') ADVANCE(284);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
+          lookahead == ' ') ADVANCE(21);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 112:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == 't') ADVANCE(111);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '-') ADVANCE(144);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 113:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '>') ADVANCE(284);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 114:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '-') ADVANCE(117);
-      if (lookahead == '>') ADVANCE(297);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '>') ADVANCE(283);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == ' ') ADVANCE(20);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
-      if (lookahead != 0) ADVANCE(144);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
+      if (lookahead != 0) ADVANCE(115);
       END_STATE();
     case 115:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '-') ADVANCE(147);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '>') ADVANCE(287);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 116:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '>') ADVANCE(297);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'B') ADVANCE(295);
+      if (lookahead == 'D') ADVANCE(293);
+      if (lookahead == 'I') ADVANCE(294);
+      if (lookahead == 'P') ADVANCE(291);
+      if (lookahead == 'S') ADVANCE(290);
+      if (lookahead == '{') ADVANCE(292);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(297);
+      if (lookahead != 0) ADVANCE(296);
       END_STATE();
     case 117:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '>') ADVANCE(296);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'D') ADVANCE(131);
+      if (lookahead == 'U') ADVANCE(132);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
-      if (lookahead != 0) ADVANCE(118);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 118:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '>') ADVANCE(300);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'F') ADVANCE(120);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 119:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'B') ADVANCE(308);
-      if (lookahead == 'D') ADVANCE(306);
-      if (lookahead == 'I') ADVANCE(307);
-      if (lookahead == 'P') ADVANCE(304);
-      if (lookahead == 'S') ADVANCE(303);
-      if (lookahead == '{') ADVANCE(305);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'I') ADVANCE(118);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(310);
-      if (lookahead != 0) ADVANCE(309);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 120:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'D') ADVANCE(134);
-      if (lookahead == 'U') ADVANCE(135);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'T') ADVANCE(112);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 121:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'F') ADVANCE(123);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'a') ADVANCE(128);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 122:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'I') ADVANCE(121);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'a') ADVANCE(134);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 123:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'T') ADVANCE(115);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'e') ADVANCE(121);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 124:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'a') ADVANCE(131);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'e') ADVANCE(133);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 125:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'a') ADVANCE(137);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'e') ADVANCE(117);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 126:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'e') ADVANCE(124);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'g') ADVANCE(125);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 127:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'e') ADVANCE(136);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'h') ADVANCE(122);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 128:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'e') ADVANCE(120);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'k') ADVANCE(321);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 129:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'g') ADVANCE(128);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'l') ADVANCE(321);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 130:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'h') ADVANCE(125);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'n') ADVANCE(321);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 131:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'k') ADVANCE(334);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'o') ADVANCE(137);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 132:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'l') ADVANCE(334);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'p') ADVANCE(321);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 133:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'n') ADVANCE(334);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'r') ADVANCE(136);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 134:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'o') ADVANCE(140);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'r') ADVANCE(138);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 135:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'p') ADVANCE(334);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 's') ADVANCE(124);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 136:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'r') ADVANCE(139);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 't') ADVANCE(321);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 137:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'r') ADVANCE(141);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'w') ADVANCE(130);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 138:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 's') ADVANCE(127);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '}') ADVANCE(323);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 139:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 't') ADVANCE(334);
+      if (lookahead == '\n') ADVANCE(380);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(141);
+      if (lookahead != 0) ADVANCE(447);
       END_STATE();
     case 140:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'w') ADVANCE(133);
+      if (lookahead == '\n') ADVANCE(380);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 141:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '}') ADVANCE(336);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 142:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(144);
-      if (lookahead != 0) ADVANCE(405);
-      END_STATE();
-    case 143:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
+          lookahead == ' ') ADVANCE(21);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(114);
+          lookahead == 'S') ADVANCE(111);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
-      if (lookahead != 0) ADVANCE(144);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
+      if (lookahead != 0) ADVANCE(141);
+      END_STATE();
+    case 141:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
+      END_STATE();
+    case 142:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(330);
+      if (lookahead != 0) ADVANCE(329);
+      END_STATE();
+    case 143:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(326);
+      if (lookahead != 0) ADVANCE(325);
       END_STATE();
     case 144:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\n') ADVANCE(380);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(318);
+      if (lookahead != 0) ADVANCE(317);
       END_STATE();
     case 145:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(343);
-      if (lookahead != 0) ADVANCE(342);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == '-') ADVANCE(205);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 146:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(339);
-      if (lookahead != 0) ADVANCE(338);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == '-') ADVANCE(182);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 147:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(331);
-      if (lookahead != 0) ADVANCE(330);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == '-') ADVANCE(206);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 148:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == '-') ADVANCE(208);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == ':') ADVANCE(208);
+      if (lookahead == 's') ADVANCE(149);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 149:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == '-') ADVANCE(185);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == ':') ADVANCE(208);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 150:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == '-') ADVANCE(209);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 151:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == ':') ADVANCE(211);
-      if (lookahead == 's') ADVANCE(152);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 152:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == ':') ADVANCE(211);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 153:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'A') ADVANCE(150);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 'A') ADVANCE(147);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
+      END_STATE();
+    case 151:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 'E') ADVANCE(157);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(211);
+      END_STATE();
+    case 152:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 'L') ADVANCE(156);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(211);
+      END_STATE();
+    case 153:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 'L') ADVANCE(146);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 154:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'E') ADVANCE(160);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 'R') ADVANCE(153);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 155:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'L') ADVANCE(159);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 'T') ADVANCE(154);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 156:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'L') ADVANCE(149);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 'T') ADVANCE(145);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 157:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'R') ADVANCE(156);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 'T') ADVANCE(150);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 158:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'T') ADVANCE(157);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 'p') ADVANCE(148);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 159:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'T') ADVANCE(148);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 't') ADVANCE(158);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 160:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'T') ADVANCE(153);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 't') ADVANCE(159);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 161:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'p') ADVANCE(151);
+      if (lookahead == '(') ADVANCE(271);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 162:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 't') ADVANCE(161);
+      if (lookahead == '(') ADVANCE(354);
+      if (lookahead == 'E') ADVANCE(339);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(354);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+          lookahead == '_') ADVANCE(340);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 163:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 't') ADVANCE(162);
+      if (lookahead == '(') ADVANCE(354);
+      if (lookahead == 'L') ADVANCE(338);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(354);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+          lookahead == '_') ADVANCE(340);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 164:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == '(') ADVANCE(354);
+      if (lookahead == 'T') ADVANCE(337);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(354);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+          lookahead == '_') ADVANCE(340);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 165:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == 'E') ADVANCE(352);
+      if (lookahead == '(') ADVANCE(354);
       if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+          lookahead == '.') ADVANCE(354);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
+          lookahead == '_') ADVANCE(340);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 166:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == 'L') ADVANCE(351);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 167:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == 'T') ADVANCE(350);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 168:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 169:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '-') ADVANCE(183);
-      if (lookahead == '>') ADVANCE(295);
+      if (lookahead == '-') ADVANCE(180);
+      if (lookahead == '>') ADVANCE(282);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(179);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
+      END_STATE();
+    case 167:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '-') ADVANCE(207);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(211);
+      END_STATE();
+    case 168:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '=') ADVANCE(93);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(211);
+      END_STATE();
+    case 169:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '=') ADVANCE(168);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 170:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '-') ADVANCE(210);
+      if (lookahead == '=') ADVANCE(169);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 171:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(96);
+      if (lookahead == '=') ADVANCE(170);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 172:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
@@ -2958,7 +2918,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 173:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
@@ -2966,7 +2926,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 174:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
@@ -2974,7 +2934,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 175:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
@@ -2982,7 +2942,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 176:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
@@ -2990,7 +2950,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 177:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
@@ -2998,7 +2958,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 178:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
@@ -3006,304 +2966,280 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 179:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(178);
+      if (lookahead == '>') ADVANCE(282);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(179);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 180:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(179);
+      if (lookahead == '>') ADVANCE(285);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(25);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(179);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != '\n') ADVANCE(181);
       END_STATE();
     case 181:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(180);
+      if (lookahead == '>') ADVANCE(286);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 182:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '>') ADVANCE(295);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
+      if (lookahead == 'B') ADVANCE(314);
+      if (lookahead == 'D') ADVANCE(308);
+      if (lookahead == 'I') ADVANCE(311);
+      if (lookahead == 'P') ADVANCE(303);
+      if (lookahead == 'S') ADVANCE(299);
+      if (lookahead == '{') ADVANCE(305);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(289);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != '\n') ADVANCE(289);
       END_STATE();
     case 183:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '>') ADVANCE(298);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(27);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
+      if (lookahead == 'D') ADVANCE(197);
+      if (lookahead == 'U') ADVANCE(198);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(184);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 184:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '>') ADVANCE(299);
+      if (lookahead == 'F') ADVANCE(186);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 185:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'B') ADVANCE(327);
-      if (lookahead == 'D') ADVANCE(321);
-      if (lookahead == 'I') ADVANCE(324);
-      if (lookahead == 'P') ADVANCE(316);
-      if (lookahead == 'S') ADVANCE(312);
-      if (lookahead == '{') ADVANCE(318);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(302);
+      if (lookahead == 'I') ADVANCE(184);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(302);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 186:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'D') ADVANCE(200);
-      if (lookahead == 'U') ADVANCE(201);
+      if (lookahead == 'T') ADVANCE(167);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 187:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'F') ADVANCE(189);
+      if (lookahead == 'a') ADVANCE(194);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 188:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'I') ADVANCE(187);
+      if (lookahead == 'a') ADVANCE(200);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 189:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'T') ADVANCE(170);
+      if (lookahead == 'e') ADVANCE(187);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 190:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'a') ADVANCE(197);
+      if (lookahead == 'e') ADVANCE(199);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 191:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'a') ADVANCE(203);
+      if (lookahead == 'e') ADVANCE(183);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 192:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'e') ADVANCE(190);
+      if (lookahead == 'g') ADVANCE(191);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 193:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'e') ADVANCE(202);
+      if (lookahead == 'h') ADVANCE(188);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 194:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'e') ADVANCE(186);
+      if (lookahead == 'k') ADVANCE(320);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 195:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'g') ADVANCE(194);
+      if (lookahead == 'l') ADVANCE(320);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 196:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'h') ADVANCE(191);
+      if (lookahead == 'n') ADVANCE(320);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 197:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'k') ADVANCE(333);
+      if (lookahead == 'o') ADVANCE(203);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 198:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'l') ADVANCE(333);
+      if (lookahead == 'p') ADVANCE(320);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 199:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'n') ADVANCE(333);
+      if (lookahead == 'r') ADVANCE(202);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 200:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'o') ADVANCE(206);
+      if (lookahead == 'r') ADVANCE(204);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 201:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'p') ADVANCE(333);
+      if (lookahead == 's') ADVANCE(190);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 202:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'r') ADVANCE(205);
+      if (lookahead == 't') ADVANCE(320);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 203:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'r') ADVANCE(207);
+      if (lookahead == 'w') ADVANCE(196);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 204:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 's') ADVANCE(193);
+      if (lookahead == '}') ADVANCE(322);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
     case 205:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 't') ADVANCE(333);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(328);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != '\n') ADVANCE(328);
       END_STATE();
     case 206:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'w') ADVANCE(199);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(324);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != '\n') ADVANCE(324);
       END_STATE();
     case 207:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '}') ADVANCE(335);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(316);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != '\n') ADVANCE(316);
       END_STATE();
     case 208:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(341);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(341);
-      END_STATE();
-    case 209:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(337);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(337);
-      END_STATE();
-    case 210:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(329);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(329);
-      END_STATE();
-    case 211:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
       if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(214);
+          lookahead == ']') ADVANCE(211);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(406);
+          lookahead != ' ') ADVANCE(448);
       END_STATE();
-    case 212:
+    case 209:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(169);
+          lookahead == 'S') ADVANCE(166);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(179);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
-    case 213:
+    case 210:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
       if (lookahead == '(' ||
           lookahead == ')' ||
@@ -3311,41 +3247,65 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
+          lookahead == '_') ADVANCE(354);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
       END_STATE();
-    case 214:
+    case 211:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ') ADVANCE(211);
+      END_STATE();
+    case 212:
+      ACCEPT_TOKEN(aux_sym_word_noli_token2);
+      if (lookahead == '\n') ADVANCE(382);
+      if (lookahead == '-') ADVANCE(212);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(18);
+      if (lookahead != 0) ADVANCE(224);
+      END_STATE();
+    case 213:
+      ACCEPT_TOKEN(aux_sym_word_noli_token2);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(213);
+      END_STATE();
+    case 214:
+      ACCEPT_TOKEN(aux_sym_word_noli_token2);
+      if (lookahead == '-') ADVANCE(212);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(224);
       END_STATE();
     case 215:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '\n') ADVANCE(396);
-      if (lookahead == '-') ADVANCE(215);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(20);
-      if (lookahead != 0) ADVANCE(227);
+      if (lookahead == '-') ADVANCE(214);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(224);
       END_STATE();
     case 216:
-      ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(216);
-      END_STATE();
-    case 217:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
       if (lookahead == '-') ADVANCE(215);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(227);
+          lookahead != ' ') ADVANCE(224);
+      END_STATE();
+    case 217:
+      ACCEPT_TOKEN(aux_sym_word_noli_token2);
+      if (lookahead == '-') ADVANCE(216);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(224);
       END_STATE();
     case 218:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
@@ -3353,7 +3313,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(227);
+          lookahead != ' ') ADVANCE(224);
       END_STATE();
     case 219:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
@@ -3361,7 +3321,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(227);
+          lookahead != ' ') ADVANCE(224);
       END_STATE();
     case 220:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
@@ -3369,7 +3329,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(227);
+          lookahead != ' ') ADVANCE(224);
       END_STATE();
     case 221:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
@@ -3377,7 +3337,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(227);
+          lookahead != ' ') ADVANCE(224);
       END_STATE();
     case 222:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
@@ -3385,7 +3345,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(227);
+          lookahead != ' ') ADVANCE(224);
       END_STATE();
     case 223:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
@@ -3393,57 +3353,46 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(227);
+          lookahead != ' ') ADVANCE(224);
       END_STATE();
     case 224:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(223);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(227);
+          lookahead != ' ') ADVANCE(224);
       END_STATE();
     case 225:
-      ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(224);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(227);
+      ACCEPT_TOKEN(anon_sym_STAR);
       END_STATE();
     case 226:
-      ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(225);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(227);
+      ACCEPT_TOKEN(anon_sym_STAR);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 227:
-      ACCEPT_TOKEN(aux_sym_word_noli_token2);
+      ACCEPT_TOKEN(anon_sym_STAR);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
+      END_STATE();
+    case 228:
+      ACCEPT_TOKEN(anon_sym_STAR);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(227);
-      END_STATE();
-    case 228:
-      ACCEPT_TOKEN(anon_sym_SQUOTE);
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
       END_STATE();
     case 229:
       ACCEPT_TOKEN(anon_sym_SQUOTE);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
       END_STATE();
     case 230:
       ACCEPT_TOKEN(anon_sym_SQUOTE);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 231:
       ACCEPT_TOKEN(anon_sym_SQUOTE);
@@ -3451,2882 +3400,3296 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '}') ADVANCE(576);
       END_STATE();
     case 232:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 'E') ADVANCE(49);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(240);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(53);
       END_STATE();
     case 233:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '\t') ADVANCE(261);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 'L') ADVANCE(48);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(240);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(53);
       END_STATE();
     case 234:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '\t') ADVANCE(261);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
+      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == 'T') ADVANCE(46);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(240);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(53);
       END_STATE();
     case 235:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'E') ADVANCE(52);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(249);
+      if (lookahead == '(') ADVANCE(271);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(240);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(53);
       END_STATE();
     case 236:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'E') ADVANCE(52);
+      if (lookahead == '(') ADVANCE(242);
+      if (lookahead == 't') ADVANCE(452);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(453);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          lookahead == '_') ADVANCE(240);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '\'') ADVANCE(242);
       END_STATE();
     case 237:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'L') ADVANCE(51);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(249);
+      if (lookahead == '(') ADVANCE(242);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(453);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(240);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '\'') ADVANCE(242);
       END_STATE();
     case 238:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'L') ADVANCE(51);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      END_STATE();
-    case 239:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'T') ADVANCE(49);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(249);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
-      END_STATE();
-    case 240:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'T') ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      END_STATE();
-    case 241:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 't') ADVANCE(410);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(411);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
-      END_STATE();
-    case 242:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(411);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
-      END_STATE();
-    case 243:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(249);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
-      END_STATE();
-    case 244:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      END_STATE();
-    case 245:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(251);
-      if (lookahead == 't') ADVANCE(415);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(416);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(249);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(251);
-      END_STATE();
-    case 246:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(251);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(416);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(249);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(251);
-      END_STATE();
-    case 247:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(61);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(250);
+          lookahead == 'S') ADVANCE(58);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(241);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(63);
+          lookahead == '_') ADVANCE(60);
       END_STATE();
-    case 248:
+    case 239:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
       END_STATE();
-    case 249:
+    case 240:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == '(') ADVANCE(282);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(249);
+      if (lookahead == '(') ADVANCE(271);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(240);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(53);
       END_STATE();
-    case 250:
+    case 241:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == '>') ADVANCE(295);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(250);
+      if (lookahead == '>') ADVANCE(282);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(241);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(63);
+          lookahead == '_') ADVANCE(60);
       END_STATE();
-    case 251:
+    case 242:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
       END_STATE();
-    case 252:
+    case 243:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(252);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(243);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != ')' &&
-          lookahead != ']') ADVANCE(406);
+          lookahead != ']') ADVANCE(448);
       END_STATE();
-    case 253:
+    case 244:
       ACCEPT_TOKEN(anon_sym_SQUOTE2);
       END_STATE();
-    case 254:
+    case 245:
       ACCEPT_TOKEN(aux_sym__word_common_token3);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '|') ADVANCE(254);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '|') ADVANCE(245);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
-    case 255:
+    case 246:
       ACCEPT_TOKEN(aux_sym__word_common_token3);
-      if (lookahead == '|') ADVANCE(255);
+      if (lookahead == '|') ADVANCE(246);
       END_STATE();
-    case 256:
+    case 247:
       ACCEPT_TOKEN(anon_sym_PIPE);
       END_STATE();
-    case 257:
+    case 248:
       ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '|') ADVANCE(254);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '|') ADVANCE(245);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
-    case 258:
+    case 249:
       ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '|') ADVANCE(543);
+      if (lookahead == '|') ADVANCE(246);
+      END_STATE();
+    case 250:
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == '|') ADVANCE(246);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
+      END_STATE();
+    case 251:
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == '|') ADVANCE(568);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          (lookahead < '{' || '}' < lookahead)) ADVANCE(546);
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 252:
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '{') ADVANCE(261);
+      if (lookahead == '}') ADVANCE(260);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
+      END_STATE();
+    case 253:
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      if (lookahead == '{') ADVANCE(263);
+      if (lookahead == '}') ADVANCE(259);
+      END_STATE();
+    case 254:
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      if (lookahead == '{') ADVANCE(263);
+      if (lookahead == '}') ADVANCE(259);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
+      END_STATE();
+    case 255:
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      if (lookahead == '{') ADVANCE(567);
+      if (lookahead == '}') ADVANCE(259);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(576);
+      END_STATE();
+    case 256:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
+      END_STATE();
+    case 257:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
+      END_STATE();
+    case 258:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
       END_STATE();
     case 259:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '|') ADVANCE(255);
+      ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
       END_STATE();
     case 260:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '|') ADVANCE(255);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
+      ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 261:
       ACCEPT_TOKEN(aux_sym__word_common_token4);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '{') ADVANCE(261);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(262);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 262:
       ACCEPT_TOKEN(aux_sym__word_common_token4);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead != 0) ADVANCE(23);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(262);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 263:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '{') ADVANCE(272);
-      if (lookahead == '}') ADVANCE(270);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+      ACCEPT_TOKEN(aux_sym__word_common_token4);
+      if (lookahead == '{') ADVANCE(263);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(264);
       END_STATE();
     case 264:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
-      if (lookahead == '{') ADVANCE(274);
-      if (lookahead == '}') ADVANCE(269);
+      ACCEPT_TOKEN(aux_sym__word_common_token4);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(264);
       END_STATE();
     case 265:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
-      if (lookahead == '{') ADVANCE(274);
-      if (lookahead == '}') ADVANCE(269);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
       END_STATE();
     case 266:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 267:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
       END_STATE();
     case 268:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(354);
       END_STATE();
     case 269:
-      ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(372);
       END_STATE();
     case 270:
-      ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 271:
-      ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 271:
+      ACCEPT_TOKEN(aux_sym__word_common_token5);
       END_STATE();
     case 272:
       ACCEPT_TOKEN(aux_sym__word_common_token5);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '{') ADVANCE(272);
+      if (lookahead == '\n') ADVANCE(380);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(273);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 273:
       ACCEPT_TOKEN(aux_sym__word_common_token5);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(273);
-      if (lookahead != 0) ADVANCE(144);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(372);
       END_STATE();
     case 274:
-      ACCEPT_TOKEN(aux_sym__word_common_token5);
-      if (lookahead == '{') ADVANCE(274);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(275);
+      ACCEPT_TOKEN(anon_sym_TILDE);
       END_STATE();
     case 275:
-      ACCEPT_TOKEN(aux_sym__word_common_token5);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(275);
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 276:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
       END_STATE();
     case 277:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
       END_STATE();
     case 278:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+      ACCEPT_TOKEN(anon_sym_GT);
       END_STATE();
     case 279:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
+      ACCEPT_TOKEN(anon_sym_GT);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 280:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
+      ACCEPT_TOKEN(anon_sym_GT);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
       END_STATE();
     case 281:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
+      ACCEPT_TOKEN(anon_sym_GT);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
       END_STATE();
     case 282:
-      ACCEPT_TOKEN(aux_sym__word_common_token6);
+      ACCEPT_TOKEN(aux_sym_keycode_token1);
       END_STATE();
     case 283:
-      ACCEPT_TOKEN(aux_sym__word_common_token6);
-      if (lookahead == '\n') ADVANCE(394);
+      ACCEPT_TOKEN(aux_sym_keycode_token1);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '>') ADVANCE(287);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 284:
-      ACCEPT_TOKEN(aux_sym__word_common_token6);
+      ACCEPT_TOKEN(aux_sym_keycode_token1);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
+      END_STATE();
+    case 285:
+      ACCEPT_TOKEN(aux_sym_keycode_token1);
+      if (lookahead == '>') ADVANCE(286);
+      END_STATE();
+    case 286:
+      ACCEPT_TOKEN(aux_sym_keycode_token2);
+      END_STATE();
+    case 287:
+      ACCEPT_TOKEN(aux_sym_keycode_token2);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
+      END_STATE();
+    case 288:
+      ACCEPT_TOKEN(aux_sym_keycode_token2);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead != 0) ADVANCE(21);
+      END_STATE();
+    case 289:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      END_STATE();
+    case 290:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'H') ADVANCE(119);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
+      END_STATE();
+    case 291:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'a') ADVANCE(126);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
+      END_STATE();
+    case 292:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'c') ADVANCE(127);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
+      END_STATE();
+    case 293:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'e') ADVANCE(129);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
+      END_STATE();
+    case 294:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'n') ADVANCE(135);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
+      END_STATE();
+    case 295:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == 'r') ADVANCE(123);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
+      END_STATE();
+    case 296:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
+      END_STATE();
+    case 297:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead != 0) ADVANCE(21);
+      END_STATE();
+    case 298:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'H') ADVANCE(66);
+      END_STATE();
+    case 299:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'H') ADVANCE(185);
+      END_STATE();
+    case 300:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'H') ADVANCE(367);
       if (lookahead == '(' ||
           lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      END_STATE();
-    case 285:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      END_STATE();
-    case 286:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 287:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 288:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
-      END_STATE();
-    case 289:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 290:
-      ACCEPT_TOKEN(anon_sym_GT);
-      END_STATE();
-    case 291:
-      ACCEPT_TOKEN(anon_sym_GT);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 292:
-      ACCEPT_TOKEN(anon_sym_GT);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 293:
-      ACCEPT_TOKEN(anon_sym_GT);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
-      END_STATE();
-    case 294:
-      ACCEPT_TOKEN(anon_sym_GT);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 295:
-      ACCEPT_TOKEN(aux_sym_keycode_token1);
-      END_STATE();
-    case 296:
-      ACCEPT_TOKEN(aux_sym_keycode_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '>') ADVANCE(300);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 297:
-      ACCEPT_TOKEN(aux_sym_keycode_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 298:
-      ACCEPT_TOKEN(aux_sym_keycode_token1);
-      if (lookahead == '>') ADVANCE(299);
-      END_STATE();
-    case 299:
-      ACCEPT_TOKEN(aux_sym_keycode_token2);
-      END_STATE();
-    case 300:
-      ACCEPT_TOKEN(aux_sym_keycode_token2);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == '_') ADVANCE(372);
       END_STATE();
     case 301:
-      ACCEPT_TOKEN(aux_sym_keycode_token2);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead != 0) ADVANCE(23);
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'a') ADVANCE(73);
       END_STATE();
     case 302:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'a') ADVANCE(73);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(372);
       END_STATE();
     case 303:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'H') ADVANCE(122);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+      if (lookahead == 'a') ADVANCE(192);
       END_STATE();
     case 304:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'a') ADVANCE(129);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+      if (lookahead == 'c') ADVANCE(74);
       END_STATE();
     case 305:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'c') ADVANCE(130);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+      if (lookahead == 'c') ADVANCE(193);
       END_STATE();
     case 306:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'e') ADVANCE(132);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+      if (lookahead == 'e') ADVANCE(76);
       END_STATE();
     case 307:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'n') ADVANCE(138);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+      if (lookahead == 'e') ADVANCE(76);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(372);
       END_STATE();
     case 308:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'r') ADVANCE(126);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+      if (lookahead == 'e') ADVANCE(195);
       END_STATE();
     case 309:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+      if (lookahead == 'n') ADVANCE(82);
       END_STATE();
     case 310:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead != 0) ADVANCE(23);
+      if (lookahead == 'n') ADVANCE(82);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(372);
       END_STATE();
     case 311:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'H') ADVANCE(69);
+      if (lookahead == 'n') ADVANCE(201);
       END_STATE();
     case 312:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'H') ADVANCE(188);
+      if (lookahead == 'r') ADVANCE(70);
       END_STATE();
     case 313:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'H') ADVANCE(380);
+      if (lookahead == 'r') ADVANCE(70);
       if (lookahead == '(' ||
           lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
+          lookahead == '_') ADVANCE(372);
       END_STATE();
     case 314:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'a') ADVANCE(76);
+      if (lookahead == 'r') ADVANCE(189);
       END_STATE();
     case 315:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'a') ADVANCE(76);
       if (lookahead == '(' ||
           lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
+          lookahead == '_') ADVANCE(372);
       END_STATE();
     case 316:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'a') ADVANCE(195);
+      ACCEPT_TOKEN(aux_sym_keycode_token4);
       END_STATE();
     case 317:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'c') ADVANCE(77);
+      ACCEPT_TOKEN(aux_sym_keycode_token4);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 318:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'c') ADVANCE(196);
+      ACCEPT_TOKEN(aux_sym_keycode_token4);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead != 0) ADVANCE(21);
       END_STATE();
     case 319:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'e') ADVANCE(79);
+      ACCEPT_TOKEN(aux_sym_keycode_token4);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(372);
       END_STATE();
     case 320:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'e') ADVANCE(79);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
+      ACCEPT_TOKEN(aux_sym_keycode_token5);
       END_STATE();
     case 321:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'e') ADVANCE(198);
+      ACCEPT_TOKEN(aux_sym_keycode_token5);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 322:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'n') ADVANCE(85);
+      ACCEPT_TOKEN(anon_sym_CTRL_DASH_LBRACEchar_RBRACE);
       END_STATE();
     case 323:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'n') ADVANCE(85);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
+      ACCEPT_TOKEN(anon_sym_CTRL_DASH_LBRACEchar_RBRACE);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 324:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'n') ADVANCE(204);
+      ACCEPT_TOKEN(aux_sym_keycode_token6);
       END_STATE();
     case 325:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'r') ADVANCE(73);
+      ACCEPT_TOKEN(aux_sym_keycode_token6);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 326:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'r') ADVANCE(73);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
+      ACCEPT_TOKEN(aux_sym_keycode_token6);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead != 0) ADVANCE(21);
       END_STATE();
     case 327:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'r') ADVANCE(192);
+      ACCEPT_TOKEN(aux_sym_keycode_token6);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(372);
       END_STATE();
     case 328:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
+      ACCEPT_TOKEN(aux_sym_keycode_token7);
       END_STATE();
     case 329:
-      ACCEPT_TOKEN(aux_sym_keycode_token4);
+      ACCEPT_TOKEN(aux_sym_keycode_token7);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
     case 330:
-      ACCEPT_TOKEN(aux_sym_keycode_token4);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+      ACCEPT_TOKEN(aux_sym_keycode_token7);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead != 0) ADVANCE(21);
       END_STATE();
     case 331:
-      ACCEPT_TOKEN(aux_sym_keycode_token4);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead != 0) ADVANCE(23);
+      ACCEPT_TOKEN(aux_sym_keycode_token7);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(372);
       END_STATE();
     case 332:
-      ACCEPT_TOKEN(aux_sym_keycode_token4);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(354);
+      if (lookahead == '-') ADVANCE(351);
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(354);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
+          lookahead == '_') ADVANCE(340);
       END_STATE();
     case 333:
-      ACCEPT_TOKEN(aux_sym_keycode_token5);
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(354);
+      if (lookahead == '-') ADVANCE(342);
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(354);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(340);
       END_STATE();
     case 334:
-      ACCEPT_TOKEN(aux_sym_keycode_token5);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(354);
+      if (lookahead == '-') ADVANCE(352);
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(354);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(340);
       END_STATE();
     case 335:
-      ACCEPT_TOKEN(aux_sym_keycode_token6);
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(354);
+      if (lookahead == 'A') ADVANCE(334);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(354);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(340);
       END_STATE();
     case 336:
-      ACCEPT_TOKEN(aux_sym_keycode_token6);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(354);
+      if (lookahead == 'L') ADVANCE(333);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(354);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(340);
       END_STATE();
     case 337:
-      ACCEPT_TOKEN(aux_sym_keycode_token7);
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(354);
+      if (lookahead == 'R') ADVANCE(336);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(354);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(340);
       END_STATE();
     case 338:
-      ACCEPT_TOKEN(aux_sym_keycode_token7);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(354);
+      if (lookahead == 'T') ADVANCE(332);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(354);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(340);
       END_STATE();
     case 339:
-      ACCEPT_TOKEN(aux_sym_keycode_token7);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead != 0) ADVANCE(23);
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(354);
+      if (lookahead == 'T') ADVANCE(335);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(354);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(340);
       END_STATE();
     case 340:
-      ACCEPT_TOKEN(aux_sym_keycode_token7);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(354);
+      if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.') ADVANCE(354);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
+          lookahead == '_') ADVANCE(340);
       END_STATE();
     case 341:
-      ACCEPT_TOKEN(aux_sym_keycode_token8);
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '-') ADVANCE(353);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(354);
       END_STATE();
     case 342:
-      ACCEPT_TOKEN(aux_sym_keycode_token8);
-      if (lookahead == '\n') ADVANCE(394);
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == 'B') ADVANCE(350);
+      if (lookahead == 'D') ADVANCE(348);
+      if (lookahead == 'I') ADVANCE(349);
+      if (lookahead == 'P') ADVANCE(347);
+      if (lookahead == 'S') ADVANCE(344);
+      if (lookahead == '{') ADVANCE(305);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 343:
-      ACCEPT_TOKEN(aux_sym_keycode_token8);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead != 0) ADVANCE(23);
-      END_STATE();
-    case 344:
-      ACCEPT_TOKEN(aux_sym_keycode_token8);
+          lookahead == ' ') ADVANCE(289);
       if (lookahead == '(' ||
           lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
+          lookahead == '_') ADVANCE(354);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(289);
+      END_STATE();
+    case 343:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == 'F') ADVANCE(346);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(354);
+      END_STATE();
+    case 344:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == 'H') ADVANCE(345);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(354);
       END_STATE();
     case 345:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == '-') ADVANCE(364);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'I') ADVANCE(343);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
+          lookahead == '_') ADVANCE(354);
       END_STATE();
     case 346:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == '-') ADVANCE(355);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'T') ADVANCE(341);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
+          lookahead == '_') ADVANCE(354);
       END_STATE();
     case 347:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == '-') ADVANCE(365);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'a') ADVANCE(192);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
+          lookahead == '_') ADVANCE(354);
       END_STATE();
     case 348:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == 'A') ADVANCE(347);
-      if (lookahead == ')' ||
+      if (lookahead == 'e') ADVANCE(195);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(354);
       END_STATE();
     case 349:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == 'L') ADVANCE(346);
-      if (lookahead == ')' ||
+      if (lookahead == 'n') ADVANCE(201);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
+          lookahead == '_') ADVANCE(354);
       END_STATE();
     case 350:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == 'R') ADVANCE(349);
-      if (lookahead == ')' ||
+      if (lookahead == 'r') ADVANCE(189);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
+          lookahead == '_') ADVANCE(354);
       END_STATE();
     case 351:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == 'T') ADVANCE(345);
-      if (lookahead == ')' ||
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(328);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
+          lookahead == '_') ADVANCE(354);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(328);
       END_STATE();
     case 352:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == 'T') ADVANCE(348);
-      if (lookahead == ')' ||
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(324);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
+          lookahead == '_') ADVANCE(354);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(324);
       END_STATE();
     case 353:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == ')' ||
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(316);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
+          lookahead == '_') ADVANCE(354);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(316);
       END_STATE();
     case 354:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '-') ADVANCE(366);
       if (lookahead == '(' ||
           lookahead == ')' ||
+          lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
+          lookahead == '_') ADVANCE(354);
       END_STATE();
     case 355:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'B') ADVANCE(363);
-      if (lookahead == 'D') ADVANCE(361);
-      if (lookahead == 'I') ADVANCE(362);
-      if (lookahead == 'P') ADVANCE(360);
-      if (lookahead == 'S') ADVANCE(357);
-      if (lookahead == '{') ADVANCE(318);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(302);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(273);
+      if (lookahead == '-') ADVANCE(369);
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(372);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(302);
+          lookahead == '_') ADVANCE(363);
       END_STATE();
     case 356:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'F') ADVANCE(359);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(273);
+      if (lookahead == '-') ADVANCE(365);
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(372);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
+          lookahead == '_') ADVANCE(363);
       END_STATE();
     case 357:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'H') ADVANCE(358);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(273);
+      if (lookahead == '-') ADVANCE(370);
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(372);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
+          lookahead == '_') ADVANCE(363);
       END_STATE();
     case 358:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'I') ADVANCE(356);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(273);
+      if (lookahead == 'A') ADVANCE(357);
+      if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
+          lookahead == '.') ADVANCE(372);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(363);
       END_STATE();
     case 359:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'T') ADVANCE(354);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(273);
+      if (lookahead == 'L') ADVANCE(356);
+      if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.') ADVANCE(372);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
+          lookahead == '_') ADVANCE(363);
       END_STATE();
     case 360:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'a') ADVANCE(195);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(273);
+      if (lookahead == 'R') ADVANCE(359);
+      if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.') ADVANCE(372);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
+          lookahead == '_') ADVANCE(363);
       END_STATE();
     case 361:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'e') ADVANCE(198);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(273);
+      if (lookahead == 'T') ADVANCE(355);
+      if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.') ADVANCE(372);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
+          lookahead == '_') ADVANCE(363);
       END_STATE();
     case 362:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'n') ADVANCE(204);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(273);
+      if (lookahead == 'T') ADVANCE(358);
+      if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.') ADVANCE(372);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
+          lookahead == '_') ADVANCE(363);
       END_STATE();
     case 363:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'r') ADVANCE(192);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(273);
+      if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.') ADVANCE(372);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
+          lookahead == '_') ADVANCE(363);
       END_STATE();
     case 364:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(341);
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '-') ADVANCE(371);
       if (lookahead == '(' ||
           lookahead == ')' ||
-          lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(341);
+          lookahead == '_') ADVANCE(372);
       END_STATE();
     case 365:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == 'B') ADVANCE(313);
+      if (lookahead == 'D') ADVANCE(307);
+      if (lookahead == 'I') ADVANCE(310);
+      if (lookahead == 'P') ADVANCE(302);
+      if (lookahead == 'S') ADVANCE(300);
+      if (lookahead == '{') ADVANCE(304);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(337);
+          lookahead == ' ') ADVANCE(289);
       if (lookahead == '(' ||
           lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
+          lookahead == '_') ADVANCE(315);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(337);
+          lookahead != '\n') ADVANCE(289);
       END_STATE();
     case 366:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(329);
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == 'F') ADVANCE(368);
       if (lookahead == '(' ||
           lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(329);
+          lookahead == '_') ADVANCE(372);
       END_STATE();
     case 367:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == 'I') ADVANCE(366);
       if (lookahead == '(' ||
           lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
+          lookahead == '_') ADVANCE(372);
       END_STATE();
     case 368:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == '-') ADVANCE(382);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'T') ADVANCE(364);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
+          lookahead == '_') ADVANCE(372);
       END_STATE();
     case 369:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == '-') ADVANCE(378);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(328);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
+          lookahead == '_') ADVANCE(331);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(328);
       END_STATE();
     case 370:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == '-') ADVANCE(383);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(324);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
+          lookahead == '_') ADVANCE(327);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(324);
       END_STATE();
     case 371:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == 'A') ADVANCE(370);
-      if (lookahead == ')' ||
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(316);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(319);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(316);
       END_STATE();
     case 372:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == 'L') ADVANCE(369);
-      if (lookahead == ')' ||
+      if (lookahead == '(' ||
+          lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
+          lookahead == '_') ADVANCE(372);
       END_STATE();
     case 373:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == 'R') ADVANCE(372);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_LT);
       END_STATE();
     case 374:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == 'T') ADVANCE(368);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_LT);
+      if (lookahead == 'A' ||
+          lookahead == 'C' ||
+          lookahead == 'D' ||
+          lookahead == 'M' ||
+          lookahead == 'S') ADVANCE(166);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(179);
       END_STATE();
     case 375:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == 'T') ADVANCE(371);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
-      END_STATE();
-    case 376:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
-      END_STATE();
-    case 377:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '-') ADVANCE(384);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      END_STATE();
-    case 378:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == 'B') ADVANCE(326);
-      if (lookahead == 'D') ADVANCE(320);
-      if (lookahead == 'I') ADVANCE(323);
-      if (lookahead == 'P') ADVANCE(315);
-      if (lookahead == 'S') ADVANCE(313);
-      if (lookahead == '{') ADVANCE(317);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(302);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(328);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(302);
-      END_STATE();
-    case 379:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == 'F') ADVANCE(381);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      END_STATE();
-    case 380:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == 'I') ADVANCE(379);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      END_STATE();
-    case 381:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == 'T') ADVANCE(377);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      END_STATE();
-    case 382:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(341);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(344);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(341);
-      END_STATE();
-    case 383:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(337);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(340);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(337);
-      END_STATE();
-    case 384:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(329);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(332);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(329);
-      END_STATE();
-    case 385:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      END_STATE();
-    case 386:
-      ACCEPT_TOKEN(anon_sym_LT);
-      END_STATE();
-    case 387:
-      ACCEPT_TOKEN(anon_sym_LT);
-      if (lookahead == 'A' ||
-          lookahead == 'C' ||
-          lookahead == 'D' ||
-          lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(61);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(63);
-      END_STATE();
-    case 388:
-      ACCEPT_TOKEN(anon_sym_LT);
-      if (lookahead == 'A' ||
-          lookahead == 'C' ||
-          lookahead == 'D' ||
-          lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(169);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
-      END_STATE();
-    case 389:
       ACCEPT_TOKEN(aux_sym_codeblock_token1);
       END_STATE();
-    case 390:
+    case 376:
       ACCEPT_TOKEN(anon_sym_LF);
       END_STATE();
-    case 391:
+    case 377:
       ACCEPT_TOKEN(anon_sym_LF2);
       END_STATE();
-    case 392:
+    case 378:
       ACCEPT_TOKEN(aux_sym_line_li_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == ' ') ADVANCE(392);
-      if (lookahead != 0) ADVANCE(23);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == ' ') ADVANCE(378);
+      if (lookahead != 0) ADVANCE(21);
       END_STATE();
-    case 393:
+    case 379:
       ACCEPT_TOKEN(aux_sym_line_li_token1);
-      if (lookahead == ' ') ADVANCE(393);
+      if (lookahead == ' ') ADVANCE(379);
       END_STATE();
-    case 394:
+    case 380:
       ACCEPT_TOKEN(aux_sym_line_code_token1);
       END_STATE();
-    case 395:
+    case 381:
       ACCEPT_TOKEN(aux_sym_h1_token1);
       END_STATE();
-    case 396:
+    case 382:
       ACCEPT_TOKEN(aux_sym_h2_token1);
       END_STATE();
-    case 397:
-      ACCEPT_TOKEN(anon_sym_STAR);
-      END_STATE();
-    case 398:
-      ACCEPT_TOKEN(anon_sym_STAR);
-      if (lookahead == '\t') ADVANCE(23);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == ' ') ADVANCE(392);
-      if (lookahead != 0) ADVANCE(216);
-      END_STATE();
-    case 399:
-      ACCEPT_TOKEN(anon_sym_STAR);
-      if (lookahead == ' ') ADVANCE(393);
-      END_STATE();
-    case 400:
-      ACCEPT_TOKEN(anon_sym_STAR);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 401:
-      ACCEPT_TOKEN(anon_sym_STAR);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
-      END_STATE();
-    case 402:
-      ACCEPT_TOKEN(anon_sym_STAR);
+    case 383:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(') ADVANCE(445);
+      if (lookahead == '-') ADVANCE(445);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 384:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(') ADVANCE(445);
+      if (lookahead == '-') ADVANCE(410);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 385:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(') ADVANCE(445);
+      if (lookahead == ':') ADVANCE(442);
+      if (lookahead == 's') ADVANCE(387);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(403);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(404);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 386:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(') ADVANCE(445);
+      if (lookahead == ':') ADVANCE(442);
+      if (lookahead == 's') ADVANCE(388);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 387:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(') ADVANCE(445);
+      if (lookahead == ':') ADVANCE(442);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(403);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(404);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 388:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(') ADVANCE(445);
+      if (lookahead == ':') ADVANCE(442);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 389:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(') ADVANCE(445);
+      if (lookahead == 'A') ADVANCE(383);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 390:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(') ADVANCE(445);
+      if (lookahead == 'E') ADVANCE(396);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 391:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(') ADVANCE(445);
+      if (lookahead == 'L') ADVANCE(395);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 392:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(') ADVANCE(445);
+      if (lookahead == 'L') ADVANCE(384);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 393:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(') ADVANCE(445);
+      if (lookahead == 'R') ADVANCE(392);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 394:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(') ADVANCE(445);
+      if (lookahead == 'T') ADVANCE(393);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 395:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(') ADVANCE(445);
+      if (lookahead == 'T') ADVANCE(383);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 396:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(') ADVANCE(445);
+      if (lookahead == 'T') ADVANCE(389);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 397:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(') ADVANCE(445);
+      if (lookahead == 'p') ADVANCE(385);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(403);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(404);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 398:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(') ADVANCE(445);
+      if (lookahead == 'p') ADVANCE(386);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 399:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(') ADVANCE(445);
+      if (lookahead == 't') ADVANCE(397);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(403);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(404);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 400:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(') ADVANCE(445);
+      if (lookahead == 't') ADVANCE(398);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 401:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(') ADVANCE(445);
+      if (lookahead == 't') ADVANCE(399);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(403);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(404);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 402:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(') ADVANCE(445);
+      if (lookahead == 't') ADVANCE(400);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
       END_STATE();
     case 403:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(') ADVANCE(445);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(403);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(404);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 404:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(') ADVANCE(445);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 405:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '-') ADVANCE(445);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 406:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '-') ADVANCE(409);
+      if (lookahead == '>') ADVANCE(445);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(407);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 407:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '>') ADVANCE(445);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(407);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 408:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '>') ADVANCE(445);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 409:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '>') ADVANCE(408);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(407);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(408);
+      END_STATE();
+    case 410:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'B') ADVANCE(434);
+      if (lookahead == 'D') ADVANCE(420);
+      if (lookahead == 'I') ADVANCE(429);
+      if (lookahead == 'P') ADVANCE(416);
+      if (lookahead == 'S') ADVANCE(413);
+      if (lookahead == '{') ADVANCE(419);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 411:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'D') ADVANCE(430);
+      if (lookahead == 'U') ADVANCE(431);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 412:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'F') ADVANCE(415);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 413:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'H') ADVANCE(414);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 414:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'I') ADVANCE(412);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 415:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'T') ADVANCE(405);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 416:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'a') ADVANCE(424);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 417:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'a') ADVANCE(426);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 418:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'a') ADVANCE(433);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 419:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'c') ADVANCE(425);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 420:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'e') ADVANCE(427);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 421:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'e') ADVANCE(411);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 422:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'e') ADVANCE(432);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 423:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'e') ADVANCE(417);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 424:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'g') ADVANCE(421);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 425:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'h') ADVANCE(418);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 426:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'k') ADVANCE(445);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 427:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'l') ADVANCE(445);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 428:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'n') ADVANCE(445);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 429:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'n') ADVANCE(435);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 430:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'o') ADVANCE(437);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 431:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'p') ADVANCE(445);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 432:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'r') ADVANCE(436);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 433:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'r') ADVANCE(441);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 434:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'r') ADVANCE(423);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 435:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 's') ADVANCE(422);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 436:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 't') ADVANCE(445);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 437:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'w') ADVANCE(428);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 438:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '{') ADVANCE(439);
+      if (lookahead == '}') ADVANCE(445);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 439:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '{') ADVANCE(439);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(444);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 440:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '|') ADVANCE(440);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 441:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '}') ADVANCE(445);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 442:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(445);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(442);
+      END_STATE();
+    case 443:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'A' ||
+          lookahead == 'C' ||
+          lookahead == 'D' ||
+          lookahead == 'M' ||
+          lookahead == 'S') ADVANCE(406);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(407);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 444:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(444);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(445);
+      END_STATE();
+    case 445:
       ACCEPT_TOKEN(aux_sym_tag_token1);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(403);
+          lookahead != '*') ADVANCE(445);
       END_STATE();
-    case 404:
+    case 446:
       ACCEPT_TOKEN(anon_sym_STAR2);
       END_STATE();
-    case 405:
+    case 447:
       ACCEPT_TOKEN(sym_url_word);
-      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\n') ADVANCE(380);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
+          lookahead == ' ') ADVANCE(21);
       if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(144);
-      if (lookahead != 0) ADVANCE(405);
+          lookahead == ']') ADVANCE(141);
+      if (lookahead != 0) ADVANCE(447);
       END_STATE();
-    case 406:
+    case 448:
       ACCEPT_TOKEN(sym_url_word);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != ')' &&
-          lookahead != ']') ADVANCE(406);
-      END_STATE();
-    case 407:
-      ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == ':') ADVANCE(92);
-      if (lookahead == 's') ADVANCE(408);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(411);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
-      END_STATE();
-    case 408:
-      ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == ':') ADVANCE(92);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(411);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
-      END_STATE();
-    case 409:
-      ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'p') ADVANCE(407);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(411);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
-      END_STATE();
-    case 410:
-      ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 't') ADVANCE(409);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(411);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
-      END_STATE();
-    case 411:
-      ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(411);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
-      END_STATE();
-    case 412:
-      ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(251);
-      if (lookahead == ':') ADVANCE(252);
-      if (lookahead == 's') ADVANCE(413);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(416);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(249);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(251);
-      END_STATE();
-    case 413:
-      ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(251);
-      if (lookahead == ':') ADVANCE(252);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(416);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(249);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(251);
-      END_STATE();
-    case 414:
-      ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(251);
-      if (lookahead == 'p') ADVANCE(412);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(416);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(249);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(251);
-      END_STATE();
-    case 415:
-      ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(251);
-      if (lookahead == 't') ADVANCE(414);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(416);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(249);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(251);
-      END_STATE();
-    case 416:
-      ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(251);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(416);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(249);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(251);
-      END_STATE();
-    case 417:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '\t') ADVANCE(261);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 418:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == '-') ADVANCE(469);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 419:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == '-') ADVANCE(440);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 420:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == '-') ADVANCE(470);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 421:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == ':') ADVANCE(471);
-      if (lookahead == 's') ADVANCE(422);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 422:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == ':') ADVANCE(471);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 423:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == 'A') ADVANCE(420);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 424:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == 'E') ADVANCE(430);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 425:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == 'L') ADVANCE(429);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 426:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == 'L') ADVANCE(419);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 427:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == 'R') ADVANCE(426);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 428:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == 'T') ADVANCE(427);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 429:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == 'T') ADVANCE(418);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 430:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == 'T') ADVANCE(423);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 431:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == 'p') ADVANCE(421);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 432:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == 't') ADVANCE(431);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 433:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == 't') ADVANCE(432);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 434:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 435:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '-') ADVANCE(439);
-      if (lookahead == '>') ADVANCE(476);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(437);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 436:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '-') ADVANCE(472);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 437:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '>') ADVANCE(476);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(437);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 438:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '>') ADVANCE(476);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 439:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '>') ADVANCE(438);
-      if (lookahead == '|') ADVANCE(65);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(27);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(437);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(438);
-      END_STATE();
-    case 440:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'B') ADVANCE(464);
-      if (lookahead == 'D') ADVANCE(450);
-      if (lookahead == 'I') ADVANCE(459);
-      if (lookahead == 'P') ADVANCE(446);
-      if (lookahead == 'S') ADVANCE(443);
-      if (lookahead == '{') ADVANCE(449);
-      if (lookahead == '|') ADVANCE(302);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(302);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(476);
-      END_STATE();
-    case 441:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'D') ADVANCE(460);
-      if (lookahead == 'U') ADVANCE(461);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 442:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'F') ADVANCE(445);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 443:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'H') ADVANCE(444);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 444:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'I') ADVANCE(442);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 445:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'T') ADVANCE(436);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 446:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'a') ADVANCE(454);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 447:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'a') ADVANCE(456);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 448:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'a') ADVANCE(463);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != ']') ADVANCE(448);
       END_STATE();
     case 449:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'c') ADVANCE(455);
+      ACCEPT_TOKEN(aux_sym_optionlink_token1);
+      if (lookahead == '(') ADVANCE(242);
+      if (lookahead == ':') ADVANCE(243);
+      if (lookahead == 's') ADVANCE(450);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(453);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(240);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '\'') ADVANCE(242);
       END_STATE();
     case 450:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'e') ADVANCE(457);
+      ACCEPT_TOKEN(aux_sym_optionlink_token1);
+      if (lookahead == '(') ADVANCE(242);
+      if (lookahead == ':') ADVANCE(243);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(453);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(240);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '\'') ADVANCE(242);
       END_STATE();
     case 451:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'e') ADVANCE(441);
+      ACCEPT_TOKEN(aux_sym_optionlink_token1);
+      if (lookahead == '(') ADVANCE(242);
+      if (lookahead == 'p') ADVANCE(449);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(453);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(240);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '\'') ADVANCE(242);
       END_STATE();
     case 452:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'e') ADVANCE(462);
+      ACCEPT_TOKEN(aux_sym_optionlink_token1);
+      if (lookahead == '(') ADVANCE(242);
+      if (lookahead == 't') ADVANCE(451);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(453);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(240);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '\'') ADVANCE(242);
       END_STATE();
     case 453:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'e') ADVANCE(447);
+      ACCEPT_TOKEN(aux_sym_optionlink_token1);
+      if (lookahead == '(') ADVANCE(242);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(453);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(240);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '\'') ADVANCE(242);
       END_STATE();
     case 454:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'g') ADVANCE(451);
+      if (lookahead == '(') ADVANCE(509);
+      if (lookahead == '-') ADVANCE(509);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(509);
       END_STATE();
     case 455:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'h') ADVANCE(448);
+      if (lookahead == '(') ADVANCE(509);
+      if (lookahead == '-') ADVANCE(475);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(509);
       END_STATE();
     case 456:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'k') ADVANCE(476);
+      if (lookahead == '(') ADVANCE(509);
+      if (lookahead == ':') ADVANCE(506);
+      if (lookahead == 's') ADVANCE(457);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(509);
       END_STATE();
     case 457:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'l') ADVANCE(476);
+      if (lookahead == '(') ADVANCE(509);
+      if (lookahead == ':') ADVANCE(506);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(509);
       END_STATE();
     case 458:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'n') ADVANCE(476);
+      if (lookahead == '(') ADVANCE(509);
+      if (lookahead == 'A') ADVANCE(454);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(509);
       END_STATE();
     case 459:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'n') ADVANCE(465);
+      if (lookahead == '(') ADVANCE(509);
+      if (lookahead == 'E') ADVANCE(465);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(509);
       END_STATE();
     case 460:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'o') ADVANCE(467);
+      if (lookahead == '(') ADVANCE(509);
+      if (lookahead == 'L') ADVANCE(464);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(509);
       END_STATE();
     case 461:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'p') ADVANCE(476);
+      if (lookahead == '(') ADVANCE(509);
+      if (lookahead == 'L') ADVANCE(455);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(509);
       END_STATE();
     case 462:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'r') ADVANCE(466);
+      if (lookahead == '(') ADVANCE(509);
+      if (lookahead == 'R') ADVANCE(461);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(509);
       END_STATE();
     case 463:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'r') ADVANCE(473);
+      if (lookahead == '(') ADVANCE(509);
+      if (lookahead == 'T') ADVANCE(462);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(509);
       END_STATE();
     case 464:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'r') ADVANCE(453);
+      if (lookahead == '(') ADVANCE(509);
+      if (lookahead == 'T') ADVANCE(454);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(509);
       END_STATE();
     case 465:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 's') ADVANCE(452);
+      if (lookahead == '(') ADVANCE(509);
+      if (lookahead == 'T') ADVANCE(458);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(509);
       END_STATE();
     case 466:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 't') ADVANCE(476);
+      if (lookahead == '(') ADVANCE(509);
+      if (lookahead == 'p') ADVANCE(456);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(509);
       END_STATE();
     case 467:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'w') ADVANCE(458);
+      if (lookahead == '(') ADVANCE(509);
+      if (lookahead == 't') ADVANCE(466);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(509);
       END_STATE();
     case 468:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '{') ADVANCE(468);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(475);
+      if (lookahead == '(') ADVANCE(509);
+      if (lookahead == 't') ADVANCE(467);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(509);
       END_STATE();
     case 469:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '|') ADVANCE(341);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(341);
+      if (lookahead == '(') ADVANCE(509);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(476);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
       END_STATE();
     case 470:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '|') ADVANCE(337);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(337);
+      if (lookahead == '-') ADVANCE(509);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(476);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
       END_STATE();
     case 471:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '|') ADVANCE(406);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(476);
+      if (lookahead == '-') ADVANCE(474);
+      if (lookahead == '>') ADVANCE(509);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(472);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(471);
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
       END_STATE();
     case 472:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '|') ADVANCE(329);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(329);
+      if (lookahead == '>') ADVANCE(509);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(472);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(476);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
       END_STATE();
     case 473:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '}') ADVANCE(476);
+      if (lookahead == '>') ADVANCE(509);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(509);
       END_STATE();
     case 474:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'A' ||
-          lookahead == 'C' ||
-          lookahead == 'D' ||
-          lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(435);
+      if (lookahead == '>') ADVANCE(473);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(437);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(472);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(473);
       END_STATE();
     case 475:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(475);
+      if (lookahead == 'B') ADVANCE(499);
+      if (lookahead == 'D') ADVANCE(485);
+      if (lookahead == 'I') ADVANCE(494);
+      if (lookahead == 'P') ADVANCE(481);
+      if (lookahead == 'S') ADVANCE(478);
+      if (lookahead == '{') ADVANCE(484);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(509);
       END_STATE();
     case 476:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'D') ADVANCE(495);
+      if (lookahead == 'U') ADVANCE(496);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 477:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'F') ADVANCE(480);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 478:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'H') ADVANCE(479);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 479:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'I') ADVANCE(477);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 480:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'T') ADVANCE(470);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 481:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'a') ADVANCE(489);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 482:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'a') ADVANCE(491);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 483:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'a') ADVANCE(498);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 484:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'c') ADVANCE(490);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 485:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'e') ADVANCE(492);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 486:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'e') ADVANCE(476);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 487:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'e') ADVANCE(497);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 488:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'e') ADVANCE(482);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 489:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'g') ADVANCE(486);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 490:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'h') ADVANCE(483);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 491:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'k') ADVANCE(509);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 492:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'l') ADVANCE(509);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 493:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'n') ADVANCE(509);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 494:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'n') ADVANCE(500);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 495:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'o') ADVANCE(502);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 496:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'p') ADVANCE(509);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 497:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'r') ADVANCE(501);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 498:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'r') ADVANCE(505);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 499:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'r') ADVANCE(488);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 500:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 's') ADVANCE(487);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 501:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 't') ADVANCE(509);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 502:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'w') ADVANCE(493);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 503:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '{') ADVANCE(504);
+      if (lookahead == '}') ADVANCE(509);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 504:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '{') ADVANCE(504);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(508);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 505:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '}') ADVANCE(509);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 506:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(509);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(506);
+      END_STATE();
+    case 507:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'A' ||
+          lookahead == 'C' ||
+          lookahead == 'D' ||
+          lookahead == 'M' ||
+          lookahead == 'S') ADVANCE(471);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(472);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 508:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(508);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(509);
+      END_STATE();
+    case 509:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(509);
       END_STATE();
-    case 477:
-      ACCEPT_TOKEN(anon_sym_LBRACE2);
-      if (lookahead == '{') ADVANCE(274);
-      if (lookahead == '}') ADVANCE(269);
-      END_STATE();
-    case 478:
-      ACCEPT_TOKEN(anon_sym_LBRACE2);
-      if (lookahead == '{') ADVANCE(468);
-      if (lookahead == '}') ADVANCE(271);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 479:
-      ACCEPT_TOKEN(anon_sym_RBRACE2);
-      END_STATE();
-    case 480:
-      ACCEPT_TOKEN(anon_sym_RBRACE2);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 481:
-      ACCEPT_TOKEN(anon_sym_LPAREN2);
-      END_STATE();
-    case 482:
-      ACCEPT_TOKEN(anon_sym_LPAREN2);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 483:
-      ACCEPT_TOKEN(anon_sym_RPAREN);
-      END_STATE();
-    case 484:
-      ACCEPT_TOKEN(anon_sym_RPAREN);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 485:
-      ACCEPT_TOKEN(anon_sym_BQUOTE);
-      END_STATE();
-    case 486:
-      ACCEPT_TOKEN(anon_sym_BQUOTE);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 487:
+    case 510:
       ACCEPT_TOKEN(anon_sym_PIPE2);
       END_STATE();
-    case 488:
-      ACCEPT_TOKEN(anon_sym_BQUOTE2);
+    case 511:
+      ACCEPT_TOKEN(anon_sym_BQUOTE);
       END_STATE();
-    case 489:
-      ACCEPT_TOKEN(anon_sym_BQUOTE2);
-      if (lookahead == '\n') ADVANCE(394);
+    case 512:
+      ACCEPT_TOKEN(anon_sym_BQUOTE);
+      if (lookahead == '\n') ADVANCE(380);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(141);
       END_STATE();
-    case 490:
-      ACCEPT_TOKEN(anon_sym_BQUOTE2);
-      if (lookahead == ' ') ADVANCE(548);
+    case 513:
+      ACCEPT_TOKEN(anon_sym_BQUOTE);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
+      END_STATE();
+    case 514:
+      ACCEPT_TOKEN(anon_sym_BQUOTE);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
       END_STATE();
-    case 491:
-      ACCEPT_TOKEN(anon_sym_BQUOTE2);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
-      END_STATE();
-    case 492:
+    case 515:
       ACCEPT_TOKEN(aux_sym_codespan_token1);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '`') ADVANCE(492);
-      END_STATE();
-    case 493:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '\t') ADVANCE(261);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 494:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '\t') ADVANCE(27);
-      if (lookahead == ' ') ADVANCE(547);
-      if (lookahead == '>') ADVANCE(519);
-      if (lookahead == '{' ||
-          lookahead == '}') ADVANCE(65);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(518);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(519);
-      END_STATE();
-    case 495:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '\t') ADVANCE(341);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '{' ||
-          lookahead == '}') ADVANCE(341);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(546);
-      END_STATE();
-    case 496:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '\t') ADVANCE(302);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'B') ADVANCE(539);
-      if (lookahead == 'D') ADVANCE(527);
-      if (lookahead == 'I') ADVANCE(535);
-      if (lookahead == 'P') ADVANCE(525);
-      if (lookahead == 'S') ADVANCE(522);
-      if (lookahead == '{') ADVANCE(317);
-      if (lookahead == '}') ADVANCE(302);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(546);
-      END_STATE();
-    case 497:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '\t') ADVANCE(337);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '{' ||
-          lookahead == '}') ADVANCE(337);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(546);
-      END_STATE();
-    case 498:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '\t') ADVANCE(329);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '{' ||
-          lookahead == '}') ADVANCE(329);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(546);
-      END_STATE();
-    case 499:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == '-') ADVANCE(495);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 500:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == '-') ADVANCE(496);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 501:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == '-') ADVANCE(497);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 502:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == ':') ADVANCE(544);
-      if (lookahead == 's') ADVANCE(503);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 503:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == ':') ADVANCE(544);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 504:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == 'A') ADVANCE(501);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 505:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == 'E') ADVANCE(511);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 506:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == 'L') ADVANCE(510);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 507:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == 'L') ADVANCE(500);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 508:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == 'R') ADVANCE(507);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 509:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == 'T') ADVANCE(508);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 510:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == 'T') ADVANCE(499);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 511:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == 'T') ADVANCE(504);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 512:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == 'p') ADVANCE(502);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 513:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == 't') ADVANCE(512);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 514:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == 't') ADVANCE(513);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 515:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '`') ADVANCE(515);
       END_STATE();
     case 516:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '-') ADVANCE(494);
-      if (lookahead == '>') ADVANCE(546);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(518);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+      ACCEPT_TOKEN(anon_sym_BQUOTE2);
       END_STATE();
     case 517:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '-') ADVANCE(498);
+      if (lookahead == '(') ADVANCE(576);
+      if (lookahead == '-') ADVANCE(569);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
       END_STATE();
     case 518:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '>') ADVANCE(546);
+      if (lookahead == '(') ADVANCE(576);
+      if (lookahead == '-') ADVANCE(539);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 519:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '(') ADVANCE(576);
+      if (lookahead == '-') ADVANCE(570);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 520:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '(') ADVANCE(576);
+      if (lookahead == ':') ADVANCE(571);
+      if (lookahead == 's') ADVANCE(521);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 521:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '(') ADVANCE(576);
+      if (lookahead == ':') ADVANCE(571);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 522:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '(') ADVANCE(576);
+      if (lookahead == 'A') ADVANCE(519);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 523:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '(') ADVANCE(576);
+      if (lookahead == 'E') ADVANCE(529);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 524:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '(') ADVANCE(576);
+      if (lookahead == 'L') ADVANCE(528);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 525:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '(') ADVANCE(576);
+      if (lookahead == 'L') ADVANCE(518);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 526:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '(') ADVANCE(576);
+      if (lookahead == 'R') ADVANCE(525);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 527:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '(') ADVANCE(576);
+      if (lookahead == 'T') ADVANCE(526);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 528:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '(') ADVANCE(576);
+      if (lookahead == 'T') ADVANCE(517);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 529:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '(') ADVANCE(576);
+      if (lookahead == 'T') ADVANCE(522);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 530:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '(') ADVANCE(576);
+      if (lookahead == 'p') ADVANCE(520);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 531:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '(') ADVANCE(576);
+      if (lookahead == 't') ADVANCE(530);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 532:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '(') ADVANCE(576);
+      if (lookahead == 't') ADVANCE(531);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 533:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '(') ADVANCE(576);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 534:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '-') ADVANCE(538);
+      if (lookahead == '>') ADVANCE(576);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(536);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 535:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '-') ADVANCE(573);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 536:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '>') ADVANCE(576);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(518);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(536);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 519:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '>') ADVANCE(546);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 520:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'D') ADVANCE(536);
-      if (lookahead == 'U') ADVANCE(537);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 521:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'F') ADVANCE(524);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 522:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'H') ADVANCE(523);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 523:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'I') ADVANCE(521);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 524:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'T') ADVANCE(517);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 525:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'a') ADVANCE(531);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 526:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'a') ADVANCE(532);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 527:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'e') ADVANCE(533);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 528:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'e') ADVANCE(520);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 529:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'e') ADVANCE(538);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 530:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'e') ADVANCE(526);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 531:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'g') ADVANCE(528);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 532:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'k') ADVANCE(546);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 533:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'l') ADVANCE(546);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 534:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'n') ADVANCE(546);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 535:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'n') ADVANCE(540);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 536:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'o') ADVANCE(542);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
       END_STATE();
     case 537:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'p') ADVANCE(546);
+      if (lookahead == '>') ADVANCE(576);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
       END_STATE();
     case 538:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'r') ADVANCE(541);
+      if (lookahead == '>') ADVANCE(537);
+      if (lookahead == '}') ADVANCE(62);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(25);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(536);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '\n') ADVANCE(537);
       END_STATE();
     case 539:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'r') ADVANCE(530);
+      if (lookahead == 'B') ADVANCE(563);
+      if (lookahead == 'D') ADVANCE(549);
+      if (lookahead == 'I') ADVANCE(558);
+      if (lookahead == 'P') ADVANCE(545);
+      if (lookahead == 'S') ADVANCE(542);
+      if (lookahead == '{') ADVANCE(548);
+      if (lookahead == '}') ADVANCE(289);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(289);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '\n') ADVANCE(576);
       END_STATE();
     case 540:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 's') ADVANCE(529);
+      if (lookahead == 'D') ADVANCE(559);
+      if (lookahead == 'U') ADVANCE(560);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
       END_STATE();
     case 541:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 't') ADVANCE(546);
+      if (lookahead == 'F') ADVANCE(544);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
       END_STATE();
     case 542:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'w') ADVANCE(534);
+      if (lookahead == 'H') ADVANCE(543);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
       END_STATE();
     case 543:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '|') ADVANCE(543);
+      if (lookahead == 'I') ADVANCE(541);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          (lookahead < '{' || '}' < lookahead)) ADVANCE(546);
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
       END_STATE();
     case 544:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(546);
-      if (lookahead == '{' ||
-          lookahead == '}') ADVANCE(406);
+      if (lookahead == 'T') ADVANCE(535);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(544);
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
       END_STATE();
     case 545:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == 'a') ADVANCE(553);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 546:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'a') ADVANCE(555);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 547:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'a') ADVANCE(562);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 548:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'c') ADVANCE(554);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 549:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'e') ADVANCE(556);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 550:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'e') ADVANCE(540);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 551:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'e') ADVANCE(561);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 552:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'e') ADVANCE(546);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 553:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'g') ADVANCE(550);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 554:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'h') ADVANCE(547);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 555:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'k') ADVANCE(576);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 556:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'l') ADVANCE(576);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 557:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'n') ADVANCE(576);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 558:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'n') ADVANCE(564);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 559:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'o') ADVANCE(566);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 560:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'p') ADVANCE(576);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 561:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'r') ADVANCE(565);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 562:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'r') ADVANCE(572);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 563:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'r') ADVANCE(552);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 564:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 's') ADVANCE(551);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 565:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 't') ADVANCE(576);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 566:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'w') ADVANCE(557);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 567:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '{') ADVANCE(567);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(575);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 568:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '|') ADVANCE(568);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 569:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '}') ADVANCE(328);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(328);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(576);
+      END_STATE();
+    case 570:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '}') ADVANCE(324);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(324);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(576);
+      END_STATE();
+    case 571:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '}') ADVANCE(448);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(576);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(571);
+      END_STATE();
+    case 572:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '}') ADVANCE(322);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(576);
+      END_STATE();
+    case 573:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '}') ADVANCE(316);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(316);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(576);
+      END_STATE();
+    case 574:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(516);
+          lookahead == 'S') ADVANCE(534);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(518);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(536);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
       END_STATE();
-    case 546:
+    case 575:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(575);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
       END_STATE();
-    case 547:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '>') ADVANCE(548);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(548);
-      END_STATE();
-    case 548:
+    case 576:
       ACCEPT_TOKEN(aux_sym_argument_token1);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(548);
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(576);
+      END_STATE();
+    case 577:
+      ACCEPT_TOKEN(anon_sym_RBRACE2);
       END_STATE();
     default:
       return false;
@@ -6335,111 +6698,112 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 31},
-  [2] = {.lex_state = 31},
-  [3] = {.lex_state = 31},
-  [4] = {.lex_state = 31},
-  [5] = {.lex_state = 31},
-  [6] = {.lex_state = 31},
-  [7] = {.lex_state = 31},
-  [8] = {.lex_state = 11},
-  [9] = {.lex_state = 11},
-  [10] = {.lex_state = 11},
-  [11] = {.lex_state = 11},
-  [12] = {.lex_state = 11},
-  [13] = {.lex_state = 11},
-  [14] = {.lex_state = 11},
-  [15] = {.lex_state = 11},
-  [16] = {.lex_state = 11},
-  [17] = {.lex_state = 8},
-  [18] = {.lex_state = 8},
-  [19] = {.lex_state = 8},
-  [20] = {.lex_state = 8},
-  [21] = {.lex_state = 8},
-  [22] = {.lex_state = 8},
-  [23] = {.lex_state = 8},
-  [24] = {.lex_state = 8},
-  [25] = {.lex_state = 8},
-  [26] = {.lex_state = 8},
-  [27] = {.lex_state = 8},
-  [28] = {.lex_state = 8},
-  [29] = {.lex_state = 8},
-  [30] = {.lex_state = 8},
-  [31] = {.lex_state = 8},
-  [32] = {.lex_state = 31},
-  [33] = {.lex_state = 31},
-  [34] = {.lex_state = 10},
-  [35] = {.lex_state = 10},
-  [36] = {.lex_state = 31},
-  [37] = {.lex_state = 31},
-  [38] = {.lex_state = 31},
-  [39] = {.lex_state = 31},
-  [40] = {.lex_state = 31},
-  [41] = {.lex_state = 31},
-  [42] = {.lex_state = 31},
-  [43] = {.lex_state = 31},
-  [44] = {.lex_state = 31},
-  [45] = {.lex_state = 12},
-  [46] = {.lex_state = 31},
-  [47] = {.lex_state = 31},
-  [48] = {.lex_state = 10},
-  [49] = {.lex_state = 10},
-  [50] = {.lex_state = 12},
-  [51] = {.lex_state = 16},
-  [52] = {.lex_state = 31},
-  [53] = {.lex_state = 31},
-  [54] = {.lex_state = 31},
-  [55] = {.lex_state = 31},
-  [56] = {.lex_state = 31},
-  [57] = {.lex_state = 31},
-  [58] = {.lex_state = 31},
-  [59] = {.lex_state = 31},
-  [60] = {.lex_state = 31},
-  [61] = {.lex_state = 31},
-  [62] = {.lex_state = 12},
-  [63] = {.lex_state = 12},
-  [64] = {.lex_state = 11},
-  [65] = {.lex_state = 13},
-  [66] = {.lex_state = 11},
+  [1] = {.lex_state = 29},
+  [2] = {.lex_state = 29},
+  [3] = {.lex_state = 29},
+  [4] = {.lex_state = 29},
+  [5] = {.lex_state = 29},
+  [6] = {.lex_state = 29},
+  [7] = {.lex_state = 29},
+  [8] = {.lex_state = 8},
+  [9] = {.lex_state = 8},
+  [10] = {.lex_state = 8},
+  [11] = {.lex_state = 8},
+  [12] = {.lex_state = 8},
+  [13] = {.lex_state = 8},
+  [14] = {.lex_state = 8},
+  [15] = {.lex_state = 8},
+  [16] = {.lex_state = 8},
+  [17] = {.lex_state = 5},
+  [18] = {.lex_state = 5},
+  [19] = {.lex_state = 5},
+  [20] = {.lex_state = 5},
+  [21] = {.lex_state = 5},
+  [22] = {.lex_state = 5},
+  [23] = {.lex_state = 5},
+  [24] = {.lex_state = 5},
+  [25] = {.lex_state = 5},
+  [26] = {.lex_state = 5},
+  [27] = {.lex_state = 5},
+  [28] = {.lex_state = 5},
+  [29] = {.lex_state = 5},
+  [30] = {.lex_state = 5},
+  [31] = {.lex_state = 5},
+  [32] = {.lex_state = 29},
+  [33] = {.lex_state = 29},
+  [34] = {.lex_state = 29},
+  [35] = {.lex_state = 29},
+  [36] = {.lex_state = 7},
+  [37] = {.lex_state = 29},
+  [38] = {.lex_state = 29},
+  [39] = {.lex_state = 29},
+  [40] = {.lex_state = 29},
+  [41] = {.lex_state = 29},
+  [42] = {.lex_state = 7},
+  [43] = {.lex_state = 29},
+  [44] = {.lex_state = 29},
+  [45] = {.lex_state = 9},
+  [46] = {.lex_state = 9},
+  [47] = {.lex_state = 29},
+  [48] = {.lex_state = 7},
+  [49] = {.lex_state = 7},
+  [50] = {.lex_state = 29},
+  [51] = {.lex_state = 29},
+  [52] = {.lex_state = 29},
+  [53] = {.lex_state = 29},
+  [54] = {.lex_state = 29},
+  [55] = {.lex_state = 29},
+  [56] = {.lex_state = 29},
+  [57] = {.lex_state = 29},
+  [58] = {.lex_state = 29},
+  [59] = {.lex_state = 29},
+  [60] = {.lex_state = 29},
+  [61] = {.lex_state = 9},
+  [62] = {.lex_state = 9},
+  [63] = {.lex_state = 8},
+  [64] = {.lex_state = 8},
+  [65] = {.lex_state = 10},
+  [66] = {.lex_state = 8},
   [67] = {.lex_state = 11},
-  [68] = {.lex_state = 6},
-  [69] = {.lex_state = 14},
-  [70] = {.lex_state = 14},
-  [71] = {.lex_state = 14},
-  [72] = {.lex_state = 14},
-  [73] = {.lex_state = 14},
-  [74] = {.lex_state = 6},
-  [75] = {.lex_state = 5},
-  [76] = {.lex_state = 7},
-  [77] = {.lex_state = 17},
-  [78] = {.lex_state = 5},
-  [79] = {.lex_state = 14},
-  [80] = {.lex_state = 8},
-  [81] = {.lex_state = 8},
-  [82] = {.lex_state = 8},
-  [83] = {.lex_state = 8},
-  [84] = {.lex_state = 8},
-  [85] = {.lex_state = 8},
-  [86] = {.lex_state = 8},
-  [87] = {.lex_state = 8},
-  [88] = {.lex_state = 8},
-  [89] = {.lex_state = 8},
-  [90] = {.lex_state = 8},
-  [91] = {.lex_state = 18},
-  [92] = {.lex_state = 18},
-  [93] = {.lex_state = 18},
-  [94] = {.lex_state = 10},
-  [95] = {.lex_state = 10},
-  [96] = {.lex_state = 31},
-  [97] = {.lex_state = 0},
-  [98] = {.lex_state = 7},
-  [99] = {.lex_state = 31},
-  [100] = {.lex_state = 18},
+  [68] = {.lex_state = 11},
+  [69] = {.lex_state = 3},
+  [70] = {.lex_state = 11},
+  [71] = {.lex_state = 3},
+  [72] = {.lex_state = 11},
+  [73] = {.lex_state = 11},
+  [74] = {.lex_state = 13},
+  [75] = {.lex_state = 2},
+  [76] = {.lex_state = 14},
+  [77] = {.lex_state = 4},
+  [78] = {.lex_state = 2},
+  [79] = {.lex_state = 15},
+  [80] = {.lex_state = 11},
+  [81] = {.lex_state = 5},
+  [82] = {.lex_state = 5},
+  [83] = {.lex_state = 5},
+  [84] = {.lex_state = 5},
+  [85] = {.lex_state = 5},
+  [86] = {.lex_state = 5},
+  [87] = {.lex_state = 5},
+  [88] = {.lex_state = 5},
+  [89] = {.lex_state = 5},
+  [90] = {.lex_state = 5},
+  [91] = {.lex_state = 5},
+  [92] = {.lex_state = 16},
+  [93] = {.lex_state = 16},
+  [94] = {.lex_state = 16},
+  [95] = {.lex_state = 7},
+  [96] = {.lex_state = 7},
+  [97] = {.lex_state = 29},
+  [98] = {.lex_state = 16},
+  [99] = {.lex_state = 16},
+  [100] = {.lex_state = 16},
   [101] = {.lex_state = 26},
-  [102] = {.lex_state = 28},
-  [103] = {.lex_state = 26},
-  [104] = {.lex_state = 18},
-  [105] = {.lex_state = 18},
+  [102] = {.lex_state = 0},
+  [103] = {.lex_state = 14},
+  [104] = {.lex_state = 4},
+  [105] = {.lex_state = 29},
+  [106] = {.lex_state = 16},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -6449,17 +6813,17 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_word_token2] = ACTIONS(1),
     [aux_sym_word_noli_token1] = ACTIONS(1),
     [aux_sym_word_noli_token2] = ACTIONS(1),
+    [anon_sym_STAR] = ACTIONS(1),
     [anon_sym_SQUOTE] = ACTIONS(1),
     [aux_sym__word_common_token1] = ACTIONS(1),
     [anon_sym_SQUOTE2] = ACTIONS(1),
     [anon_sym_PIPE] = ACTIONS(1),
-    [aux_sym__word_common_token4] = ACTIONS(1),
     [anon_sym_LBRACE] = ACTIONS(1),
     [anon_sym_RBRACE] = ACTIONS(1),
     [anon_sym_LBRACE_RBRACE] = ACTIONS(1),
-    [aux_sym__word_common_token5] = ACTIONS(1),
+    [aux_sym__word_common_token4] = ACTIONS(1),
     [anon_sym_LPAREN] = ACTIONS(1),
-    [aux_sym__word_common_token6] = ACTIONS(1),
+    [aux_sym__word_common_token5] = ACTIONS(1),
     [anon_sym_TILDE] = ACTIONS(1),
     [anon_sym_GT] = ACTIONS(1),
     [aux_sym_keycode_token1] = ACTIONS(1),
@@ -6467,43 +6831,40 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_keycode_token3] = ACTIONS(1),
     [aux_sym_keycode_token4] = ACTIONS(1),
     [aux_sym_keycode_token5] = ACTIONS(1),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(1),
     [aux_sym_keycode_token6] = ACTIONS(1),
     [aux_sym_keycode_token7] = ACTIONS(1),
-    [aux_sym_keycode_token8] = ACTIONS(1),
     [anon_sym_LT] = ACTIONS(1),
     [anon_sym_LF] = ACTIONS(1),
     [anon_sym_LF2] = ACTIONS(1),
-    [anon_sym_STAR] = ACTIONS(1),
+    [aux_sym_tag_token1] = ACTIONS(1),
     [anon_sym_STAR2] = ACTIONS(1),
     [sym_url_word] = ACTIONS(1),
     [aux_sym_optionlink_token1] = ACTIONS(1),
-    [anon_sym_LBRACE2] = ACTIONS(1),
-    [anon_sym_RBRACE2] = ACTIONS(1),
-    [anon_sym_LPAREN2] = ACTIONS(1),
-    [anon_sym_RPAREN] = ACTIONS(1),
-    [anon_sym_BQUOTE] = ACTIONS(1),
     [anon_sym_PIPE2] = ACTIONS(1),
+    [anon_sym_BQUOTE] = ACTIONS(1),
     [anon_sym_BQUOTE2] = ACTIONS(1),
+    [anon_sym_RBRACE2] = ACTIONS(1),
   },
   [1] = {
-    [sym_help_file] = STATE(97),
+    [sym_help_file] = STATE(102),
     [sym__atom_noli] = STATE(18),
     [sym_word_noli] = STATE(18),
     [sym__atom_common] = STATE(18),
-    [sym__word_common] = STATE(80),
+    [sym__word_common] = STATE(87),
     [sym_keycode] = STATE(18),
-    [sym_uppercase_name] = STATE(96),
+    [sym_uppercase_name] = STATE(97),
     [sym__uppercase_words] = STATE(18),
     [sym_block] = STATE(5),
-    [sym_codeblock] = STATE(58),
-    [sym__blank] = STATE(46),
+    [sym_codeblock] = STATE(60),
+    [sym__blank] = STATE(50),
     [sym_line] = STATE(6),
     [sym_line_li] = STATE(92),
-    [sym__line_noli] = STATE(58),
-    [sym_column_heading] = STATE(58),
-    [sym_h1] = STATE(58),
-    [sym_h2] = STATE(58),
-    [sym_h3] = STATE(58),
+    [sym__line_noli] = STATE(60),
+    [sym_column_heading] = STATE(60),
+    [sym_h1] = STATE(60),
+    [sym_h2] = STATE(60),
+    [sym_h3] = STATE(60),
     [sym_tag] = STATE(18),
     [sym_url] = STATE(18),
     [sym_optionlink] = STATE(18),
@@ -6517,54 +6878,53 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [ts_builtin_sym_end] = ACTIONS(3),
     [aux_sym_word_noli_token1] = ACTIONS(5),
     [aux_sym_word_noli_token2] = ACTIONS(5),
-    [anon_sym_SQUOTE] = ACTIONS(7),
-    [aux_sym__word_common_token3] = ACTIONS(9),
-    [anon_sym_PIPE] = ACTIONS(11),
-    [aux_sym__word_common_token4] = ACTIONS(9),
-    [anon_sym_LBRACE] = ACTIONS(13),
-    [anon_sym_RBRACE] = ACTIONS(9),
-    [anon_sym_LBRACE_RBRACE] = ACTIONS(9),
-    [aux_sym__word_common_token5] = ACTIONS(9),
+    [anon_sym_STAR] = ACTIONS(7),
+    [anon_sym_SQUOTE] = ACTIONS(9),
+    [aux_sym__word_common_token3] = ACTIONS(11),
+    [anon_sym_PIPE] = ACTIONS(13),
+    [anon_sym_LBRACE] = ACTIONS(15),
+    [anon_sym_RBRACE] = ACTIONS(11),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(11),
     [anon_sym_LPAREN] = ACTIONS(5),
-    [aux_sym__word_common_token6] = ACTIONS(5),
-    [anon_sym_TILDE] = ACTIONS(9),
-    [anon_sym_GT] = ACTIONS(15),
-    [aux_sym_keycode_token1] = ACTIONS(17),
-    [aux_sym_keycode_token2] = ACTIONS(17),
-    [aux_sym_keycode_token3] = ACTIONS(17),
-    [aux_sym_keycode_token4] = ACTIONS(17),
-    [aux_sym_keycode_token5] = ACTIONS(19),
+    [aux_sym__word_common_token5] = ACTIONS(5),
+    [anon_sym_TILDE] = ACTIONS(11),
+    [anon_sym_GT] = ACTIONS(17),
+    [aux_sym_keycode_token1] = ACTIONS(19),
+    [aux_sym_keycode_token2] = ACTIONS(19),
+    [aux_sym_keycode_token3] = ACTIONS(19),
+    [aux_sym_keycode_token4] = ACTIONS(19),
+    [aux_sym_keycode_token5] = ACTIONS(21),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(21),
     [aux_sym_keycode_token6] = ACTIONS(19),
-    [aux_sym_keycode_token7] = ACTIONS(17),
-    [aux_sym_keycode_token8] = ACTIONS(17),
-    [aux_sym_uppercase_name_token1] = ACTIONS(21),
-    [anon_sym_LT] = ACTIONS(23),
-    [anon_sym_LF2] = ACTIONS(25),
-    [aux_sym_line_li_token1] = ACTIONS(27),
-    [aux_sym_h1_token1] = ACTIONS(29),
-    [aux_sym_h2_token1] = ACTIONS(31),
-    [anon_sym_STAR] = ACTIONS(33),
+    [aux_sym_keycode_token7] = ACTIONS(19),
+    [aux_sym_uppercase_name_token1] = ACTIONS(23),
+    [anon_sym_LT] = ACTIONS(25),
+    [anon_sym_LF2] = ACTIONS(27),
+    [aux_sym_line_li_token1] = ACTIONS(29),
+    [aux_sym_h1_token1] = ACTIONS(31),
+    [aux_sym_h2_token1] = ACTIONS(33),
     [sym_url_word] = ACTIONS(35),
-    [anon_sym_BQUOTE2] = ACTIONS(37),
+    [anon_sym_BQUOTE] = ACTIONS(37),
   },
   [2] = {
     [sym__atom_noli] = STATE(18),
     [sym_word_noli] = STATE(18),
     [sym__atom_common] = STATE(18),
-    [sym__word_common] = STATE(80),
+    [sym__word_common] = STATE(87),
     [sym_keycode] = STATE(18),
-    [sym_uppercase_name] = STATE(96),
+    [sym_uppercase_name] = STATE(97),
     [sym__uppercase_words] = STATE(18),
-    [sym_block] = STATE(4),
-    [sym_codeblock] = STATE(58),
-    [sym__blank] = STATE(46),
+    [sym_block] = STATE(3),
+    [sym_codeblock] = STATE(60),
+    [sym__blank] = STATE(50),
     [sym_line] = STATE(6),
     [sym_line_li] = STATE(92),
-    [sym__line_noli] = STATE(58),
-    [sym_column_heading] = STATE(58),
-    [sym_h1] = STATE(58),
-    [sym_h2] = STATE(58),
-    [sym_h3] = STATE(58),
+    [sym__line_noli] = STATE(60),
+    [sym_column_heading] = STATE(60),
+    [sym_h1] = STATE(60),
+    [sym_h2] = STATE(60),
+    [sym_h3] = STATE(60),
     [sym_tag] = STATE(18),
     [sym_url] = STATE(18),
     [sym_optionlink] = STATE(18),
@@ -6572,233 +6932,229 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_codespan] = STATE(18),
     [sym_argument] = STATE(18),
     [aux_sym_help_file_repeat1] = STATE(43),
-    [aux_sym_help_file_repeat2] = STATE(4),
+    [aux_sym_help_file_repeat2] = STATE(3),
     [aux_sym_block_repeat1] = STATE(6),
     [aux_sym_block_repeat2] = STATE(92),
     [ts_builtin_sym_end] = ACTIONS(39),
     [aux_sym_word_noli_token1] = ACTIONS(5),
     [aux_sym_word_noli_token2] = ACTIONS(5),
-    [anon_sym_SQUOTE] = ACTIONS(7),
-    [aux_sym__word_common_token3] = ACTIONS(9),
-    [anon_sym_PIPE] = ACTIONS(11),
-    [aux_sym__word_common_token4] = ACTIONS(9),
-    [anon_sym_LBRACE] = ACTIONS(13),
-    [anon_sym_RBRACE] = ACTIONS(9),
-    [anon_sym_LBRACE_RBRACE] = ACTIONS(9),
-    [aux_sym__word_common_token5] = ACTIONS(9),
+    [anon_sym_STAR] = ACTIONS(7),
+    [anon_sym_SQUOTE] = ACTIONS(9),
+    [aux_sym__word_common_token3] = ACTIONS(11),
+    [anon_sym_PIPE] = ACTIONS(13),
+    [anon_sym_LBRACE] = ACTIONS(15),
+    [anon_sym_RBRACE] = ACTIONS(11),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(11),
     [anon_sym_LPAREN] = ACTIONS(5),
-    [aux_sym__word_common_token6] = ACTIONS(5),
-    [anon_sym_TILDE] = ACTIONS(9),
-    [anon_sym_GT] = ACTIONS(15),
-    [aux_sym_keycode_token1] = ACTIONS(17),
-    [aux_sym_keycode_token2] = ACTIONS(17),
-    [aux_sym_keycode_token3] = ACTIONS(17),
-    [aux_sym_keycode_token4] = ACTIONS(17),
-    [aux_sym_keycode_token5] = ACTIONS(19),
+    [aux_sym__word_common_token5] = ACTIONS(5),
+    [anon_sym_TILDE] = ACTIONS(11),
+    [anon_sym_GT] = ACTIONS(17),
+    [aux_sym_keycode_token1] = ACTIONS(19),
+    [aux_sym_keycode_token2] = ACTIONS(19),
+    [aux_sym_keycode_token3] = ACTIONS(19),
+    [aux_sym_keycode_token4] = ACTIONS(19),
+    [aux_sym_keycode_token5] = ACTIONS(21),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(21),
     [aux_sym_keycode_token6] = ACTIONS(19),
-    [aux_sym_keycode_token7] = ACTIONS(17),
-    [aux_sym_keycode_token8] = ACTIONS(17),
-    [aux_sym_uppercase_name_token1] = ACTIONS(21),
-    [anon_sym_LT] = ACTIONS(23),
-    [anon_sym_LF2] = ACTIONS(25),
-    [aux_sym_line_li_token1] = ACTIONS(27),
-    [aux_sym_h1_token1] = ACTIONS(29),
-    [aux_sym_h2_token1] = ACTIONS(31),
-    [anon_sym_STAR] = ACTIONS(33),
+    [aux_sym_keycode_token7] = ACTIONS(19),
+    [aux_sym_uppercase_name_token1] = ACTIONS(23),
+    [anon_sym_LT] = ACTIONS(25),
+    [anon_sym_LF2] = ACTIONS(27),
+    [aux_sym_line_li_token1] = ACTIONS(29),
+    [aux_sym_h1_token1] = ACTIONS(31),
+    [aux_sym_h2_token1] = ACTIONS(33),
     [sym_url_word] = ACTIONS(35),
-    [anon_sym_BQUOTE2] = ACTIONS(37),
+    [anon_sym_BQUOTE] = ACTIONS(37),
   },
   [3] = {
     [sym__atom_noli] = STATE(18),
     [sym_word_noli] = STATE(18),
     [sym__atom_common] = STATE(18),
-    [sym__word_common] = STATE(80),
+    [sym__word_common] = STATE(87),
     [sym_keycode] = STATE(18),
-    [sym_uppercase_name] = STATE(96),
+    [sym_uppercase_name] = STATE(97),
     [sym__uppercase_words] = STATE(18),
-    [sym_block] = STATE(3),
-    [sym_codeblock] = STATE(58),
+    [sym_block] = STATE(4),
+    [sym_codeblock] = STATE(60),
     [sym_line] = STATE(6),
     [sym_line_li] = STATE(92),
-    [sym__line_noli] = STATE(58),
-    [sym_column_heading] = STATE(58),
-    [sym_h1] = STATE(58),
-    [sym_h2] = STATE(58),
-    [sym_h3] = STATE(58),
+    [sym__line_noli] = STATE(60),
+    [sym_column_heading] = STATE(60),
+    [sym_h1] = STATE(60),
+    [sym_h2] = STATE(60),
+    [sym_h3] = STATE(60),
     [sym_tag] = STATE(18),
     [sym_url] = STATE(18),
     [sym_optionlink] = STATE(18),
     [sym_taglink] = STATE(18),
     [sym_codespan] = STATE(18),
     [sym_argument] = STATE(18),
-    [aux_sym_help_file_repeat2] = STATE(3),
+    [aux_sym_help_file_repeat2] = STATE(4),
     [aux_sym_block_repeat1] = STATE(6),
     [aux_sym_block_repeat2] = STATE(92),
     [ts_builtin_sym_end] = ACTIONS(41),
-    [aux_sym_word_noli_token1] = ACTIONS(43),
-    [aux_sym_word_noli_token2] = ACTIONS(43),
-    [anon_sym_SQUOTE] = ACTIONS(46),
-    [aux_sym__word_common_token3] = ACTIONS(49),
-    [anon_sym_PIPE] = ACTIONS(52),
-    [aux_sym__word_common_token4] = ACTIONS(49),
-    [anon_sym_LBRACE] = ACTIONS(55),
-    [anon_sym_RBRACE] = ACTIONS(49),
-    [anon_sym_LBRACE_RBRACE] = ACTIONS(49),
-    [aux_sym__word_common_token5] = ACTIONS(49),
-    [anon_sym_LPAREN] = ACTIONS(43),
-    [aux_sym__word_common_token6] = ACTIONS(43),
-    [anon_sym_TILDE] = ACTIONS(49),
-    [anon_sym_GT] = ACTIONS(58),
-    [aux_sym_keycode_token1] = ACTIONS(61),
-    [aux_sym_keycode_token2] = ACTIONS(61),
-    [aux_sym_keycode_token3] = ACTIONS(61),
-    [aux_sym_keycode_token4] = ACTIONS(61),
-    [aux_sym_keycode_token5] = ACTIONS(64),
-    [aux_sym_keycode_token6] = ACTIONS(64),
-    [aux_sym_keycode_token7] = ACTIONS(61),
-    [aux_sym_keycode_token8] = ACTIONS(61),
-    [aux_sym_uppercase_name_token1] = ACTIONS(67),
-    [anon_sym_LT] = ACTIONS(70),
-    [aux_sym_line_li_token1] = ACTIONS(73),
-    [aux_sym_h1_token1] = ACTIONS(76),
-    [aux_sym_h2_token1] = ACTIONS(79),
-    [anon_sym_STAR] = ACTIONS(82),
-    [sym_url_word] = ACTIONS(85),
-    [anon_sym_BQUOTE2] = ACTIONS(88),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(5),
+    [anon_sym_STAR] = ACTIONS(7),
+    [anon_sym_SQUOTE] = ACTIONS(9),
+    [aux_sym__word_common_token3] = ACTIONS(11),
+    [anon_sym_PIPE] = ACTIONS(13),
+    [anon_sym_LBRACE] = ACTIONS(15),
+    [anon_sym_RBRACE] = ACTIONS(11),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(11),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [aux_sym__word_common_token5] = ACTIONS(5),
+    [anon_sym_TILDE] = ACTIONS(11),
+    [anon_sym_GT] = ACTIONS(17),
+    [aux_sym_keycode_token1] = ACTIONS(19),
+    [aux_sym_keycode_token2] = ACTIONS(19),
+    [aux_sym_keycode_token3] = ACTIONS(19),
+    [aux_sym_keycode_token4] = ACTIONS(19),
+    [aux_sym_keycode_token5] = ACTIONS(21),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(21),
+    [aux_sym_keycode_token6] = ACTIONS(19),
+    [aux_sym_keycode_token7] = ACTIONS(19),
+    [aux_sym_uppercase_name_token1] = ACTIONS(23),
+    [anon_sym_LT] = ACTIONS(25),
+    [aux_sym_line_li_token1] = ACTIONS(29),
+    [aux_sym_h1_token1] = ACTIONS(31),
+    [aux_sym_h2_token1] = ACTIONS(33),
+    [sym_url_word] = ACTIONS(35),
+    [anon_sym_BQUOTE] = ACTIONS(37),
   },
   [4] = {
     [sym__atom_noli] = STATE(18),
     [sym_word_noli] = STATE(18),
     [sym__atom_common] = STATE(18),
-    [sym__word_common] = STATE(80),
+    [sym__word_common] = STATE(87),
     [sym_keycode] = STATE(18),
-    [sym_uppercase_name] = STATE(96),
+    [sym_uppercase_name] = STATE(97),
     [sym__uppercase_words] = STATE(18),
-    [sym_block] = STATE(3),
-    [sym_codeblock] = STATE(58),
+    [sym_block] = STATE(4),
+    [sym_codeblock] = STATE(60),
     [sym_line] = STATE(6),
     [sym_line_li] = STATE(92),
-    [sym__line_noli] = STATE(58),
-    [sym_column_heading] = STATE(58),
-    [sym_h1] = STATE(58),
-    [sym_h2] = STATE(58),
-    [sym_h3] = STATE(58),
+    [sym__line_noli] = STATE(60),
+    [sym_column_heading] = STATE(60),
+    [sym_h1] = STATE(60),
+    [sym_h2] = STATE(60),
+    [sym_h3] = STATE(60),
     [sym_tag] = STATE(18),
     [sym_url] = STATE(18),
     [sym_optionlink] = STATE(18),
     [sym_taglink] = STATE(18),
     [sym_codespan] = STATE(18),
     [sym_argument] = STATE(18),
-    [aux_sym_help_file_repeat2] = STATE(3),
+    [aux_sym_help_file_repeat2] = STATE(4),
     [aux_sym_block_repeat1] = STATE(6),
     [aux_sym_block_repeat2] = STATE(92),
-    [ts_builtin_sym_end] = ACTIONS(91),
-    [aux_sym_word_noli_token1] = ACTIONS(5),
-    [aux_sym_word_noli_token2] = ACTIONS(5),
-    [anon_sym_SQUOTE] = ACTIONS(7),
-    [aux_sym__word_common_token3] = ACTIONS(9),
-    [anon_sym_PIPE] = ACTIONS(11),
-    [aux_sym__word_common_token4] = ACTIONS(9),
-    [anon_sym_LBRACE] = ACTIONS(13),
-    [anon_sym_RBRACE] = ACTIONS(9),
-    [anon_sym_LBRACE_RBRACE] = ACTIONS(9),
-    [aux_sym__word_common_token5] = ACTIONS(9),
-    [anon_sym_LPAREN] = ACTIONS(5),
-    [aux_sym__word_common_token6] = ACTIONS(5),
-    [anon_sym_TILDE] = ACTIONS(9),
-    [anon_sym_GT] = ACTIONS(15),
-    [aux_sym_keycode_token1] = ACTIONS(17),
-    [aux_sym_keycode_token2] = ACTIONS(17),
-    [aux_sym_keycode_token3] = ACTIONS(17),
-    [aux_sym_keycode_token4] = ACTIONS(17),
-    [aux_sym_keycode_token5] = ACTIONS(19),
-    [aux_sym_keycode_token6] = ACTIONS(19),
-    [aux_sym_keycode_token7] = ACTIONS(17),
-    [aux_sym_keycode_token8] = ACTIONS(17),
-    [aux_sym_uppercase_name_token1] = ACTIONS(21),
-    [anon_sym_LT] = ACTIONS(23),
-    [aux_sym_line_li_token1] = ACTIONS(27),
-    [aux_sym_h1_token1] = ACTIONS(29),
-    [aux_sym_h2_token1] = ACTIONS(31),
-    [anon_sym_STAR] = ACTIONS(33),
-    [sym_url_word] = ACTIONS(35),
-    [anon_sym_BQUOTE2] = ACTIONS(37),
+    [ts_builtin_sym_end] = ACTIONS(43),
+    [aux_sym_word_noli_token1] = ACTIONS(45),
+    [aux_sym_word_noli_token2] = ACTIONS(45),
+    [anon_sym_STAR] = ACTIONS(48),
+    [anon_sym_SQUOTE] = ACTIONS(51),
+    [aux_sym__word_common_token3] = ACTIONS(54),
+    [anon_sym_PIPE] = ACTIONS(57),
+    [anon_sym_LBRACE] = ACTIONS(60),
+    [anon_sym_RBRACE] = ACTIONS(54),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(54),
+    [aux_sym__word_common_token4] = ACTIONS(54),
+    [anon_sym_LPAREN] = ACTIONS(45),
+    [aux_sym__word_common_token5] = ACTIONS(45),
+    [anon_sym_TILDE] = ACTIONS(54),
+    [anon_sym_GT] = ACTIONS(63),
+    [aux_sym_keycode_token1] = ACTIONS(66),
+    [aux_sym_keycode_token2] = ACTIONS(66),
+    [aux_sym_keycode_token3] = ACTIONS(66),
+    [aux_sym_keycode_token4] = ACTIONS(66),
+    [aux_sym_keycode_token5] = ACTIONS(69),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(69),
+    [aux_sym_keycode_token6] = ACTIONS(66),
+    [aux_sym_keycode_token7] = ACTIONS(66),
+    [aux_sym_uppercase_name_token1] = ACTIONS(72),
+    [anon_sym_LT] = ACTIONS(75),
+    [aux_sym_line_li_token1] = ACTIONS(78),
+    [aux_sym_h1_token1] = ACTIONS(81),
+    [aux_sym_h2_token1] = ACTIONS(84),
+    [sym_url_word] = ACTIONS(87),
+    [anon_sym_BQUOTE] = ACTIONS(90),
   },
   [5] = {
     [sym__atom_noli] = STATE(18),
     [sym_word_noli] = STATE(18),
     [sym__atom_common] = STATE(18),
-    [sym__word_common] = STATE(80),
+    [sym__word_common] = STATE(87),
     [sym_keycode] = STATE(18),
-    [sym_uppercase_name] = STATE(96),
+    [sym_uppercase_name] = STATE(97),
     [sym__uppercase_words] = STATE(18),
-    [sym_block] = STATE(3),
-    [sym_codeblock] = STATE(58),
+    [sym_block] = STATE(4),
+    [sym_codeblock] = STATE(60),
     [sym_line] = STATE(6),
     [sym_line_li] = STATE(92),
-    [sym__line_noli] = STATE(58),
-    [sym_column_heading] = STATE(58),
-    [sym_h1] = STATE(58),
-    [sym_h2] = STATE(58),
-    [sym_h3] = STATE(58),
+    [sym__line_noli] = STATE(60),
+    [sym_column_heading] = STATE(60),
+    [sym_h1] = STATE(60),
+    [sym_h2] = STATE(60),
+    [sym_h3] = STATE(60),
     [sym_tag] = STATE(18),
     [sym_url] = STATE(18),
     [sym_optionlink] = STATE(18),
     [sym_taglink] = STATE(18),
     [sym_codespan] = STATE(18),
     [sym_argument] = STATE(18),
-    [aux_sym_help_file_repeat2] = STATE(3),
+    [aux_sym_help_file_repeat2] = STATE(4),
     [aux_sym_block_repeat1] = STATE(6),
     [aux_sym_block_repeat2] = STATE(92),
     [ts_builtin_sym_end] = ACTIONS(93),
     [aux_sym_word_noli_token1] = ACTIONS(5),
     [aux_sym_word_noli_token2] = ACTIONS(5),
-    [anon_sym_SQUOTE] = ACTIONS(7),
-    [aux_sym__word_common_token3] = ACTIONS(9),
-    [anon_sym_PIPE] = ACTIONS(11),
-    [aux_sym__word_common_token4] = ACTIONS(9),
-    [anon_sym_LBRACE] = ACTIONS(13),
-    [anon_sym_RBRACE] = ACTIONS(9),
-    [anon_sym_LBRACE_RBRACE] = ACTIONS(9),
-    [aux_sym__word_common_token5] = ACTIONS(9),
+    [anon_sym_STAR] = ACTIONS(7),
+    [anon_sym_SQUOTE] = ACTIONS(9),
+    [aux_sym__word_common_token3] = ACTIONS(11),
+    [anon_sym_PIPE] = ACTIONS(13),
+    [anon_sym_LBRACE] = ACTIONS(15),
+    [anon_sym_RBRACE] = ACTIONS(11),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(11),
     [anon_sym_LPAREN] = ACTIONS(5),
-    [aux_sym__word_common_token6] = ACTIONS(5),
-    [anon_sym_TILDE] = ACTIONS(9),
-    [anon_sym_GT] = ACTIONS(15),
-    [aux_sym_keycode_token1] = ACTIONS(17),
-    [aux_sym_keycode_token2] = ACTIONS(17),
-    [aux_sym_keycode_token3] = ACTIONS(17),
-    [aux_sym_keycode_token4] = ACTIONS(17),
-    [aux_sym_keycode_token5] = ACTIONS(19),
+    [aux_sym__word_common_token5] = ACTIONS(5),
+    [anon_sym_TILDE] = ACTIONS(11),
+    [anon_sym_GT] = ACTIONS(17),
+    [aux_sym_keycode_token1] = ACTIONS(19),
+    [aux_sym_keycode_token2] = ACTIONS(19),
+    [aux_sym_keycode_token3] = ACTIONS(19),
+    [aux_sym_keycode_token4] = ACTIONS(19),
+    [aux_sym_keycode_token5] = ACTIONS(21),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(21),
     [aux_sym_keycode_token6] = ACTIONS(19),
-    [aux_sym_keycode_token7] = ACTIONS(17),
-    [aux_sym_keycode_token8] = ACTIONS(17),
-    [aux_sym_uppercase_name_token1] = ACTIONS(21),
-    [anon_sym_LT] = ACTIONS(23),
-    [aux_sym_line_li_token1] = ACTIONS(27),
-    [aux_sym_h1_token1] = ACTIONS(29),
-    [aux_sym_h2_token1] = ACTIONS(31),
-    [anon_sym_STAR] = ACTIONS(33),
+    [aux_sym_keycode_token7] = ACTIONS(19),
+    [aux_sym_uppercase_name_token1] = ACTIONS(23),
+    [anon_sym_LT] = ACTIONS(25),
+    [aux_sym_line_li_token1] = ACTIONS(29),
+    [aux_sym_h1_token1] = ACTIONS(31),
+    [aux_sym_h2_token1] = ACTIONS(33),
     [sym_url_word] = ACTIONS(35),
-    [anon_sym_BQUOTE2] = ACTIONS(37),
+    [anon_sym_BQUOTE] = ACTIONS(37),
   },
   [6] = {
     [sym__atom_noli] = STATE(18),
     [sym_word_noli] = STATE(18),
     [sym__atom_common] = STATE(18),
-    [sym__word_common] = STATE(80),
+    [sym__word_common] = STATE(87),
     [sym_keycode] = STATE(18),
-    [sym_uppercase_name] = STATE(96),
+    [sym_uppercase_name] = STATE(97),
     [sym__uppercase_words] = STATE(18),
-    [sym_codeblock] = STATE(58),
-    [sym__blank] = STATE(41),
+    [sym_codeblock] = STATE(60),
+    [sym__blank] = STATE(33),
     [sym_line] = STATE(7),
-    [sym_line_li] = STATE(91),
-    [sym__line_noli] = STATE(58),
-    [sym_column_heading] = STATE(58),
-    [sym_h1] = STATE(58),
-    [sym_h2] = STATE(58),
-    [sym_h3] = STATE(58),
+    [sym_line_li] = STATE(93),
+    [sym__line_noli] = STATE(60),
+    [sym_column_heading] = STATE(60),
+    [sym_h1] = STATE(60),
+    [sym_h2] = STATE(60),
+    [sym_h3] = STATE(60),
     [sym_tag] = STATE(18),
     [sym_url] = STATE(18),
     [sym_optionlink] = STATE(18),
@@ -6806,54 +7162,53 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_codespan] = STATE(18),
     [sym_argument] = STATE(18),
     [aux_sym_block_repeat1] = STATE(7),
-    [aux_sym_block_repeat2] = STATE(91),
+    [aux_sym_block_repeat2] = STATE(93),
     [aux_sym_word_noli_token1] = ACTIONS(5),
     [aux_sym_word_noli_token2] = ACTIONS(5),
-    [anon_sym_SQUOTE] = ACTIONS(7),
-    [aux_sym__word_common_token3] = ACTIONS(9),
-    [anon_sym_PIPE] = ACTIONS(11),
-    [aux_sym__word_common_token4] = ACTIONS(9),
-    [anon_sym_LBRACE] = ACTIONS(13),
-    [anon_sym_RBRACE] = ACTIONS(9),
-    [anon_sym_LBRACE_RBRACE] = ACTIONS(9),
-    [aux_sym__word_common_token5] = ACTIONS(9),
+    [anon_sym_STAR] = ACTIONS(7),
+    [anon_sym_SQUOTE] = ACTIONS(9),
+    [aux_sym__word_common_token3] = ACTIONS(11),
+    [anon_sym_PIPE] = ACTIONS(13),
+    [anon_sym_LBRACE] = ACTIONS(15),
+    [anon_sym_RBRACE] = ACTIONS(11),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(11),
     [anon_sym_LPAREN] = ACTIONS(5),
-    [aux_sym__word_common_token6] = ACTIONS(5),
-    [anon_sym_TILDE] = ACTIONS(9),
-    [anon_sym_GT] = ACTIONS(15),
-    [aux_sym_keycode_token1] = ACTIONS(17),
-    [aux_sym_keycode_token2] = ACTIONS(17),
-    [aux_sym_keycode_token3] = ACTIONS(17),
-    [aux_sym_keycode_token4] = ACTIONS(17),
-    [aux_sym_keycode_token5] = ACTIONS(19),
+    [aux_sym__word_common_token5] = ACTIONS(5),
+    [anon_sym_TILDE] = ACTIONS(11),
+    [anon_sym_GT] = ACTIONS(17),
+    [aux_sym_keycode_token1] = ACTIONS(19),
+    [aux_sym_keycode_token2] = ACTIONS(19),
+    [aux_sym_keycode_token3] = ACTIONS(19),
+    [aux_sym_keycode_token4] = ACTIONS(19),
+    [aux_sym_keycode_token5] = ACTIONS(21),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(21),
     [aux_sym_keycode_token6] = ACTIONS(19),
-    [aux_sym_keycode_token7] = ACTIONS(17),
-    [aux_sym_keycode_token8] = ACTIONS(17),
-    [aux_sym_uppercase_name_token1] = ACTIONS(21),
+    [aux_sym_keycode_token7] = ACTIONS(19),
+    [aux_sym_uppercase_name_token1] = ACTIONS(23),
     [anon_sym_LT] = ACTIONS(95),
-    [anon_sym_LF2] = ACTIONS(25),
-    [aux_sym_line_li_token1] = ACTIONS(27),
-    [aux_sym_h1_token1] = ACTIONS(29),
-    [aux_sym_h2_token1] = ACTIONS(31),
-    [anon_sym_STAR] = ACTIONS(33),
+    [anon_sym_LF2] = ACTIONS(27),
+    [aux_sym_line_li_token1] = ACTIONS(29),
+    [aux_sym_h1_token1] = ACTIONS(31),
+    [aux_sym_h2_token1] = ACTIONS(33),
     [sym_url_word] = ACTIONS(35),
-    [anon_sym_BQUOTE2] = ACTIONS(37),
+    [anon_sym_BQUOTE] = ACTIONS(37),
   },
   [7] = {
     [sym__atom_noli] = STATE(18),
     [sym_word_noli] = STATE(18),
     [sym__atom_common] = STATE(18),
-    [sym__word_common] = STATE(80),
+    [sym__word_common] = STATE(87),
     [sym_keycode] = STATE(18),
-    [sym_uppercase_name] = STATE(96),
+    [sym_uppercase_name] = STATE(97),
     [sym__uppercase_words] = STATE(18),
-    [sym_codeblock] = STATE(58),
+    [sym_codeblock] = STATE(60),
     [sym_line] = STATE(7),
-    [sym__line_noli] = STATE(58),
-    [sym_column_heading] = STATE(58),
-    [sym_h1] = STATE(58),
-    [sym_h2] = STATE(58),
-    [sym_h3] = STATE(58),
+    [sym__line_noli] = STATE(60),
+    [sym_column_heading] = STATE(60),
+    [sym_h1] = STATE(60),
+    [sym_h2] = STATE(60),
+    [sym_h3] = STATE(60),
     [sym_tag] = STATE(18),
     [sym_url] = STATE(18),
     [sym_optionlink] = STATE(18),
@@ -6863,86 +7218,84 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_block_repeat1] = STATE(7),
     [aux_sym_word_noli_token1] = ACTIONS(97),
     [aux_sym_word_noli_token2] = ACTIONS(97),
-    [anon_sym_SQUOTE] = ACTIONS(100),
-    [aux_sym__word_common_token3] = ACTIONS(103),
-    [anon_sym_PIPE] = ACTIONS(106),
-    [aux_sym__word_common_token4] = ACTIONS(103),
-    [anon_sym_LBRACE] = ACTIONS(109),
-    [anon_sym_RBRACE] = ACTIONS(103),
-    [anon_sym_LBRACE_RBRACE] = ACTIONS(103),
-    [aux_sym__word_common_token5] = ACTIONS(103),
+    [anon_sym_STAR] = ACTIONS(100),
+    [anon_sym_SQUOTE] = ACTIONS(103),
+    [aux_sym__word_common_token3] = ACTIONS(106),
+    [anon_sym_PIPE] = ACTIONS(109),
+    [anon_sym_LBRACE] = ACTIONS(112),
+    [anon_sym_RBRACE] = ACTIONS(106),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(106),
+    [aux_sym__word_common_token4] = ACTIONS(106),
     [anon_sym_LPAREN] = ACTIONS(97),
-    [aux_sym__word_common_token6] = ACTIONS(97),
-    [anon_sym_TILDE] = ACTIONS(103),
-    [anon_sym_GT] = ACTIONS(112),
-    [aux_sym_keycode_token1] = ACTIONS(115),
-    [aux_sym_keycode_token2] = ACTIONS(115),
-    [aux_sym_keycode_token3] = ACTIONS(115),
-    [aux_sym_keycode_token4] = ACTIONS(115),
-    [aux_sym_keycode_token5] = ACTIONS(118),
+    [aux_sym__word_common_token5] = ACTIONS(97),
+    [anon_sym_TILDE] = ACTIONS(106),
+    [anon_sym_GT] = ACTIONS(115),
+    [aux_sym_keycode_token1] = ACTIONS(118),
+    [aux_sym_keycode_token2] = ACTIONS(118),
+    [aux_sym_keycode_token3] = ACTIONS(118),
+    [aux_sym_keycode_token4] = ACTIONS(118),
+    [aux_sym_keycode_token5] = ACTIONS(121),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(121),
     [aux_sym_keycode_token6] = ACTIONS(118),
-    [aux_sym_keycode_token7] = ACTIONS(115),
-    [aux_sym_keycode_token8] = ACTIONS(115),
-    [aux_sym_uppercase_name_token1] = ACTIONS(121),
-    [anon_sym_LT] = ACTIONS(124),
-    [anon_sym_LF2] = ACTIONS(126),
-    [aux_sym_line_li_token1] = ACTIONS(126),
-    [aux_sym_h1_token1] = ACTIONS(128),
-    [aux_sym_h2_token1] = ACTIONS(131),
-    [anon_sym_STAR] = ACTIONS(134),
+    [aux_sym_keycode_token7] = ACTIONS(118),
+    [aux_sym_uppercase_name_token1] = ACTIONS(124),
+    [anon_sym_LT] = ACTIONS(127),
+    [anon_sym_LF2] = ACTIONS(129),
+    [aux_sym_line_li_token1] = ACTIONS(129),
+    [aux_sym_h1_token1] = ACTIONS(131),
+    [aux_sym_h2_token1] = ACTIONS(134),
     [sym_url_word] = ACTIONS(137),
-    [anon_sym_BQUOTE2] = ACTIONS(140),
+    [anon_sym_BQUOTE] = ACTIONS(140),
   },
 };
 
 static const uint16_t ts_small_parse_table[] = {
   [0] = 17,
-    ACTIONS(146), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(152), 1,
-      anon_sym_PIPE,
-    ACTIONS(155), 1,
-      anon_sym_LBRACE,
-    ACTIONS(164), 1,
-      aux_sym_uppercase_name_token1,
-    ACTIONS(167), 1,
-      anon_sym_LT,
-    ACTIONS(171), 1,
+    ACTIONS(149), 1,
       anon_sym_STAR,
+    ACTIONS(152), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(155), 1,
+      anon_sym_PIPE,
+    ACTIONS(158), 1,
+      anon_sym_LBRACE,
+    ACTIONS(167), 1,
+      aux_sym_uppercase_name_token1,
+    ACTIONS(170), 1,
+      anon_sym_LT,
     ACTIONS(174), 1,
       sym_url_word,
     ACTIONS(177), 1,
-      anon_sym_BQUOTE2,
+      anon_sym_BQUOTE,
     STATE(8), 1,
       aux_sym_line_li_repeat2,
-    STATE(67), 1,
+    STATE(66), 1,
       sym__line_noli,
-    STATE(80), 1,
+    STATE(87), 1,
       sym__word_common,
-    ACTIONS(161), 2,
+    ACTIONS(164), 2,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-    ACTIONS(169), 2,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+    ACTIONS(172), 2,
       anon_sym_LF2,
       aux_sym_line_li_token1,
-    ACTIONS(143), 4,
+    ACTIONS(143), 3,
       aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-    ACTIONS(158), 6,
+      aux_sym__word_common_token5,
+    ACTIONS(161), 6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(149), 7,
+    ACTIONS(146), 7,
+      aux_sym_word_noli_token2,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
     STATE(17), 11,
@@ -6957,53 +7310,52 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [78] = 17,
+  [77] = 17,
     ACTIONS(7), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(33), 1,
       anon_sym_STAR,
+    ACTIONS(9), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
+      anon_sym_LBRACE,
     ACTIONS(35), 1,
       sym_url_word,
     ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
+      anon_sym_BQUOTE,
     ACTIONS(180), 1,
       aux_sym_uppercase_name_token1,
     ACTIONS(182), 1,
       anon_sym_LT,
     STATE(8), 1,
       aux_sym_line_li_repeat2,
-    STATE(67), 1,
+    STATE(66), 1,
       sym__line_noli,
-    STATE(80), 1,
+    STATE(87), 1,
       sym__word_common,
-    ACTIONS(19), 2,
+    ACTIONS(21), 2,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
     ACTIONS(184), 2,
       anon_sym_LF2,
       aux_sym_line_li_token1,
-    ACTIONS(5), 4,
+    ACTIONS(5), 3,
       aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-    ACTIONS(17), 6,
+      aux_sym__word_common_token5,
+    ACTIONS(19), 6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(9), 7,
+    ACTIONS(11), 7,
+      aux_sym_word_noli_token2,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
     STATE(17), 11,
@@ -7018,53 +7370,52 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [156] = 17,
+  [154] = 17,
     ACTIONS(7), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(33), 1,
       anon_sym_STAR,
+    ACTIONS(9), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
+      anon_sym_LBRACE,
     ACTIONS(35), 1,
       sym_url_word,
     ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
+      anon_sym_BQUOTE,
     ACTIONS(180), 1,
       aux_sym_uppercase_name_token1,
     ACTIONS(186), 1,
       anon_sym_LT,
     STATE(8), 1,
       aux_sym_line_li_repeat2,
-    STATE(67), 1,
+    STATE(66), 1,
       sym__line_noli,
-    STATE(80), 1,
+    STATE(87), 1,
       sym__word_common,
-    ACTIONS(19), 2,
+    ACTIONS(21), 2,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
     ACTIONS(188), 2,
       anon_sym_LF2,
       aux_sym_line_li_token1,
-    ACTIONS(5), 4,
+    ACTIONS(5), 3,
       aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-    ACTIONS(17), 6,
+      aux_sym__word_common_token5,
+    ACTIONS(19), 6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(9), 7,
+    ACTIONS(11), 7,
+      aux_sym_word_noli_token2,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
     STATE(17), 11,
@@ -7079,53 +7430,52 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [234] = 17,
+  [231] = 17,
     ACTIONS(7), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(33), 1,
       anon_sym_STAR,
+    ACTIONS(9), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
+      anon_sym_LBRACE,
     ACTIONS(35), 1,
       sym_url_word,
     ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
+      anon_sym_BQUOTE,
     ACTIONS(180), 1,
       aux_sym_uppercase_name_token1,
     ACTIONS(190), 1,
       anon_sym_LT,
     STATE(8), 1,
       aux_sym_line_li_repeat2,
-    STATE(67), 1,
+    STATE(66), 1,
       sym__line_noli,
-    STATE(80), 1,
+    STATE(87), 1,
       sym__word_common,
-    ACTIONS(19), 2,
+    ACTIONS(21), 2,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
     ACTIONS(192), 2,
       anon_sym_LF2,
       aux_sym_line_li_token1,
-    ACTIONS(5), 4,
+    ACTIONS(5), 3,
       aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-    ACTIONS(17), 6,
+      aux_sym__word_common_token5,
+    ACTIONS(19), 6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(9), 7,
+    ACTIONS(11), 7,
+      aux_sym_word_noli_token2,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
     STATE(17), 11,
@@ -7140,53 +7490,52 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [312] = 17,
+  [308] = 17,
     ACTIONS(7), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(33), 1,
       anon_sym_STAR,
+    ACTIONS(9), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
+      anon_sym_LBRACE,
     ACTIONS(35), 1,
       sym_url_word,
     ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
+      anon_sym_BQUOTE,
     ACTIONS(180), 1,
       aux_sym_uppercase_name_token1,
     ACTIONS(194), 1,
       anon_sym_LT,
     STATE(8), 1,
       aux_sym_line_li_repeat2,
-    STATE(67), 1,
+    STATE(66), 1,
       sym__line_noli,
-    STATE(80), 1,
+    STATE(87), 1,
       sym__word_common,
-    ACTIONS(19), 2,
+    ACTIONS(21), 2,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
     ACTIONS(196), 2,
       anon_sym_LF2,
       aux_sym_line_li_token1,
-    ACTIONS(5), 4,
+    ACTIONS(5), 3,
       aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-    ACTIONS(17), 6,
+      aux_sym__word_common_token5,
+    ACTIONS(19), 6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(9), 7,
+    ACTIONS(11), 7,
+      aux_sym_word_noli_token2,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
     STATE(17), 11,
@@ -7201,53 +7550,52 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [390] = 17,
+  [385] = 17,
     ACTIONS(7), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(33), 1,
       anon_sym_STAR,
+    ACTIONS(9), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
+      anon_sym_LBRACE,
     ACTIONS(35), 1,
       sym_url_word,
     ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
+      anon_sym_BQUOTE,
     ACTIONS(180), 1,
       aux_sym_uppercase_name_token1,
     ACTIONS(198), 1,
       anon_sym_LT,
     STATE(9), 1,
       aux_sym_line_li_repeat2,
-    STATE(67), 1,
+    STATE(66), 1,
       sym__line_noli,
-    STATE(80), 1,
+    STATE(87), 1,
       sym__word_common,
-    ACTIONS(19), 2,
+    ACTIONS(21), 2,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
     ACTIONS(200), 2,
       anon_sym_LF2,
       aux_sym_line_li_token1,
-    ACTIONS(5), 4,
+    ACTIONS(5), 3,
       aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-    ACTIONS(17), 6,
+      aux_sym__word_common_token5,
+    ACTIONS(19), 6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(9), 7,
+    ACTIONS(11), 7,
+      aux_sym_word_noli_token2,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
     STATE(17), 11,
@@ -7262,53 +7610,52 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [468] = 17,
+  [462] = 17,
     ACTIONS(7), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(33), 1,
       anon_sym_STAR,
+    ACTIONS(9), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
+      anon_sym_LBRACE,
     ACTIONS(35), 1,
       sym_url_word,
     ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
+      anon_sym_BQUOTE,
     ACTIONS(180), 1,
       aux_sym_uppercase_name_token1,
     ACTIONS(202), 1,
       anon_sym_LT,
     STATE(10), 1,
       aux_sym_line_li_repeat2,
-    STATE(67), 1,
+    STATE(66), 1,
       sym__line_noli,
-    STATE(80), 1,
+    STATE(87), 1,
       sym__word_common,
-    ACTIONS(19), 2,
+    ACTIONS(21), 2,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
     ACTIONS(204), 2,
       anon_sym_LF2,
       aux_sym_line_li_token1,
-    ACTIONS(5), 4,
+    ACTIONS(5), 3,
       aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-    ACTIONS(17), 6,
+      aux_sym__word_common_token5,
+    ACTIONS(19), 6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(9), 7,
+    ACTIONS(11), 7,
+      aux_sym_word_noli_token2,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
     STATE(17), 11,
@@ -7323,53 +7670,52 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [546] = 17,
+  [539] = 17,
     ACTIONS(7), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(33), 1,
       anon_sym_STAR,
+    ACTIONS(9), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
+      anon_sym_LBRACE,
     ACTIONS(35), 1,
       sym_url_word,
     ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
+      anon_sym_BQUOTE,
     ACTIONS(180), 1,
       aux_sym_uppercase_name_token1,
     ACTIONS(206), 1,
       anon_sym_LT,
     STATE(11), 1,
       aux_sym_line_li_repeat2,
-    STATE(67), 1,
+    STATE(66), 1,
       sym__line_noli,
-    STATE(80), 1,
+    STATE(87), 1,
       sym__word_common,
-    ACTIONS(19), 2,
+    ACTIONS(21), 2,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
     ACTIONS(208), 2,
       anon_sym_LF2,
       aux_sym_line_li_token1,
-    ACTIONS(5), 4,
+    ACTIONS(5), 3,
       aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-    ACTIONS(17), 6,
+      aux_sym__word_common_token5,
+    ACTIONS(19), 6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(9), 7,
+    ACTIONS(11), 7,
+      aux_sym_word_noli_token2,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
     STATE(17), 11,
@@ -7384,53 +7730,52 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [624] = 17,
+  [616] = 17,
     ACTIONS(7), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(33), 1,
       anon_sym_STAR,
+    ACTIONS(9), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
+      anon_sym_LBRACE,
     ACTIONS(35), 1,
       sym_url_word,
     ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
+      anon_sym_BQUOTE,
     ACTIONS(180), 1,
       aux_sym_uppercase_name_token1,
     ACTIONS(210), 1,
       anon_sym_LT,
     STATE(12), 1,
       aux_sym_line_li_repeat2,
-    STATE(67), 1,
+    STATE(66), 1,
       sym__line_noli,
-    STATE(80), 1,
+    STATE(87), 1,
       sym__word_common,
-    ACTIONS(19), 2,
+    ACTIONS(21), 2,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
     ACTIONS(212), 2,
       anon_sym_LF2,
       aux_sym_line_li_token1,
-    ACTIONS(5), 4,
+    ACTIONS(5), 3,
       aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-    ACTIONS(17), 6,
+      aux_sym__word_common_token5,
+    ACTIONS(19), 6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(9), 7,
+    ACTIONS(11), 7,
+      aux_sym_word_noli_token2,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
     STATE(17), 11,
@@ -7445,219 +7790,49 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [702] = 16,
+  [693] = 16,
     ACTIONS(7), 1,
+      anon_sym_STAR,
+    ACTIONS(9), 1,
       anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
     ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
       anon_sym_LBRACE,
     ACTIONS(35), 1,
       sym_url_word,
     ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
+      anon_sym_BQUOTE,
     ACTIONS(218), 1,
       anon_sym_GT,
     ACTIONS(220), 1,
       anon_sym_LF2,
-    ACTIONS(222), 1,
-      anon_sym_STAR,
     STATE(20), 1,
-      aux_sym_line_li_repeat1,
-    STATE(66), 1,
-      sym_codeblock,
-    STATE(82), 1,
-      sym__word_common,
-    ACTIONS(214), 2,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
-    ACTIONS(17), 3,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-    ACTIONS(19), 5,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(216), 8,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-    STATE(84), 10,
-      sym__atom,
-      sym_word,
-      sym__atom_common,
-      sym_keycode,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [774] = 17,
-    ACTIONS(7), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(15), 1,
-      anon_sym_GT,
-    ACTIONS(35), 1,
-      sym_url_word,
-    ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
-    ACTIONS(222), 1,
-      anon_sym_STAR,
-    ACTIONS(224), 1,
-      anon_sym_TILDE,
-    ACTIONS(226), 1,
-      anon_sym_LF2,
-    STATE(22), 1,
-      aux_sym_line_li_repeat1,
-    STATE(54), 1,
-      sym_codeblock,
-    STATE(82), 1,
-      sym__word_common,
-    ACTIONS(214), 2,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
-    ACTIONS(17), 3,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-    ACTIONS(19), 5,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(216), 7,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-    STATE(84), 10,
-      sym__atom,
-      sym_word,
-      sym__atom_common,
-      sym_keycode,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [848] = 16,
-    ACTIONS(7), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(35), 1,
-      sym_url_word,
-    ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
-    ACTIONS(218), 1,
-      anon_sym_GT,
-    ACTIONS(222), 1,
-      anon_sym_STAR,
-    ACTIONS(228), 1,
-      anon_sym_LF2,
-    STATE(13), 1,
-      sym_codeblock,
-    STATE(23), 1,
-      aux_sym_line_li_repeat1,
-    STATE(82), 1,
-      sym__word_common,
-    ACTIONS(214), 2,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
-    ACTIONS(17), 3,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-    ACTIONS(19), 5,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(216), 8,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-    STATE(84), 10,
-      sym__atom,
-      sym_word,
-      sym__atom_common,
-      sym_keycode,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [920] = 16,
-    ACTIONS(7), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(35), 1,
-      sym_url_word,
-    ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
-    ACTIONS(218), 1,
-      anon_sym_GT,
-    ACTIONS(222), 1,
-      anon_sym_STAR,
-    ACTIONS(230), 1,
-      anon_sym_LF2,
-    STATE(23), 1,
       aux_sym_line_li_repeat1,
     STATE(64), 1,
       sym_codeblock,
-    STATE(82), 1,
+    STATE(85), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
       aux_sym_word_token2,
-    ACTIONS(17), 3,
+    ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(19), 5,
+    ACTIONS(21), 5,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(216), 8,
+    ACTIONS(216), 7,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
     STATE(84), 10,
       sym__atom,
@@ -7670,50 +7845,105 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [992] = 16,
+  [764] = 17,
     ACTIONS(7), 1,
+      anon_sym_STAR,
+    ACTIONS(9), 1,
       anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
     ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
+      anon_sym_LBRACE,
+    ACTIONS(17), 1,
+      anon_sym_GT,
+    ACTIONS(35), 1,
+      sym_url_word,
+    ACTIONS(37), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(222), 1,
+      anon_sym_TILDE,
+    ACTIONS(224), 1,
+      anon_sym_LF2,
+    STATE(21), 1,
+      aux_sym_line_li_repeat1,
+    STATE(53), 1,
+      sym_codeblock,
+    STATE(85), 1,
+      sym__word_common,
+    ACTIONS(214), 2,
+      aux_sym_word_token1,
+      aux_sym_word_token2,
+    ACTIONS(19), 3,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+    ACTIONS(21), 5,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+    ACTIONS(216), 6,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+    STATE(84), 10,
+      sym__atom,
+      sym_word,
+      sym__atom_common,
+      sym_keycode,
+      sym_tag,
+      sym_url,
+      sym_optionlink,
+      sym_taglink,
+      sym_codespan,
+      sym_argument,
+  [837] = 16,
+    ACTIONS(7), 1,
+      anon_sym_STAR,
+    ACTIONS(9), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
       anon_sym_LBRACE,
     ACTIONS(35), 1,
       sym_url_word,
     ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
+      anon_sym_BQUOTE,
     ACTIONS(218), 1,
       anon_sym_GT,
-    ACTIONS(222), 1,
-      anon_sym_STAR,
-    ACTIONS(232), 1,
+    ACTIONS(226), 1,
       anon_sym_LF2,
-    STATE(15), 1,
+    STATE(13), 1,
       sym_codeblock,
-    STATE(23), 1,
+    STATE(24), 1,
       aux_sym_line_li_repeat1,
-    STATE(82), 1,
+    STATE(85), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
       aux_sym_word_token2,
-    ACTIONS(17), 3,
+    ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(19), 5,
+    ACTIONS(21), 5,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(216), 8,
+    ACTIONS(216), 7,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
     STATE(84), 10,
       sym__atom,
@@ -7726,52 +7956,106 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1064] = 17,
+  [908] = 16,
     ACTIONS(7), 1,
+      anon_sym_STAR,
+    ACTIONS(9), 1,
       anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
     ACTIONS(13), 1,
-      anon_sym_LBRACE,
+      anon_sym_PIPE,
     ACTIONS(15), 1,
+      anon_sym_LBRACE,
+    ACTIONS(35), 1,
+      sym_url_word,
+    ACTIONS(37), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(218), 1,
+      anon_sym_GT,
+    ACTIONS(228), 1,
+      anon_sym_LF2,
+    STATE(24), 1,
+      aux_sym_line_li_repeat1,
+    STATE(63), 1,
+      sym_codeblock,
+    STATE(85), 1,
+      sym__word_common,
+    ACTIONS(214), 2,
+      aux_sym_word_token1,
+      aux_sym_word_token2,
+    ACTIONS(19), 3,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+    ACTIONS(21), 5,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+    ACTIONS(216), 7,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+    STATE(84), 10,
+      sym__atom,
+      sym_word,
+      sym__atom_common,
+      sym_keycode,
+      sym_tag,
+      sym_url,
+      sym_optionlink,
+      sym_taglink,
+      sym_codespan,
+      sym_argument,
+  [979] = 17,
+    ACTIONS(7), 1,
+      anon_sym_STAR,
+    ACTIONS(9), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
+      anon_sym_LBRACE,
+    ACTIONS(17), 1,
       anon_sym_GT,
     ACTIONS(35), 1,
       sym_url_word,
     ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
-    ACTIONS(222), 1,
-      anon_sym_STAR,
-    ACTIONS(234), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(230), 1,
       anon_sym_TILDE,
-    ACTIONS(236), 1,
+    ACTIONS(232), 1,
       anon_sym_LF2,
-    STATE(23), 1,
+    STATE(24), 1,
       aux_sym_line_li_repeat1,
     STATE(52), 1,
       sym_codeblock,
-    STATE(82), 1,
+    STATE(85), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
       aux_sym_word_token2,
-    ACTIONS(17), 3,
+    ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(19), 5,
+    ACTIONS(21), 5,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(216), 7,
+    ACTIONS(216), 6,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -7783,46 +8067,152 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1138] = 14,
-    ACTIONS(241), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(247), 1,
-      anon_sym_PIPE,
-    ACTIONS(250), 1,
-      anon_sym_LBRACE,
-    ACTIONS(259), 1,
-      anon_sym_LF2,
-    ACTIONS(261), 1,
+  [1052] = 16,
+    ACTIONS(7), 1,
       anon_sym_STAR,
+    ACTIONS(9), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
+      anon_sym_LBRACE,
+    ACTIONS(35), 1,
+      sym_url_word,
+    ACTIONS(37), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(218), 1,
+      anon_sym_GT,
+    ACTIONS(234), 1,
+      anon_sym_LF2,
+    STATE(15), 1,
+      sym_codeblock,
+    STATE(24), 1,
+      aux_sym_line_li_repeat1,
+    STATE(85), 1,
+      sym__word_common,
+    ACTIONS(214), 2,
+      aux_sym_word_token1,
+      aux_sym_word_token2,
+    ACTIONS(19), 3,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+    ACTIONS(21), 5,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+    ACTIONS(216), 7,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+    STATE(84), 10,
+      sym__atom,
+      sym_word,
+      sym__atom_common,
+      sym_keycode,
+      sym_tag,
+      sym_url,
+      sym_optionlink,
+      sym_taglink,
+      sym_codespan,
+      sym_argument,
+  [1123] = 14,
+    ACTIONS(7), 1,
+      anon_sym_STAR,
+    ACTIONS(9), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
+      anon_sym_LBRACE,
+    ACTIONS(35), 1,
+      sym_url_word,
+    ACTIONS(37), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(236), 1,
+      anon_sym_LF2,
+    STATE(24), 1,
+      aux_sym_line_li_repeat1,
+    STATE(85), 1,
+      sym__word_common,
+    ACTIONS(214), 2,
+      aux_sym_word_token1,
+      aux_sym_word_token2,
+    ACTIONS(19), 3,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+    ACTIONS(21), 5,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+    ACTIONS(216), 8,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+      anon_sym_GT,
+    STATE(84), 10,
+      sym__atom,
+      sym_word,
+      sym__atom_common,
+      sym_keycode,
+      sym_tag,
+      sym_url,
+      sym_optionlink,
+      sym_taglink,
+      sym_codespan,
+      sym_argument,
+  [1189] = 14,
+    ACTIONS(241), 1,
+      anon_sym_STAR,
+    ACTIONS(244), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(250), 1,
+      anon_sym_PIPE,
+    ACTIONS(253), 1,
+      anon_sym_LBRACE,
+    ACTIONS(262), 1,
+      anon_sym_LF2,
     ACTIONS(264), 1,
       sym_url_word,
     ACTIONS(267), 1,
-      anon_sym_BQUOTE2,
-    STATE(23), 1,
+      anon_sym_BQUOTE,
+    STATE(24), 1,
       aux_sym_line_li_repeat1,
-    STATE(82), 1,
+    STATE(85), 1,
       sym__word_common,
     ACTIONS(238), 2,
       aux_sym_word_token1,
       aux_sym_word_token2,
-    ACTIONS(253), 3,
+    ACTIONS(256), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(256), 5,
+    ACTIONS(259), 5,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(244), 9,
+    ACTIONS(247), 8,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
     STATE(84), 10,
@@ -7836,46 +8226,45 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1205] = 14,
+  [1255] = 14,
     ACTIONS(7), 1,
+      anon_sym_STAR,
+    ACTIONS(9), 1,
       anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
     ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
       anon_sym_LBRACE,
     ACTIONS(35), 1,
       sym_url_word,
     ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
-    ACTIONS(222), 1,
-      anon_sym_STAR,
+      anon_sym_BQUOTE,
     ACTIONS(270), 1,
       anon_sym_LF2,
     STATE(23), 1,
       aux_sym_line_li_repeat1,
-    STATE(82), 1,
+    STATE(85), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
       aux_sym_word_token2,
-    ACTIONS(17), 3,
+    ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(19), 5,
+    ACTIONS(21), 5,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(216), 9,
+    ACTIONS(216), 8,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
     STATE(84), 10,
@@ -7889,46 +8278,45 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1272] = 14,
+  [1321] = 14,
     ACTIONS(7), 1,
+      anon_sym_STAR,
+    ACTIONS(9), 1,
       anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
     ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
       anon_sym_LBRACE,
     ACTIONS(35), 1,
       sym_url_word,
     ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
-    ACTIONS(222), 1,
-      anon_sym_STAR,
+      anon_sym_BQUOTE,
     ACTIONS(272), 1,
       anon_sym_LF2,
     STATE(24), 1,
       aux_sym_line_li_repeat1,
-    STATE(82), 1,
+    STATE(85), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
       aux_sym_word_token2,
-    ACTIONS(17), 3,
+    ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(19), 5,
+    ACTIONS(21), 5,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(216), 9,
+    ACTIONS(216), 8,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
     STATE(84), 10,
@@ -7942,46 +8330,45 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1339] = 14,
+  [1387] = 14,
     ACTIONS(7), 1,
+      anon_sym_STAR,
+    ACTIONS(9), 1,
       anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
     ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
       anon_sym_LBRACE,
     ACTIONS(35), 1,
       sym_url_word,
     ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
-    ACTIONS(222), 1,
-      anon_sym_STAR,
+      anon_sym_BQUOTE,
     ACTIONS(274), 1,
       anon_sym_LF2,
-    STATE(23), 1,
+    STATE(24), 1,
       aux_sym_line_li_repeat1,
-    STATE(82), 1,
+    STATE(85), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
       aux_sym_word_token2,
-    ACTIONS(17), 3,
+    ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(19), 5,
+    ACTIONS(21), 5,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(216), 9,
+    ACTIONS(216), 8,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
     STATE(84), 10,
@@ -7995,97 +8382,43 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1406] = 14,
+  [1453] = 13,
     ACTIONS(7), 1,
+      anon_sym_STAR,
+    ACTIONS(9), 1,
       anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
     ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
       anon_sym_LBRACE,
     ACTIONS(35), 1,
       sym_url_word,
     ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
-    ACTIONS(222), 1,
-      anon_sym_STAR,
-    ACTIONS(276), 1,
-      anon_sym_LF2,
-    STATE(23), 1,
-      aux_sym_line_li_repeat1,
-    STATE(82), 1,
-      sym__word_common,
-    ACTIONS(214), 2,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
-    ACTIONS(17), 3,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-    ACTIONS(19), 5,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(216), 9,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
-    STATE(84), 10,
-      sym__atom,
-      sym_word,
-      sym__atom_common,
-      sym_keycode,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [1473] = 13,
-    ACTIONS(7), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(35), 1,
-      sym_url_word,
-    ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
-    ACTIONS(222), 1,
-      anon_sym_STAR,
+      anon_sym_BQUOTE,
     STATE(27), 1,
       aux_sym_line_li_repeat1,
-    STATE(82), 1,
+    STATE(85), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
       aux_sym_word_token2,
-    ACTIONS(17), 3,
+    ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(19), 5,
+    ACTIONS(21), 5,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(216), 9,
+    ACTIONS(216), 8,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
     STATE(84), 10,
@@ -8099,44 +8432,43 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1537] = 13,
+  [1516] = 13,
     ACTIONS(7), 1,
+      anon_sym_STAR,
+    ACTIONS(9), 1,
       anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
     ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
       anon_sym_LBRACE,
     ACTIONS(35), 1,
       sym_url_word,
     ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
-    ACTIONS(222), 1,
-      anon_sym_STAR,
+      anon_sym_BQUOTE,
     STATE(26), 1,
       aux_sym_line_li_repeat1,
-    STATE(82), 1,
+    STATE(85), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
       aux_sym_word_token2,
-    ACTIONS(17), 3,
+    ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(19), 5,
+    ACTIONS(21), 5,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(216), 9,
+    ACTIONS(216), 8,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
     STATE(84), 10,
@@ -8150,44 +8482,93 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1601] = 13,
+  [1579] = 13,
     ACTIONS(7), 1,
+      anon_sym_STAR,
+    ACTIONS(9), 1,
       anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
     ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
       anon_sym_LBRACE,
     ACTIONS(35), 1,
       sym_url_word,
     ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
-    ACTIONS(222), 1,
+      anon_sym_BQUOTE,
+    STATE(22), 1,
+      aux_sym_line_li_repeat1,
+    STATE(85), 1,
+      sym__word_common,
+    ACTIONS(214), 2,
+      aux_sym_word_token1,
+      aux_sym_word_token2,
+    ACTIONS(19), 3,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+    ACTIONS(21), 5,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+    ACTIONS(216), 8,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+      anon_sym_GT,
+    STATE(84), 10,
+      sym__atom,
+      sym_word,
+      sym__atom_common,
+      sym_keycode,
+      sym_tag,
+      sym_url,
+      sym_optionlink,
+      sym_taglink,
+      sym_codespan,
+      sym_argument,
+  [1642] = 13,
+    ACTIONS(7), 1,
       anon_sym_STAR,
+    ACTIONS(9), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
+      anon_sym_LBRACE,
+    ACTIONS(35), 1,
+      sym_url_word,
+    ACTIONS(37), 1,
+      anon_sym_BQUOTE,
     STATE(19), 1,
       aux_sym_line_li_repeat1,
-    STATE(82), 1,
+    STATE(85), 1,
       sym__word_common,
     ACTIONS(214), 2,
       aux_sym_word_token1,
       aux_sym_word_token2,
-    ACTIONS(17), 3,
+    ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(19), 5,
+    ACTIONS(21), 5,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(216), 9,
+    ACTIONS(216), 8,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
     STATE(84), 10,
@@ -8201,707 +8582,643 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1665] = 13,
-    ACTIONS(7), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(35), 1,
-      sym_url_word,
-    ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
-    ACTIONS(222), 1,
-      anon_sym_STAR,
-    STATE(21), 1,
-      aux_sym_line_li_repeat1,
-    STATE(82), 1,
-      sym__word_common,
-    ACTIONS(214), 2,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
-    ACTIONS(17), 3,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-    ACTIONS(19), 5,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(216), 9,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
-    STATE(84), 10,
-      sym__atom,
-      sym_word,
-      sym__atom_common,
-      sym_keycode,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [1729] = 6,
-    ACTIONS(25), 1,
-      anon_sym_LF2,
-    ACTIONS(282), 1,
-      aux_sym_line_li_token1,
-    STATE(33), 1,
-      aux_sym_help_file_repeat1,
-    STATE(46), 1,
-      sym__blank,
-    ACTIONS(278), 15,
-      ts_builtin_sym_end,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-    ACTIONS(280), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-  [1776] = 5,
-    ACTIONS(25), 1,
+  [1705] = 5,
+    ACTIONS(27), 1,
       anon_sym_LF2,
     STATE(43), 1,
       aux_sym_help_file_repeat1,
-    STATE(46), 1,
+    STATE(50), 1,
       sym__blank,
-    ACTIONS(286), 15,
+    ACTIONS(278), 14,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
+    ACTIONS(276), 16,
+      ts_builtin_sym_end,
       anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_line_li_token1,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [1749] = 5,
+    ACTIONS(27), 1,
+      anon_sym_LF2,
+    STATE(32), 1,
+      aux_sym_help_file_repeat1,
+    STATE(50), 1,
+      sym__blank,
+    ACTIONS(282), 14,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+    ACTIONS(280), 16,
+      ts_builtin_sym_end,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_line_li_token1,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [1793] = 5,
+    ACTIONS(27), 1,
+      anon_sym_LF2,
+    STATE(43), 1,
+      aux_sym_help_file_repeat1,
+    STATE(50), 1,
+      sym__blank,
+    ACTIONS(286), 14,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
     ACTIONS(284), 16,
       ts_builtin_sym_end,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_line_li_token1,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [1821] = 6,
-    ACTIONS(290), 1,
-      anon_sym_LF2,
-    ACTIONS(292), 1,
-      aux_sym_line_code_token1,
-    STATE(35), 1,
-      aux_sym_codeblock_repeat1,
-    STATE(48), 1,
-      sym_line_code,
-    ACTIONS(294), 2,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-    ACTIONS(288), 28,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_PIPE,
-      aux_sym__word_common_token4,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      aux_sym_line_li_token1,
       anon_sym_STAR,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [1868] = 6,
-    ACTIONS(298), 1,
-      anon_sym_LF2,
-    ACTIONS(301), 1,
-      aux_sym_line_code_token1,
-    STATE(35), 1,
-      aux_sym_codeblock_repeat1,
-    STATE(48), 1,
-      sym_line_code,
-    ACTIONS(304), 2,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-    ACTIONS(296), 28,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_PIPE,
-      aux_sym__word_common_token4,
-      anon_sym_LBRACE,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_line_li_token1,
-      anon_sym_STAR,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [1915] = 5,
-    ACTIONS(25), 1,
+      anon_sym_BQUOTE,
+  [1837] = 5,
+    ACTIONS(27), 1,
       anon_sym_LF2,
     STATE(43), 1,
       aux_sym_help_file_repeat1,
-    STATE(46), 1,
-      sym__blank,
-    ACTIONS(308), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-    ACTIONS(306), 16,
-      ts_builtin_sym_end,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_line_li_token1,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [1960] = 5,
-    ACTIONS(25), 1,
-      anon_sym_LF2,
-    STATE(39), 1,
-      aux_sym_help_file_repeat1,
-    STATE(46), 1,
-      sym__blank,
-    ACTIONS(312), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-    ACTIONS(310), 16,
-      ts_builtin_sym_end,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_line_li_token1,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [2005] = 5,
-    ACTIONS(25), 1,
-      anon_sym_LF2,
-    STATE(43), 1,
-      aux_sym_help_file_repeat1,
-    STATE(46), 1,
-      sym__blank,
-    ACTIONS(316), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-    ACTIONS(314), 16,
-      ts_builtin_sym_end,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_line_li_token1,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [2050] = 5,
-    ACTIONS(25), 1,
-      anon_sym_LF2,
-    STATE(43), 1,
-      aux_sym_help_file_repeat1,
-    STATE(46), 1,
-      sym__blank,
-    ACTIONS(320), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-    ACTIONS(318), 16,
-      ts_builtin_sym_end,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_line_li_token1,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [2095] = 5,
-    ACTIONS(25), 1,
-      anon_sym_LF2,
-    STATE(36), 1,
-      aux_sym_help_file_repeat1,
-    STATE(46), 1,
-      sym__blank,
-    ACTIONS(316), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-    ACTIONS(314), 16,
-      ts_builtin_sym_end,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_line_li_token1,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [2140] = 5,
-    ACTIONS(25), 1,
-      anon_sym_LF2,
-    STATE(44), 1,
-      aux_sym_help_file_repeat1,
-    STATE(46), 1,
-      sym__blank,
-    ACTIONS(312), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-    ACTIONS(310), 16,
-      ts_builtin_sym_end,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_line_li_token1,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [2185] = 6,
-    ACTIONS(25), 1,
-      anon_sym_LF2,
-    ACTIONS(282), 1,
-      aux_sym_line_li_token1,
-    STATE(38), 1,
-      aux_sym_help_file_repeat1,
-    STATE(46), 1,
-      sym__blank,
-    ACTIONS(322), 15,
-      ts_builtin_sym_end,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-    ACTIONS(324), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-  [2232] = 5,
-    ACTIONS(330), 1,
-      anon_sym_LF2,
-    STATE(43), 1,
-      aux_sym_help_file_repeat1,
-    STATE(46), 1,
-      sym__blank,
-    ACTIONS(328), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-    ACTIONS(326), 16,
-      ts_builtin_sym_end,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_line_li_token1,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [2277] = 5,
-    ACTIONS(25), 1,
-      anon_sym_LF2,
-    STATE(43), 1,
-      aux_sym_help_file_repeat1,
-    STATE(46), 1,
-      sym__blank,
-    ACTIONS(320), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-    ACTIONS(318), 16,
-      ts_builtin_sym_end,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_line_li_token1,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [2322] = 5,
-    ACTIONS(333), 1,
-      anon_sym_LF2,
-    ACTIONS(335), 1,
-      aux_sym_line_code_token1,
     STATE(50), 1,
-      aux_sym_codeblock_repeat1,
-    STATE(62), 1,
-      sym_line_code,
-    ACTIONS(288), 28,
+      sym__blank,
+    ACTIONS(290), 14,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
       anon_sym_PIPE,
-      aux_sym__word_common_token4,
       anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
+      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-      aux_sym_line_li_token1,
-      anon_sym_STAR,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [2365] = 2,
-    ACTIONS(339), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-    ACTIONS(337), 17,
+    ACTIONS(288), 16,
       ts_builtin_sym_end,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      anon_sym_LF2,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_line_li_token1,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [2402] = 2,
-    ACTIONS(343), 15,
+      anon_sym_BQUOTE,
+  [1881] = 6,
+    ACTIONS(294), 1,
+      anon_sym_LF2,
+    ACTIONS(297), 1,
+      aux_sym_line_code_token1,
+    STATE(36), 1,
+      aux_sym_codeblock_repeat1,
+    STATE(49), 1,
+      sym_line_code,
+    ACTIONS(300), 2,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+    ACTIONS(292), 27,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+      aux_sym_line_li_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [1927] = 5,
+    ACTIONS(27), 1,
+      anon_sym_LF2,
+    STATE(43), 1,
+      aux_sym_help_file_repeat1,
+    STATE(50), 1,
+      sym__blank,
+    ACTIONS(278), 14,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
+    ACTIONS(276), 16,
+      ts_builtin_sym_end,
       anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_line_li_token1,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [1971] = 5,
+    ACTIONS(27), 1,
+      anon_sym_LF2,
+    STATE(34), 1,
+      aux_sym_help_file_repeat1,
+    STATE(50), 1,
+      sym__blank,
+    ACTIONS(304), 14,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+    ACTIONS(302), 16,
+      ts_builtin_sym_end,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_line_li_token1,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [2015] = 6,
+    ACTIONS(27), 1,
+      anon_sym_LF2,
+    ACTIONS(310), 1,
+      aux_sym_line_li_token1,
+    STATE(35), 1,
+      aux_sym_help_file_repeat1,
+    STATE(50), 1,
+      sym__blank,
+    ACTIONS(308), 14,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+    ACTIONS(306), 15,
+      ts_builtin_sym_end,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [2061] = 5,
+    ACTIONS(27), 1,
+      anon_sym_LF2,
+    STATE(43), 1,
+      aux_sym_help_file_repeat1,
+    STATE(50), 1,
+      sym__blank,
+    ACTIONS(304), 14,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+    ACTIONS(302), 16,
+      ts_builtin_sym_end,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_line_li_token1,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [2105] = 5,
+    ACTIONS(27), 1,
+      anon_sym_LF2,
+    STATE(37), 1,
+      aux_sym_help_file_repeat1,
+    STATE(50), 1,
+      sym__blank,
+    ACTIONS(282), 14,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+    ACTIONS(280), 16,
+      ts_builtin_sym_end,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_line_li_token1,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [2149] = 6,
+    ACTIONS(314), 1,
+      anon_sym_LF2,
+    ACTIONS(316), 1,
+      aux_sym_line_code_token1,
+    STATE(36), 1,
+      aux_sym_codeblock_repeat1,
+    STATE(49), 1,
+      sym_line_code,
+    ACTIONS(318), 2,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+    ACTIONS(312), 27,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+      aux_sym_line_li_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [2195] = 5,
+    ACTIONS(324), 1,
+      anon_sym_LF2,
+    STATE(43), 1,
+      aux_sym_help_file_repeat1,
+    STATE(50), 1,
+      sym__blank,
+    ACTIONS(322), 14,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+    ACTIONS(320), 16,
+      ts_builtin_sym_end,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_line_li_token1,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [2239] = 6,
+    ACTIONS(27), 1,
+      anon_sym_LF2,
+    ACTIONS(310), 1,
+      aux_sym_line_li_token1,
+    STATE(40), 1,
+      aux_sym_help_file_repeat1,
+    STATE(50), 1,
+      sym__blank,
+    ACTIONS(329), 14,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+    ACTIONS(327), 15,
+      ts_builtin_sym_end,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [2285] = 5,
+    ACTIONS(331), 1,
+      anon_sym_LF2,
+    ACTIONS(334), 1,
+      aux_sym_line_code_token1,
+    STATE(45), 1,
+      aux_sym_codeblock_repeat1,
+    STATE(61), 1,
+      sym_line_code,
+    ACTIONS(292), 27,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+      aux_sym_line_li_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [2327] = 5,
+    ACTIONS(337), 1,
+      anon_sym_LF2,
+    ACTIONS(339), 1,
+      aux_sym_line_code_token1,
+    STATE(45), 1,
+      aux_sym_codeblock_repeat1,
+    STATE(61), 1,
+      sym_line_code,
+    ACTIONS(312), 27,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+      aux_sym_line_li_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [2369] = 2,
+    ACTIONS(343), 14,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
     ACTIONS(341), 17,
       ts_builtin_sym_end,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
       aux_sym_line_li_token1,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [2439] = 2,
+      anon_sym_BQUOTE,
+  [2405] = 2,
     ACTIONS(347), 3,
       anon_sym_LF2,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
-    ACTIONS(345), 29,
+    ACTIONS(345), 28,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       anon_sym_PIPE,
-      aux_sym__word_common_token4,
       anon_sym_LBRACE,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token1,
@@ -8909,34 +9226,33 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       aux_sym_line_li_token1,
       aux_sym_line_code_token1,
-      anon_sym_STAR,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [2476] = 2,
+      anon_sym_BQUOTE,
+  [2441] = 2,
     ACTIONS(351), 3,
       anon_sym_LF2,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
-    ACTIONS(349), 29,
+    ACTIONS(349), 28,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       anon_sym_PIPE,
-      aux_sym__word_common_token4,
       anon_sym_LBRACE,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token1,
@@ -8944,479 +9260,395 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       aux_sym_line_li_token1,
       aux_sym_line_code_token1,
-      anon_sym_STAR,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [2513] = 5,
-    ACTIONS(353), 1,
-      anon_sym_LF2,
-    ACTIONS(356), 1,
-      aux_sym_line_code_token1,
-    STATE(50), 1,
-      aux_sym_codeblock_repeat1,
-    STATE(62), 1,
-      sym_line_code,
-    ACTIONS(296), 28,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_PIPE,
-      aux_sym__word_common_token4,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      aux_sym_line_li_token1,
-      anon_sym_STAR,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [2556] = 3,
-    ACTIONS(361), 3,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_LF2,
-    ACTIONS(363), 6,
-      aux_sym_taglink_token1,
-      anon_sym_LBRACE2,
-      anon_sym_RBRACE2,
-      anon_sym_LPAREN2,
-      anon_sym_RPAREN,
       anon_sym_BQUOTE,
-    ACTIONS(359), 23,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
-      anon_sym_SQUOTE,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      anon_sym_STAR,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [2595] = 2,
-    ACTIONS(365), 15,
+  [2477] = 2,
+    ACTIONS(355), 14,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
+    ACTIONS(353), 17,
+      ts_builtin_sym_end,
       anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      anon_sym_LF2,
+      aux_sym_line_li_token1,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [2513] = 2,
+    ACTIONS(357), 14,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+    ACTIONS(359), 16,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      anon_sym_LF2,
+      aux_sym_line_li_token1,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [2548] = 2,
+    ACTIONS(361), 14,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+    ACTIONS(363), 16,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      anon_sym_LF2,
+      aux_sym_line_li_token1,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [2583] = 2,
+    ACTIONS(365), 14,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
     ACTIONS(367), 16,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
       aux_sym_line_li_token1,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [2631] = 2,
-    ACTIONS(369), 15,
+      anon_sym_BQUOTE,
+  [2618] = 2,
+    ACTIONS(369), 14,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-      anon_sym_STAR,
     ACTIONS(371), 16,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
       aux_sym_line_li_token1,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [2667] = 2,
-    ACTIONS(373), 15,
+      anon_sym_BQUOTE,
+  [2653] = 2,
+    ACTIONS(373), 14,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-      anon_sym_STAR,
     ACTIONS(375), 16,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
       aux_sym_line_li_token1,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [2703] = 2,
-    ACTIONS(377), 15,
+      anon_sym_BQUOTE,
+  [2688] = 2,
+    ACTIONS(377), 14,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-      anon_sym_STAR,
     ACTIONS(379), 16,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
       aux_sym_line_li_token1,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [2739] = 2,
-    ACTIONS(381), 15,
+      anon_sym_BQUOTE,
+  [2723] = 2,
+    ACTIONS(381), 14,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-      anon_sym_STAR,
     ACTIONS(383), 16,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
       aux_sym_line_li_token1,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [2775] = 2,
-    ACTIONS(385), 15,
+      anon_sym_BQUOTE,
+  [2758] = 2,
+    ACTIONS(385), 14,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-      anon_sym_STAR,
     ACTIONS(387), 16,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
       aux_sym_line_li_token1,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [2811] = 2,
-    ACTIONS(389), 15,
+      anon_sym_BQUOTE,
+  [2793] = 2,
+    ACTIONS(389), 14,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-      anon_sym_STAR,
     ACTIONS(391), 16,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
       aux_sym_line_li_token1,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [2847] = 2,
-    ACTIONS(393), 15,
+      anon_sym_BQUOTE,
+  [2828] = 2,
+    ACTIONS(393), 14,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-      anon_sym_STAR,
     ACTIONS(395), 16,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
       aux_sym_line_li_token1,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [2883] = 2,
-    ACTIONS(397), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-    ACTIONS(399), 16,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [2919] = 2,
-    ACTIONS(401), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-    ACTIONS(403), 16,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [2955] = 2,
-    ACTIONS(347), 1,
-      anon_sym_LF2,
-    ACTIONS(345), 29,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_PIPE,
-      aux_sym__word_common_token4,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      aux_sym_line_li_token1,
-      aux_sym_line_code_token1,
-      anon_sym_STAR,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [2990] = 2,
+      anon_sym_BQUOTE,
+  [2863] = 2,
     ACTIONS(351), 1,
       anon_sym_LF2,
-    ACTIONS(349), 29,
+    ACTIONS(349), 28,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       anon_sym_PIPE,
-      aux_sym__word_common_token4,
       anon_sym_LBRACE,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token1,
@@ -9424,151 +9656,242 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       aux_sym_line_li_token1,
       aux_sym_line_code_token1,
-      anon_sym_STAR,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [3025] = 2,
-    ACTIONS(367), 14,
+      anon_sym_BQUOTE,
+  [2897] = 2,
+    ACTIONS(347), 1,
+      anon_sym_LF2,
+    ACTIONS(345), 28,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
       aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-    ACTIONS(365), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
+      aux_sym_line_li_token1,
+      aux_sym_line_code_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [2931] = 2,
+    ACTIONS(361), 13,
+      aux_sym_word_noli_token1,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+    ACTIONS(363), 15,
+      aux_sym_word_noli_token2,
       anon_sym_STAR,
-  [3059] = 4,
-    ACTIONS(407), 1,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      anon_sym_LF2,
+      aux_sym_line_li_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [2964] = 2,
+    ACTIONS(365), 13,
+      aux_sym_word_noli_token1,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+    ACTIONS(367), 15,
+      aux_sym_word_noli_token2,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      anon_sym_LF2,
+      aux_sym_line_li_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [2997] = 4,
+    ACTIONS(403), 1,
       aux_sym_optionlink_token1,
-    ACTIONS(405), 2,
+    ACTIONS(401), 2,
       aux_sym__word_common_token1,
       aux_sym__word_common_token2,
-    ACTIONS(361), 11,
+    ACTIONS(399), 10,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       anon_sym_LF2,
-    ACTIONS(359), 15,
+    ACTIONS(397), 15,
+      aux_sym_word_token1,
+      aux_sym_word_token2,
+      anon_sym_STAR,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [3034] = 2,
+    ACTIONS(405), 13,
+      aux_sym_word_noli_token1,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+    ACTIONS(407), 15,
+      aux_sym_word_noli_token2,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      anon_sym_LF2,
+      aux_sym_line_li_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [3067] = 4,
+    ACTIONS(413), 1,
+      aux_sym_uppercase_name_token2,
+    STATE(67), 1,
+      aux_sym_uppercase_name_repeat1,
+    ACTIONS(409), 12,
       aux_sym_word_token1,
       aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
-      anon_sym_RBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      anon_sym_STAR,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [3097] = 2,
-    ACTIONS(375), 14,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-    ACTIONS(373), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
+    ACTIONS(411), 13,
       anon_sym_STAR,
-  [3131] = 2,
-    ACTIONS(411), 14,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
-      aux_sym_line_li_token1,
       sym_url_word,
-      anon_sym_BQUOTE2,
-    ACTIONS(409), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
+      anon_sym_BQUOTE,
+  [3103] = 4,
+    ACTIONS(420), 1,
+      aux_sym_uppercase_name_token2,
+    STATE(70), 1,
+      aux_sym_uppercase_name_repeat1,
+    ACTIONS(416), 12,
+      aux_sym_word_token1,
+      aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
+    ACTIONS(418), 13,
       anon_sym_STAR,
-  [3165] = 3,
-    ACTIONS(413), 2,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      anon_sym_LF2,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [3139] = 3,
+    ACTIONS(422), 2,
       aux_sym_codeblock_token1,
       anon_sym_LF,
-    ACTIONS(359), 8,
+    ACTIONS(397), 8,
       aux_sym_word_token1,
       aux_sym_word_token2,
       anon_sym_PIPE,
@@ -9577,197 +9900,187 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       anon_sym_LF2,
-    ACTIONS(361), 18,
+    ACTIONS(399), 17,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      anon_sym_STAR,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [3200] = 4,
-    ACTIONS(419), 1,
+      anon_sym_BQUOTE,
+  [3173] = 4,
+    ACTIONS(420), 1,
       aux_sym_uppercase_name_token2,
-    STATE(69), 1,
+    STATE(67), 1,
       aux_sym_uppercase_name_repeat1,
-    ACTIONS(415), 12,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(417), 14,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      anon_sym_LF2,
-      anon_sym_STAR,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [3237] = 5,
-    ACTIONS(426), 1,
-      aux_sym_uppercase_name_token2,
-    STATE(73), 1,
-      aux_sym_uppercase_name_repeat1,
-    ACTIONS(428), 2,
-      anon_sym_LF2,
-      anon_sym_STAR,
-    ACTIONS(422), 12,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
     ACTIONS(424), 12,
+      aux_sym_word_token1,
+      aux_sym_word_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+    ACTIONS(426), 13,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      anon_sym_LF2,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [3276] = 4,
-    ACTIONS(426), 1,
+      anon_sym_BQUOTE,
+  [3209] = 3,
+    ACTIONS(428), 2,
+      aux_sym_codeblock_token1,
+      anon_sym_LF,
+    ACTIONS(397), 8,
+      aux_sym_word_token1,
+      aux_sym_word_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      anon_sym_LF2,
+    ACTIONS(399), 17,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [3243] = 5,
+    ACTIONS(420), 1,
+      aux_sym_uppercase_name_token2,
+    STATE(67), 1,
+      aux_sym_uppercase_name_repeat1,
+    ACTIONS(430), 2,
+      anon_sym_STAR,
+      anon_sym_LF2,
+    ACTIONS(426), 11,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      sym_url_word,
+      anon_sym_BQUOTE,
+    ACTIONS(424), 12,
+      aux_sym_word_token1,
+      aux_sym_word_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+  [3281] = 5,
+    ACTIONS(420), 1,
       aux_sym_uppercase_name_token2,
     STATE(72), 1,
       aux_sym_uppercase_name_repeat1,
-    ACTIONS(422), 12,
+    ACTIONS(432), 2,
+      anon_sym_STAR,
+      anon_sym_LF2,
+    ACTIONS(418), 11,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      sym_url_word,
+      anon_sym_BQUOTE,
+    ACTIONS(416), 12,
       aux_sym_word_token1,
       aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(424), 14,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
       aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+  [3319] = 3,
+    ACTIONS(434), 1,
+      aux_sym_taglink_token1,
+    ACTIONS(399), 2,
+      aux_sym__word_common_token3,
       anon_sym_LF2,
-      anon_sym_STAR,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [3313] = 4,
-    ACTIONS(426), 1,
-      aux_sym_uppercase_name_token2,
-    STATE(69), 1,
-      aux_sym_uppercase_name_repeat1,
-    ACTIONS(430), 12,
+    ACTIONS(397), 23,
       aux_sym_word_token1,
       aux_sym_word_token2,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
       anon_sym_PIPE,
       anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+      anon_sym_GT,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(432), 14,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
-      anon_sym_LF2,
-      anon_sym_STAR,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [3350] = 5,
-    ACTIONS(426), 1,
-      aux_sym_uppercase_name_token2,
-    STATE(69), 1,
-      aux_sym_uppercase_name_repeat1,
-    ACTIONS(434), 2,
-      anon_sym_LF2,
-      anon_sym_STAR,
-    ACTIONS(430), 12,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(432), 12,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [3389] = 3,
-    ACTIONS(436), 2,
-      aux_sym_codeblock_token1,
+      anon_sym_BQUOTE,
+  [3352] = 3,
+    ACTIONS(436), 1,
       anon_sym_LF,
-    ACTIONS(359), 8,
+    ACTIONS(397), 8,
       aux_sym_word_token1,
       aux_sym_word_token2,
       anon_sym_PIPE,
@@ -9776,60 +10089,28 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       anon_sym_LF2,
-    ACTIONS(361), 18,
+    ACTIONS(399), 17,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      anon_sym_STAR,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [3424] = 3,
-    ACTIONS(438), 1,
-      anon_sym_LF,
-    ACTIONS(359), 8,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      anon_sym_LF2,
-    ACTIONS(361), 18,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      anon_sym_STAR,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [3458] = 3,
+      anon_sym_BQUOTE,
+  [3385] = 3,
     ACTIONS(442), 1,
       anon_sym_SQUOTE2,
-    ACTIONS(440), 8,
+    ACTIONS(438), 8,
       aux_sym_word_token1,
       aux_sym_word_token2,
       anon_sym_SQUOTE,
@@ -9838,60 +10119,58 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(444), 18,
+    ACTIONS(440), 17,
+      anon_sym_STAR,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       anon_sym_LF2,
-      anon_sym_STAR,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [3492] = 3,
+      anon_sym_BQUOTE,
+  [3418] = 3,
+    ACTIONS(444), 1,
+      aux_sym_tag_token1,
+    ACTIONS(399), 2,
+      anon_sym_STAR,
+      anon_sym_LF2,
+    ACTIONS(397), 23,
+      aux_sym_word_token1,
+      aux_sym_word_token2,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [3451] = 3,
     ACTIONS(446), 1,
-      aux_sym_argument_token1,
-    ACTIONS(361), 6,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      aux_sym_keycode_token6,
-      anon_sym_LF2,
-    ACTIONS(359), 20,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      anon_sym_STAR,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-  [3526] = 3,
-    ACTIONS(448), 1,
       anon_sym_LF,
-    ACTIONS(359), 8,
+    ACTIONS(397), 8,
       aux_sym_word_token1,
       aux_sym_word_token2,
       anon_sym_PIPE,
@@ -9900,56 +10179,84 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       anon_sym_LF2,
-    ACTIONS(361), 18,
+    ACTIONS(399), 17,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      anon_sym_STAR,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [3560] = 2,
+      anon_sym_BQUOTE,
+  [3484] = 3,
+    ACTIONS(448), 1,
+      aux_sym_argument_token1,
+    ACTIONS(399), 4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      anon_sym_LF2,
+    ACTIONS(397), 21,
+      aux_sym_word_token1,
+      aux_sym_word_token2,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      aux_sym__word_common_token5,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [3517] = 2,
     ACTIONS(450), 13,
       aux_sym_word_token1,
       aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       aux_sym_uppercase_name_token2,
-    ACTIONS(452), 14,
+    ACTIONS(452), 13,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
-      anon_sym_STAR,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [3592] = 2,
+      anon_sym_BQUOTE,
+  [3548] = 2,
     ACTIONS(454), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -9958,27 +10265,26 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(456), 19,
+    ACTIONS(456), 18,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       anon_sym_LF2,
-      anon_sym_STAR,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [3623] = 2,
+      anon_sym_BQUOTE,
+  [3578] = 2,
     ACTIONS(458), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -9987,27 +10293,26 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(460), 19,
+    ACTIONS(460), 18,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       anon_sym_LF2,
-      anon_sym_STAR,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [3654] = 2,
+      anon_sym_BQUOTE,
+  [3608] = 2,
     ACTIONS(462), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -10016,27 +10321,26 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(464), 19,
+    ACTIONS(464), 18,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       anon_sym_LF2,
-      anon_sym_STAR,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [3685] = 2,
+      anon_sym_BQUOTE,
+  [3638] = 2,
     ACTIONS(466), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -10045,27 +10349,26 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(468), 19,
+    ACTIONS(468), 18,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       anon_sym_LF2,
-      anon_sym_STAR,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [3716] = 2,
+      anon_sym_BQUOTE,
+  [3668] = 2,
     ACTIONS(470), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -10074,27 +10377,26 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(472), 19,
+    ACTIONS(472), 18,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       anon_sym_LF2,
-      anon_sym_STAR,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [3747] = 2,
+      anon_sym_BQUOTE,
+  [3698] = 2,
     ACTIONS(474), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -10103,27 +10405,26 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(476), 19,
+    ACTIONS(476), 18,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       anon_sym_LF2,
-      anon_sym_STAR,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [3778] = 2,
+      anon_sym_BQUOTE,
+  [3728] = 2,
     ACTIONS(478), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -10132,27 +10433,26 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(480), 19,
+    ACTIONS(480), 18,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       anon_sym_LF2,
-      anon_sym_STAR,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [3809] = 2,
+      anon_sym_BQUOTE,
+  [3758] = 2,
     ACTIONS(482), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -10161,27 +10461,26 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(484), 19,
+    ACTIONS(484), 18,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       anon_sym_LF2,
-      anon_sym_STAR,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [3840] = 2,
+      anon_sym_BQUOTE,
+  [3788] = 2,
     ACTIONS(486), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -10190,27 +10489,26 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(488), 19,
+    ACTIONS(488), 18,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       anon_sym_LF2,
-      anon_sym_STAR,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [3871] = 2,
+      anon_sym_BQUOTE,
+  [3818] = 2,
     ACTIONS(490), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -10219,27 +10517,26 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(492), 19,
+    ACTIONS(492), 18,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       anon_sym_LF2,
-      anon_sym_STAR,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [3902] = 2,
+      anon_sym_BQUOTE,
+  [3848] = 2,
     ACTIONS(494), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -10248,451 +10545,451 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(496), 19,
+    ACTIONS(496), 18,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
+      aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token6,
+      aux_sym__word_common_token5,
       anon_sym_TILDE,
       anon_sym_GT,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
       anon_sym_LF2,
-      anon_sym_STAR,
       sym_url_word,
-      anon_sym_BQUOTE2,
-  [3933] = 5,
-    ACTIONS(25), 1,
-      anon_sym_LF2,
+      anon_sym_BQUOTE,
+  [3878] = 5,
     ACTIONS(27), 1,
+      anon_sym_LF2,
+    ACTIONS(29), 1,
       aux_sym_line_li_token1,
     ACTIONS(498), 1,
       anon_sym_LT,
-    STATE(40), 1,
+    STATE(41), 1,
       sym__blank,
-    STATE(93), 2,
+    STATE(94), 2,
       sym_line_li,
       aux_sym_block_repeat2,
-  [3950] = 5,
-    ACTIONS(25), 1,
-      anon_sym_LF2,
+  [3895] = 5,
     ACTIONS(27), 1,
+      anon_sym_LF2,
+    ACTIONS(29), 1,
       aux_sym_line_li_token1,
     ACTIONS(500), 1,
       anon_sym_LT,
-    STATE(37), 1,
+    STATE(38), 1,
       sym__blank,
-    STATE(93), 2,
+    STATE(94), 2,
       sym_line_li,
       aux_sym_block_repeat2,
-  [3967] = 4,
+  [3912] = 4,
     ACTIONS(502), 1,
       anon_sym_LT,
     ACTIONS(505), 1,
       anon_sym_LF2,
     ACTIONS(507), 1,
       aux_sym_line_li_token1,
-    STATE(93), 2,
+    STATE(94), 2,
       sym_line_li,
       aux_sym_block_repeat2,
-  [3981] = 4,
-    ACTIONS(290), 1,
+  [3926] = 4,
+    ACTIONS(314), 1,
       anon_sym_LF2,
-    ACTIONS(292), 1,
+    ACTIONS(316), 1,
       aux_sym_line_code_token1,
-    STATE(34), 1,
+    STATE(42), 1,
       aux_sym_codeblock_repeat1,
-    STATE(48), 1,
+    STATE(49), 1,
       sym_line_code,
-  [3994] = 4,
-    ACTIONS(333), 1,
+  [3939] = 4,
+    ACTIONS(337), 1,
       anon_sym_LF2,
-    ACTIONS(335), 1,
+    ACTIONS(339), 1,
       aux_sym_line_code_token1,
-    STATE(45), 1,
+    STATE(46), 1,
       aux_sym_codeblock_repeat1,
-    STATE(62), 1,
+    STATE(61), 1,
       sym_line_code,
-  [4007] = 3,
-    ACTIONS(222), 1,
-      anon_sym_STAR,
+  [3952] = 3,
     ACTIONS(510), 1,
+      anon_sym_STAR,
+    ACTIONS(512), 1,
       anon_sym_LF2,
     STATE(25), 1,
       sym_tag,
-  [4017] = 1,
-    ACTIONS(512), 1,
-      ts_builtin_sym_end,
-  [4021] = 1,
+  [3962] = 1,
     ACTIONS(514), 1,
-      anon_sym_SQUOTE2,
-  [4025] = 1,
-    ACTIONS(282), 1,
-      aux_sym_line_li_token1,
-  [4029] = 1,
+      anon_sym_PIPE2,
+  [3966] = 1,
     ACTIONS(516), 1,
-      anon_sym_BQUOTE,
-  [4033] = 1,
-    ACTIONS(518), 1,
       anon_sym_STAR2,
-  [4037] = 1,
+  [3970] = 1,
+    ACTIONS(518), 1,
+      anon_sym_RBRACE2,
+  [3974] = 1,
     ACTIONS(520), 1,
       aux_sym_codespan_token1,
-  [4041] = 1,
+  [3978] = 1,
     ACTIONS(522), 1,
-      aux_sym_tag_token1,
-  [4045] = 1,
+      ts_builtin_sym_end,
+  [3982] = 1,
     ACTIONS(524), 1,
-      anon_sym_RBRACE2,
-  [4049] = 1,
+      anon_sym_SQUOTE2,
+  [3986] = 1,
+    ACTIONS(444), 1,
+      aux_sym_tag_token1,
+  [3990] = 1,
+    ACTIONS(310), 1,
+      aux_sym_line_li_token1,
+  [3994] = 1,
     ACTIONS(526), 1,
-      anon_sym_PIPE2,
+      anon_sym_BQUOTE2,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(8)] = 0,
-  [SMALL_STATE(9)] = 78,
-  [SMALL_STATE(10)] = 156,
-  [SMALL_STATE(11)] = 234,
-  [SMALL_STATE(12)] = 312,
-  [SMALL_STATE(13)] = 390,
-  [SMALL_STATE(14)] = 468,
-  [SMALL_STATE(15)] = 546,
-  [SMALL_STATE(16)] = 624,
-  [SMALL_STATE(17)] = 702,
-  [SMALL_STATE(18)] = 774,
-  [SMALL_STATE(19)] = 848,
-  [SMALL_STATE(20)] = 920,
-  [SMALL_STATE(21)] = 992,
-  [SMALL_STATE(22)] = 1064,
-  [SMALL_STATE(23)] = 1138,
-  [SMALL_STATE(24)] = 1205,
-  [SMALL_STATE(25)] = 1272,
-  [SMALL_STATE(26)] = 1339,
-  [SMALL_STATE(27)] = 1406,
-  [SMALL_STATE(28)] = 1473,
-  [SMALL_STATE(29)] = 1537,
-  [SMALL_STATE(30)] = 1601,
-  [SMALL_STATE(31)] = 1665,
-  [SMALL_STATE(32)] = 1729,
-  [SMALL_STATE(33)] = 1776,
-  [SMALL_STATE(34)] = 1821,
-  [SMALL_STATE(35)] = 1868,
-  [SMALL_STATE(36)] = 1915,
-  [SMALL_STATE(37)] = 1960,
-  [SMALL_STATE(38)] = 2005,
-  [SMALL_STATE(39)] = 2050,
-  [SMALL_STATE(40)] = 2095,
-  [SMALL_STATE(41)] = 2140,
-  [SMALL_STATE(42)] = 2185,
-  [SMALL_STATE(43)] = 2232,
-  [SMALL_STATE(44)] = 2277,
-  [SMALL_STATE(45)] = 2322,
-  [SMALL_STATE(46)] = 2365,
-  [SMALL_STATE(47)] = 2402,
-  [SMALL_STATE(48)] = 2439,
-  [SMALL_STATE(49)] = 2476,
-  [SMALL_STATE(50)] = 2513,
-  [SMALL_STATE(51)] = 2556,
-  [SMALL_STATE(52)] = 2595,
-  [SMALL_STATE(53)] = 2631,
-  [SMALL_STATE(54)] = 2667,
-  [SMALL_STATE(55)] = 2703,
-  [SMALL_STATE(56)] = 2739,
-  [SMALL_STATE(57)] = 2775,
-  [SMALL_STATE(58)] = 2811,
-  [SMALL_STATE(59)] = 2847,
-  [SMALL_STATE(60)] = 2883,
-  [SMALL_STATE(61)] = 2919,
-  [SMALL_STATE(62)] = 2955,
-  [SMALL_STATE(63)] = 2990,
-  [SMALL_STATE(64)] = 3025,
-  [SMALL_STATE(65)] = 3059,
-  [SMALL_STATE(66)] = 3097,
-  [SMALL_STATE(67)] = 3131,
-  [SMALL_STATE(68)] = 3165,
-  [SMALL_STATE(69)] = 3200,
-  [SMALL_STATE(70)] = 3237,
-  [SMALL_STATE(71)] = 3276,
-  [SMALL_STATE(72)] = 3313,
-  [SMALL_STATE(73)] = 3350,
-  [SMALL_STATE(74)] = 3389,
-  [SMALL_STATE(75)] = 3424,
-  [SMALL_STATE(76)] = 3458,
-  [SMALL_STATE(77)] = 3492,
-  [SMALL_STATE(78)] = 3526,
-  [SMALL_STATE(79)] = 3560,
-  [SMALL_STATE(80)] = 3592,
-  [SMALL_STATE(81)] = 3623,
-  [SMALL_STATE(82)] = 3654,
-  [SMALL_STATE(83)] = 3685,
-  [SMALL_STATE(84)] = 3716,
-  [SMALL_STATE(85)] = 3747,
-  [SMALL_STATE(86)] = 3778,
-  [SMALL_STATE(87)] = 3809,
-  [SMALL_STATE(88)] = 3840,
-  [SMALL_STATE(89)] = 3871,
-  [SMALL_STATE(90)] = 3902,
-  [SMALL_STATE(91)] = 3933,
-  [SMALL_STATE(92)] = 3950,
-  [SMALL_STATE(93)] = 3967,
-  [SMALL_STATE(94)] = 3981,
-  [SMALL_STATE(95)] = 3994,
-  [SMALL_STATE(96)] = 4007,
-  [SMALL_STATE(97)] = 4017,
-  [SMALL_STATE(98)] = 4021,
-  [SMALL_STATE(99)] = 4025,
-  [SMALL_STATE(100)] = 4029,
-  [SMALL_STATE(101)] = 4033,
-  [SMALL_STATE(102)] = 4037,
-  [SMALL_STATE(103)] = 4041,
-  [SMALL_STATE(104)] = 4045,
-  [SMALL_STATE(105)] = 4049,
+  [SMALL_STATE(9)] = 77,
+  [SMALL_STATE(10)] = 154,
+  [SMALL_STATE(11)] = 231,
+  [SMALL_STATE(12)] = 308,
+  [SMALL_STATE(13)] = 385,
+  [SMALL_STATE(14)] = 462,
+  [SMALL_STATE(15)] = 539,
+  [SMALL_STATE(16)] = 616,
+  [SMALL_STATE(17)] = 693,
+  [SMALL_STATE(18)] = 764,
+  [SMALL_STATE(19)] = 837,
+  [SMALL_STATE(20)] = 908,
+  [SMALL_STATE(21)] = 979,
+  [SMALL_STATE(22)] = 1052,
+  [SMALL_STATE(23)] = 1123,
+  [SMALL_STATE(24)] = 1189,
+  [SMALL_STATE(25)] = 1255,
+  [SMALL_STATE(26)] = 1321,
+  [SMALL_STATE(27)] = 1387,
+  [SMALL_STATE(28)] = 1453,
+  [SMALL_STATE(29)] = 1516,
+  [SMALL_STATE(30)] = 1579,
+  [SMALL_STATE(31)] = 1642,
+  [SMALL_STATE(32)] = 1705,
+  [SMALL_STATE(33)] = 1749,
+  [SMALL_STATE(34)] = 1793,
+  [SMALL_STATE(35)] = 1837,
+  [SMALL_STATE(36)] = 1881,
+  [SMALL_STATE(37)] = 1927,
+  [SMALL_STATE(38)] = 1971,
+  [SMALL_STATE(39)] = 2015,
+  [SMALL_STATE(40)] = 2061,
+  [SMALL_STATE(41)] = 2105,
+  [SMALL_STATE(42)] = 2149,
+  [SMALL_STATE(43)] = 2195,
+  [SMALL_STATE(44)] = 2239,
+  [SMALL_STATE(45)] = 2285,
+  [SMALL_STATE(46)] = 2327,
+  [SMALL_STATE(47)] = 2369,
+  [SMALL_STATE(48)] = 2405,
+  [SMALL_STATE(49)] = 2441,
+  [SMALL_STATE(50)] = 2477,
+  [SMALL_STATE(51)] = 2513,
+  [SMALL_STATE(52)] = 2548,
+  [SMALL_STATE(53)] = 2583,
+  [SMALL_STATE(54)] = 2618,
+  [SMALL_STATE(55)] = 2653,
+  [SMALL_STATE(56)] = 2688,
+  [SMALL_STATE(57)] = 2723,
+  [SMALL_STATE(58)] = 2758,
+  [SMALL_STATE(59)] = 2793,
+  [SMALL_STATE(60)] = 2828,
+  [SMALL_STATE(61)] = 2863,
+  [SMALL_STATE(62)] = 2897,
+  [SMALL_STATE(63)] = 2931,
+  [SMALL_STATE(64)] = 2964,
+  [SMALL_STATE(65)] = 2997,
+  [SMALL_STATE(66)] = 3034,
+  [SMALL_STATE(67)] = 3067,
+  [SMALL_STATE(68)] = 3103,
+  [SMALL_STATE(69)] = 3139,
+  [SMALL_STATE(70)] = 3173,
+  [SMALL_STATE(71)] = 3209,
+  [SMALL_STATE(72)] = 3243,
+  [SMALL_STATE(73)] = 3281,
+  [SMALL_STATE(74)] = 3319,
+  [SMALL_STATE(75)] = 3352,
+  [SMALL_STATE(76)] = 3385,
+  [SMALL_STATE(77)] = 3418,
+  [SMALL_STATE(78)] = 3451,
+  [SMALL_STATE(79)] = 3484,
+  [SMALL_STATE(80)] = 3517,
+  [SMALL_STATE(81)] = 3548,
+  [SMALL_STATE(82)] = 3578,
+  [SMALL_STATE(83)] = 3608,
+  [SMALL_STATE(84)] = 3638,
+  [SMALL_STATE(85)] = 3668,
+  [SMALL_STATE(86)] = 3698,
+  [SMALL_STATE(87)] = 3728,
+  [SMALL_STATE(88)] = 3758,
+  [SMALL_STATE(89)] = 3788,
+  [SMALL_STATE(90)] = 3818,
+  [SMALL_STATE(91)] = 3848,
+  [SMALL_STATE(92)] = 3878,
+  [SMALL_STATE(93)] = 3895,
+  [SMALL_STATE(94)] = 3912,
+  [SMALL_STATE(95)] = 3926,
+  [SMALL_STATE(96)] = 3939,
+  [SMALL_STATE(97)] = 3952,
+  [SMALL_STATE(98)] = 3962,
+  [SMALL_STATE(99)] = 3966,
+  [SMALL_STATE(100)] = 3970,
+  [SMALL_STATE(101)] = 3974,
+  [SMALL_STATE(102)] = 3978,
+  [SMALL_STATE(103)] = 3982,
+  [SMALL_STATE(104)] = 3986,
+  [SMALL_STATE(105)] = 3990,
+  [SMALL_STATE(106)] = 3994,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_help_file, 0),
-  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(80),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
-  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(51),
-  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(77),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
-  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(88),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
-  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(70),
-  [23] = {.entry = {.count = 1, .reusable = false}}, SHIFT(99),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
-  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(103),
-  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
-  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(102),
+  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(87),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
+  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(74),
+  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(79),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
+  [19] = {.entry = {.count = 1, .reusable = false}}, SHIFT(88),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
+  [23] = {.entry = {.count = 1, .reusable = false}}, SHIFT(73),
+  [25] = {.entry = {.count = 1, .reusable = false}}, SHIFT(105),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
+  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
   [39] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_help_file, 1, .production_id = 4),
-  [41] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2),
-  [43] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(80),
-  [46] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(65),
-  [49] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(80),
-  [52] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(51),
-  [55] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(77),
-  [58] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(68),
-  [61] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(88),
-  [64] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(88),
-  [67] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(70),
-  [70] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(99),
-  [73] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(31),
-  [76] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(29),
-  [79] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(28),
-  [82] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(103),
-  [85] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(86),
-  [88] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(102),
-  [91] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_help_file, 2, .production_id = 4),
+  [41] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_help_file, 2, .production_id = 4),
+  [43] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2),
+  [45] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(87),
+  [48] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(77),
+  [51] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(65),
+  [54] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(87),
+  [57] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(74),
+  [60] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(79),
+  [63] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(71),
+  [66] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(88),
+  [69] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(88),
+  [72] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(73),
+  [75] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(105),
+  [78] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(30),
+  [81] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(29),
+  [84] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(28),
+  [87] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(83),
+  [90] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(101),
   [93] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_help_file, 1),
-  [95] = {.entry = {.count = 1, .reusable = false}}, SHIFT(42),
-  [97] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(80),
-  [100] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(65),
-  [103] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(80),
-  [106] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(51),
-  [109] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(77),
-  [112] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(68),
-  [115] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(88),
-  [118] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(88),
-  [121] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(70),
-  [124] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2),
-  [126] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2),
-  [128] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(29),
-  [131] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(28),
-  [134] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(103),
-  [137] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(86),
-  [140] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(102),
-  [143] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(80),
-  [146] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(65),
-  [149] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(80),
-  [152] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(51),
-  [155] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(77),
-  [158] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(88),
-  [161] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(88),
-  [164] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(71),
-  [167] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2),
-  [169] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2),
-  [171] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(103),
-  [174] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(86),
-  [177] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(102),
-  [180] = {.entry = {.count = 1, .reusable = false}}, SHIFT(71),
-  [182] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 5, .production_id = 17),
-  [184] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 5, .production_id = 17),
-  [186] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 5, .production_id = 16),
-  [188] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 5, .production_id = 16),
-  [190] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, .production_id = 13),
-  [192] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, .production_id = 13),
-  [194] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, .production_id = 12),
-  [196] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, .production_id = 12),
-  [198] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, .production_id = 17),
-  [200] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, .production_id = 17),
-  [202] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, .production_id = 16),
-  [204] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, .production_id = 16),
-  [206] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 3, .production_id = 13),
-  [208] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 3, .production_id = 13),
-  [210] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 3, .production_id = 12),
-  [212] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 3, .production_id = 12),
-  [214] = {.entry = {.count = 1, .reusable = false}}, SHIFT(82),
-  [216] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
-  [218] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
-  [220] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
-  [222] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
-  [224] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
-  [226] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
-  [228] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [230] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
-  [232] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [234] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
-  [236] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
-  [238] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(82),
-  [241] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(65),
-  [244] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(82),
-  [247] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(51),
-  [250] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(77),
-  [253] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(88),
-  [256] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(88),
-  [259] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2),
-  [261] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(103),
-  [264] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(86),
-  [267] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(102),
-  [270] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [272] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
-  [274] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
-  [276] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
-  [278] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 3),
-  [280] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 3),
-  [282] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [95] = {.entry = {.count = 1, .reusable = false}}, SHIFT(44),
+  [97] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(87),
+  [100] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(77),
+  [103] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(65),
+  [106] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(87),
+  [109] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(74),
+  [112] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(79),
+  [115] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(71),
+  [118] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(88),
+  [121] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(88),
+  [124] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(73),
+  [127] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2),
+  [129] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2),
+  [131] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(29),
+  [134] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(28),
+  [137] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(83),
+  [140] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(101),
+  [143] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(87),
+  [146] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(87),
+  [149] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(77),
+  [152] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(65),
+  [155] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(74),
+  [158] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(79),
+  [161] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(88),
+  [164] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(88),
+  [167] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(68),
+  [170] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2),
+  [172] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2),
+  [174] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(83),
+  [177] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(101),
+  [180] = {.entry = {.count = 1, .reusable = false}}, SHIFT(68),
+  [182] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 5, .production_id = 16),
+  [184] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 5, .production_id = 16),
+  [186] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 5, .production_id = 15),
+  [188] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 5, .production_id = 15),
+  [190] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, .production_id = 12),
+  [192] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, .production_id = 12),
+  [194] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, .production_id = 11),
+  [196] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, .production_id = 11),
+  [198] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, .production_id = 16),
+  [200] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, .production_id = 16),
+  [202] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, .production_id = 15),
+  [204] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, .production_id = 15),
+  [206] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 3, .production_id = 12),
+  [208] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 3, .production_id = 12),
+  [210] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 3, .production_id = 11),
+  [212] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 3, .production_id = 11),
+  [214] = {.entry = {.count = 1, .reusable = false}}, SHIFT(85),
+  [216] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
+  [218] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
+  [220] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
+  [222] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
+  [224] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [226] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [228] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
+  [230] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
+  [232] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [234] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [236] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
+  [238] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(85),
+  [241] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(77),
+  [244] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(65),
+  [247] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(85),
+  [250] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(74),
+  [253] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(79),
+  [256] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(88),
+  [259] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(88),
+  [262] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2),
+  [264] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(83),
+  [267] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(101),
+  [270] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [272] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
+  [274] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [276] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 3, .production_id = 14),
+  [278] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 3, .production_id = 14),
+  [280] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 2, .production_id = 8),
+  [282] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 2, .production_id = 8),
   [284] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 4, .production_id = 20),
   [286] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 4, .production_id = 20),
-  [288] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_codeblock, 3, .production_id = 11),
-  [290] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
-  [292] = {.entry = {.count = 1, .reusable = false}}, SHIFT(49),
-  [294] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_codeblock, 3, .production_id = 11),
-  [296] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 2),
-  [298] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 2), SHIFT_REPEAT(49),
-  [301] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 2), SHIFT_REPEAT(49),
-  [304] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 2),
-  [306] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 4, .production_id = 21),
-  [308] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 4, .production_id = 21),
-  [310] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 2, .production_id = 8),
-  [312] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 2, .production_id = 8),
-  [314] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 3, .production_id = 14),
-  [316] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 3, .production_id = 14),
-  [318] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 3, .production_id = 15),
-  [320] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 3, .production_id = 15),
-  [322] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 2),
-  [324] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 2),
-  [326] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_help_file_repeat1, 2, .production_id = 7),
-  [328] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_help_file_repeat1, 2, .production_id = 7),
-  [330] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat1, 2, .production_id = 7), SHIFT_REPEAT(47),
-  [333] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
-  [335] = {.entry = {.count = 1, .reusable = false}}, SHIFT(63),
-  [337] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_help_file_repeat1, 1, .production_id = 4),
-  [339] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_help_file_repeat1, 1, .production_id = 4),
+  [288] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 4, .production_id = 19),
+  [290] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 4, .production_id = 19),
+  [292] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 2),
+  [294] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 2), SHIFT_REPEAT(48),
+  [297] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 2), SHIFT_REPEAT(48),
+  [300] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 2),
+  [302] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 3, .production_id = 13),
+  [304] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 3, .production_id = 13),
+  [306] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 3),
+  [308] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 3),
+  [310] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [312] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_codeblock, 3, .production_id = 10),
+  [314] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
+  [316] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
+  [318] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_codeblock, 3, .production_id = 10),
+  [320] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_help_file_repeat1, 2, .production_id = 7),
+  [322] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_help_file_repeat1, 2, .production_id = 7),
+  [324] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat1, 2, .production_id = 7), SHIFT_REPEAT(47),
+  [327] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 2),
+  [329] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 2),
+  [331] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 2), SHIFT_REPEAT(62),
+  [334] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 2), SHIFT_REPEAT(62),
+  [337] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
+  [339] = {.entry = {.count = 1, .reusable = false}}, SHIFT(62),
   [341] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__blank, 1, .production_id = 2),
   [343] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__blank, 1, .production_id = 2),
-  [345] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 1),
-  [347] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 1),
-  [349] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_code, 1),
-  [351] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_code, 1),
-  [353] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 2), SHIFT_REPEAT(63),
-  [356] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 2), SHIFT_REPEAT(63),
-  [359] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__word_common, 1),
-  [361] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__word_common, 1),
-  [363] = {.entry = {.count = 1, .reusable = false}}, SHIFT(105),
-  [365] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__line_noli, 3),
-  [367] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__line_noli, 3),
-  [369] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h3, 3, .production_id = 6),
-  [371] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h3, 3, .production_id = 6),
-  [373] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__line_noli, 2),
-  [375] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__line_noli, 2),
-  [377] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_column_heading, 3, .production_id = 6),
-  [379] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_column_heading, 3, .production_id = 6),
-  [381] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h3, 4, .production_id = 6),
-  [383] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h3, 4, .production_id = 6),
-  [385] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h3, 2, .production_id = 6),
-  [387] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h3, 2, .production_id = 6),
-  [389] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line, 1),
-  [391] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line, 1),
-  [393] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_column_heading, 4, .production_id = 19),
-  [395] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_column_heading, 4, .production_id = 19),
-  [397] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h1, 3),
-  [399] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h1, 3),
-  [401] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h2, 3),
-  [403] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h2, 3),
-  [405] = {.entry = {.count = 1, .reusable = false}}, SHIFT(76),
-  [407] = {.entry = {.count = 1, .reusable = false}}, SHIFT(98),
-  [409] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 1, .production_id = 18),
-  [411] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 1, .production_id = 18),
-  [413] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
-  [415] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_uppercase_name_repeat1, 2),
-  [417] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_uppercase_name_repeat1, 2),
-  [419] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_uppercase_name_repeat1, 2), SHIFT_REPEAT(79),
-  [422] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__uppercase_words, 1, .production_id = 1),
-  [424] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__uppercase_words, 1, .production_id = 1),
-  [426] = {.entry = {.count = 1, .reusable = false}}, SHIFT(79),
-  [428] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_uppercase_name, 1),
-  [430] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__uppercase_words, 2, .production_id = 5),
-  [432] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__uppercase_words, 2, .production_id = 5),
-  [434] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_uppercase_name, 2),
-  [436] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
-  [438] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
-  [440] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__word_common, 2),
-  [442] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
-  [444] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__word_common, 2),
-  [446] = {.entry = {.count = 1, .reusable = false}}, SHIFT(104),
-  [448] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
+  [345] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_code, 1),
+  [347] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_code, 1),
+  [349] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 1),
+  [351] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 1),
+  [353] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_help_file_repeat1, 1, .production_id = 4),
+  [355] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_help_file_repeat1, 1, .production_id = 4),
+  [357] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h2, 3),
+  [359] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h2, 3),
+  [361] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__line_noli, 3),
+  [363] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__line_noli, 3),
+  [365] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__line_noli, 2),
+  [367] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__line_noli, 2),
+  [369] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h3, 2, .production_id = 6),
+  [371] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h3, 2, .production_id = 6),
+  [373] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h3, 4, .production_id = 6),
+  [375] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h3, 4, .production_id = 6),
+  [377] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_column_heading, 4, .production_id = 18),
+  [379] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_column_heading, 4, .production_id = 18),
+  [381] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_column_heading, 3, .production_id = 6),
+  [383] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_column_heading, 3, .production_id = 6),
+  [385] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h1, 3),
+  [387] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h1, 3),
+  [389] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h3, 3, .production_id = 6),
+  [391] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h3, 3, .production_id = 6),
+  [393] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line, 1),
+  [395] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line, 1),
+  [397] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__word_common, 1),
+  [399] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__word_common, 1),
+  [401] = {.entry = {.count = 1, .reusable = false}}, SHIFT(76),
+  [403] = {.entry = {.count = 1, .reusable = false}}, SHIFT(103),
+  [405] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 1, .production_id = 17),
+  [407] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 1, .production_id = 17),
+  [409] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_uppercase_name_repeat1, 2),
+  [411] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_uppercase_name_repeat1, 2),
+  [413] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_uppercase_name_repeat1, 2), SHIFT_REPEAT(80),
+  [416] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__uppercase_words, 1, .production_id = 1),
+  [418] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__uppercase_words, 1, .production_id = 1),
+  [420] = {.entry = {.count = 1, .reusable = false}}, SHIFT(80),
+  [422] = {.entry = {.count = 1, .reusable = true}}, SHIFT(96),
+  [424] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__uppercase_words, 2, .production_id = 5),
+  [426] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__uppercase_words, 2, .production_id = 5),
+  [428] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
+  [430] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_uppercase_name, 2),
+  [432] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_uppercase_name, 1),
+  [434] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
+  [436] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [438] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__word_common, 2),
+  [440] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__word_common, 2),
+  [442] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
+  [444] = {.entry = {.count = 1, .reusable = true}}, SHIFT(99),
+  [446] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [448] = {.entry = {.count = 1, .reusable = false}}, SHIFT(100),
   [450] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_uppercase_name_repeat1, 1),
   [452] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_uppercase_name_repeat1, 1),
-  [454] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_word_noli, 1),
-  [456] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_word_noli, 1),
-  [458] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_optionlink, 3, .production_id = 9),
-  [460] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_optionlink, 3, .production_id = 9),
-  [462] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_word, 1),
-  [464] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_word, 1),
-  [466] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_codespan, 3, .production_id = 9),
-  [468] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_codespan, 3, .production_id = 9),
-  [470] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 1),
-  [472] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 1),
-  [474] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__word_common, 3),
-  [476] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__word_common, 3),
-  [478] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_url, 1, .production_id = 3),
-  [480] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_url, 1, .production_id = 3),
-  [482] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 3, .production_id = 9),
-  [484] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 3, .production_id = 9),
-  [486] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keycode, 1),
-  [488] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keycode, 1),
-  [490] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_taglink, 3, .production_id = 10),
-  [492] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_taglink, 3, .production_id = 10),
-  [494] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_argument, 3, .production_id = 9),
-  [496] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument, 3, .production_id = 9),
-  [498] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [500] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
-  [502] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat2, 2), SHIFT_REPEAT(99),
+  [454] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__word_common, 3),
+  [456] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__word_common, 3),
+  [458] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_taglink, 3, .production_id = 9),
+  [460] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_taglink, 3, .production_id = 9),
+  [462] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_url, 1, .production_id = 3),
+  [464] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_url, 1, .production_id = 3),
+  [466] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 1),
+  [468] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 1),
+  [470] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_word, 1),
+  [472] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_word, 1),
+  [474] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_codespan, 3, .production_id = 9),
+  [476] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_codespan, 3, .production_id = 9),
+  [478] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_word_noli, 1),
+  [480] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_word_noli, 1),
+  [482] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keycode, 1),
+  [484] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keycode, 1),
+  [486] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_argument, 3, .production_id = 9),
+  [488] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument, 3, .production_id = 9),
+  [490] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_optionlink, 3, .production_id = 9),
+  [492] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_optionlink, 3, .production_id = 9),
+  [494] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 3, .production_id = 9),
+  [496] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 3, .production_id = 9),
+  [498] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [500] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [502] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat2, 2), SHIFT_REPEAT(105),
   [505] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_block_repeat2, 2),
-  [507] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat2, 2), SHIFT_REPEAT(31),
-  [510] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
-  [512] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [514] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
-  [516] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
-  [518] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
-  [520] = {.entry = {.count = 1, .reusable = true}}, SHIFT(100),
-  [522] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
+  [507] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat2, 2), SHIFT_REPEAT(30),
+  [510] = {.entry = {.count = 1, .reusable = true}}, SHIFT(104),
+  [512] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [514] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
+  [516] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
+  [518] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
+  [520] = {.entry = {.count = 1, .reusable = true}}, SHIFT(106),
+  [522] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
   [524] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
-  [526] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
+  [526] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Problem

- "+" and "*" have many false-positives and aren't commonly used as a listitem prefix.
- `(argument)` supports whitespace but, 
    - that isn't actually expected by vim's :help syntax definition
    - it causes [line-eating error nodes](https://github.com/neovim/tree-sitter-vimdoc/issues/96) in various cases where a random `{` is used in text

## Solution

- remove support for "+" and "*" as listitem prefixes
- disallow whitespace in `(argument)`

fixes https://github.com/neovim/tree-sitter-vimdoc/issues/96 