### PR TITLE
feat!: rename parser to vimdoc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-vimdoc"
-description = "help grammar for the tree-sitter parsing library"
+description = "Vimdoc grammar for the tree-sitter parsing library"
 version = "1.3.0"
 keywords = ["incremental", "parsing", "neovim", "vimdoc"]
 categories = ["parsing", "text-editors"]

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,7 +1,7 @@
 {
   "targets": [
     {
-      "target_name": "tree_sitter_help_binding",
+      "target_name": "tree_sitter_vimdoc_binding",
       "include_dirs": [
         "<!(node -e \"require('nan')\")",
         "src"

--- a/bindings/node/binding.cc
+++ b/bindings/node/binding.cc
@@ -4,7 +4,7 @@
 
 using namespace v8;
 
-extern "C" TSLanguage * tree_sitter_help();
+extern "C" TSLanguage * tree_sitter_vimdoc();
 
 namespace {
 
@@ -17,12 +17,12 @@ void Init(Local<Object> exports, Local<Object> module) {
 
   Local<Function> constructor = Nan::GetFunction(tpl).ToLocalChecked();
   Local<Object> instance = constructor->NewInstance(Nan::GetCurrentContext()).ToLocalChecked();
-  Nan::SetInternalFieldPointer(instance, 0, tree_sitter_help());
+  Nan::SetInternalFieldPointer(instance, 0, tree_sitter_vimdoc());
 
-  Nan::Set(instance, Nan::New("name").ToLocalChecked(), Nan::New("help").ToLocalChecked());
+  Nan::Set(instance, Nan::New("name").ToLocalChecked(), Nan::New("vimdoc").ToLocalChecked());
   Nan::Set(module, Nan::New("exports").ToLocalChecked(), instance);
 }
 
-NODE_MODULE(tree_sitter_help_binding, Init)
+NODE_MODULE(tree_sitter_vimdoc_binding, Init)
 
 }  // namespace

--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -1,11 +1,11 @@
 try {
-  module.exports = require("../../build/Release/tree_sitter_help_binding");
+  module.exports = require("../../build/Release/tree_sitter_vimdoc_binding");
 } catch (error1) {
   if (error1.code !== 'MODULE_NOT_FOUND') {
     throw error1;
   }
   try {
-    module.exports = require("../../build/Debug/tree_sitter_help_binding");
+    module.exports = require("../../build/Debug/tree_sitter_vimdoc_binding");
   } catch (error2) {
     if (error2.code !== 'MODULE_NOT_FOUND') {
       throw error2;

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -1,4 +1,4 @@
-//! This crate provides help language support for the [tree-sitter][] parsing library.
+//! This crate provides vimdoc language support for the [tree-sitter][] parsing library.
 //!
 //! Typically, you will use the [language][language func] function to add this language to a
 //! tree-sitter [Parser][], and then use the parser to parse some code:
@@ -6,7 +6,7 @@
 //! ```
 //! let code = "";
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(tree_sitter_help::language()).expect("Error loading help grammar");
+//! parser.set_language(tree_sitter_vimdoc::language()).expect("Error loading vimdoc grammar");
 //! let tree = parser.parse(code, None).unwrap();
 //! ```
 //!
@@ -18,14 +18,14 @@
 use tree_sitter::Language;
 
 extern "C" {
-    fn tree_sitter_help() -> Language;
+    fn tree_sitter_vimdoc() -> Language;
 }
 
 /// Get the tree-sitter [Language][] for this grammar.
 ///
 /// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
 pub fn language() -> Language {
-    unsafe { tree_sitter_help() }
+    unsafe { tree_sitter_vimdoc() }
 }
 
 /// The content of the [`node-types.json`][] file for this grammar.
@@ -47,6 +47,6 @@ mod tests {
         let mut parser = tree_sitter::Parser::new();
         parser
             .set_language(super::language())
-            .expect("Error loading help language");
+            .expect("Error loading vimdoc language");
     }
 }

--- a/grammar.js
+++ b/grammar.js
@@ -11,7 +11,7 @@ const _uppercase_word = /[A-Z0-9.()][-A-Z0-9.()_]+/;
 const _li_token = /[-*+•][ ]+/;
 
 module.exports = grammar({
-  name: 'help', // The actual language name is help
+  name: 'vimdoc',
 
   extras: () => [/[\t ]/],
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,5 +1,5 @@
 {
-  "name": "help",
+  "name": "vimdoc",
   "rules": {
     "help_file": {
       "type": "SEQ",

--- a/src/parser.c
+++ b/src/parser.c
@@ -10702,7 +10702,7 @@ extern "C" {
 #define extern __declspec(dllexport)
 #endif
 
-extern const TSLanguage *tree_sitter_help(void) {
+extern const TSLanguage *tree_sitter_vimdoc(void) {
   static const TSLanguage language = {
     .version = LANGUAGE_VERSION,
     .symbol_count = SYMBOL_COUNT,


### PR DESCRIPTION
Problem: installing the parser as `help.so` is confusing outside of Neovim, in particularly for distros looking to package the parsers Neovim ships with.

Solution: consistently use `vimdoc` as the language name, and leave Neovim to handle the mapping `help` filetype to `vimdoc` parser.

@jamessan 

(Will require a bump to 2.0.0.)
