### PR TITLE
fix: parse arguments properly in certain circumstances

### DIFF
--- a/corpus/arguments.txt
+++ b/corpus/arguments.txt
@@ -152,3 +152,69 @@ EXTERNAL *netrw-externapp* {{{2
         (tag
           (word))
         (word)))))
+
+================================================================================
+Many arguments
+================================================================================
+
+vim.foo({bar})
+
+vim.foo( {bar})
+
+nvim_foo({bar})
+
+nvim_foo({bar},{baz})
+
+nvim_foo({bar}, {baz})
+
+nvim_buf_detach_event[{buf}]
+
+
+--------------------------------------------------------------------------------
+
+(help_file
+  (block
+    (line
+      (word)
+      (word)
+      (argument
+        (word))
+      (word)))
+  (block
+    (line
+      (word)
+      (word)
+      (argument
+        (word))
+      (word)))
+  (block
+    (line
+      (word)
+      (argument
+        (word))
+      (word)))
+  (block
+    (line
+      (word)
+      (argument
+        (word))
+      (word)
+      (argument
+        (word))
+      (word)))
+  (block
+    (line
+      (word)
+      (argument
+        (word))
+      (word)
+      (argument
+        (word))
+      (word)))
+  (block
+    (line
+      (word)
+      (word)
+      (argument
+        (word))
+      (word))))

--- a/corpus/codeblock.txt
+++ b/corpus/codeblock.txt
@@ -90,6 +90,7 @@ text
       (word)
       (taglink
         (word))
+      (word)
       (word))
     (line
       (codeblock
@@ -352,6 +353,7 @@ To test for a non-empty string, use empty(): >
       (word)
       (word)
       (word)
+      (word)
       (codeblock
         (code
           (line))))))
@@ -393,6 +395,7 @@ codeblock stop and start on same line
       (tag
         (word)))
     (line
+      (word)
       (word)
       (word)
       (word))

--- a/corpus/optionlink.txt
+++ b/corpus/optionlink.txt
@@ -87,13 +87,15 @@ number: '04' 'ISO-10646-1' 'python3'
     (line
       (word)
       (word)
-      (word))
-    (line
-      (word)
-      (word)
       (word)
       (word))
     (line
+      (word)
+      (word)
+      (word)
+      (word))
+    (line
+      (word)
       (word)
       (word)
       (word)

--- a/corpus/url.txt
+++ b/corpus/url.txt
@@ -51,7 +51,16 @@ markdown: [https://neovim.io/doc/user/#yay](https://neovim.io/doc/user/#yay).
       (word)
       (url
         (word))
+      (word)
       (word))
     (line
+      (word)
+      (word)
+      (url
+        (word))
+      (word)
+      (word)
+      (url
+        (word))
       (word)
       (word))))

--- a/grammar.js
+++ b/grammar.js
@@ -15,9 +15,6 @@ module.exports = grammar({
 
   extras: () => [/[\t ]/],
 
-  // inline: ($) => [
-  // ],
-
   rules: {
     help_file: ($) =>
       seq(
@@ -32,9 +29,9 @@ module.exports = grammar({
     word: ($) => choice(
       // Try the more-restrictive pattern at higher relative precedence, so that things like
       // "foo({a})" parse as "(word) (argument)" instead of "(word)".
-      token(prec(-1, /[^\n\t{ ][^\n\t ]*/)),
+      token(prec(-1, /[^\n\t,({\[ ][^\n\t( ]*/)),
       token(prec(-2, /[^\n\t ]+/)),
-      choice($._word_common),
+      $._word_common,
     ),
 
     _atom_noli: ($) => prec(1, choice(
@@ -43,9 +40,9 @@ module.exports = grammar({
     )),
     word_noli: ($) => prec(1, choice(
       // Lines contained by line_li must not start with a listitem symbol.
-      token(prec(-1, /[^-*+•\n\t ][^\n\t ]*/)),
-      token(prec(-1, /[-*+•][^\n\t ]+/)),
-      choice($._word_common),
+      token(prec(-1, /[^-*+•\n\t ][^\n\t(\[ ]*/)),
+      token(prec(-1, /[-*+•][^\n\t( ]+/)),
+      $._word_common,
     )),
 
     _atom_common: ($) =>
@@ -80,10 +77,16 @@ module.exports = grammar({
       '{}',
       /\{\{+[0-9]*/,
       '(',
+      ')',
+      '[',
+      ']',
+      '[\'',
+      '\']',
       /\w+\(/,
       '~',
       // NOT codeblock: random ">" in middle of the motherflippin text.
       '>',
+      ',',
     ),
 
     keycode: () => choice(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -43,7 +43,7 @@
             "value": -1,
             "content": {
               "type": "PATTERN",
-              "value": "[^\\n\\t{ ][^\\n\\t ]*"
+              "value": "[^\\n\\t,({\\[ ][^\\n\\t( ]*"
             }
           }
         },
@@ -59,13 +59,8 @@
           }
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_word_common"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_word_common"
         }
       ]
     },
@@ -104,7 +99,7 @@
               "value": -1,
               "content": {
                 "type": "PATTERN",
-                "value": "[^-*+•\\n\\t ][^\\n\\t ]*"
+                "value": "[^-*+•\\n\\t ][^\\n\\t(\\[ ]*"
               }
             }
           },
@@ -115,18 +110,13 @@
               "value": -1,
               "content": {
                 "type": "PATTERN",
-                "value": "[-*+•][^\\n\\t ]+"
+                "value": "[-*+•][^\\n\\t( ]+"
               }
             }
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_word_common"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_word_common"
           }
         ]
       }
@@ -274,6 +264,18 @@
           "value": "("
         },
         {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        },
+        {
           "type": "PATTERN",
           "value": "\\w+\\("
         },
@@ -284,6 +286,10 @@
         {
           "type": "STRING",
           "value": ">"
+        },
+        {
+          "type": "STRING",
+          "value": ","
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -479,7 +479,15 @@
     "named": false
   },
   {
+    "type": ")",
+    "named": false
+  },
+  {
     "type": "*",
+    "named": false
+  },
+  {
+    "type": ",",
     "named": false
   },
   {
@@ -488,6 +496,14 @@
   },
   {
     "type": ">",
+    "named": false
+  },
+  {
+    "type": "[",
+    "named": false
+  },
+  {
+    "type": "]",
     "named": false
   },
   {

--- a/src/parser.c
+++ b/src/parser.c
@@ -15,10 +15,10 @@
 
 #define LANGUAGE_VERSION 14
 #define STATE_COUNT 106
-#define LARGE_STATE_COUNT 8
-#define SYMBOL_COUNT 88
+#define LARGE_STATE_COUNT 17
+#define SYMBOL_COUNT 92
 #define ALIAS_COUNT 1
-#define TOKEN_COUNT 53
+#define TOKEN_COUNT 57
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 3
 #define MAX_ALIAS_SEQUENCE_LENGTH 5
@@ -41,78 +41,82 @@ enum {
   anon_sym_LBRACE_RBRACE = 14,
   aux_sym__word_common_token5 = 15,
   anon_sym_LPAREN = 16,
-  aux_sym__word_common_token6 = 17,
-  anon_sym_TILDE = 18,
-  anon_sym_GT = 19,
-  aux_sym_keycode_token1 = 20,
-  aux_sym_keycode_token2 = 21,
-  aux_sym_keycode_token3 = 22,
-  aux_sym_keycode_token4 = 23,
-  aux_sym_keycode_token5 = 24,
-  aux_sym_keycode_token6 = 25,
-  aux_sym_keycode_token7 = 26,
-  aux_sym_keycode_token8 = 27,
-  aux_sym_uppercase_name_token1 = 28,
-  aux_sym_uppercase_name_token2 = 29,
-  anon_sym_LT = 30,
-  aux_sym_codeblock_token1 = 31,
-  anon_sym_LF = 32,
-  anon_sym_LF2 = 33,
-  aux_sym_line_li_token1 = 34,
-  aux_sym_line_code_token1 = 35,
-  aux_sym_h1_token1 = 36,
-  aux_sym_h2_token1 = 37,
-  anon_sym_STAR = 38,
-  aux_sym_tag_token1 = 39,
-  anon_sym_STAR2 = 40,
-  sym_url_word = 41,
-  aux_sym_optionlink_token1 = 42,
-  aux_sym_taglink_token1 = 43,
-  anon_sym_LBRACE2 = 44,
-  anon_sym_RBRACE2 = 45,
-  anon_sym_LPAREN2 = 46,
-  anon_sym_RPAREN = 47,
-  anon_sym_BQUOTE = 48,
-  anon_sym_PIPE2 = 49,
-  anon_sym_BQUOTE2 = 50,
-  aux_sym_codespan_token1 = 51,
-  aux_sym_argument_token1 = 52,
-  sym_help_file = 53,
-  sym__atom = 54,
-  sym_word = 55,
-  sym__atom_noli = 56,
-  sym_word_noli = 57,
-  sym__atom_common = 58,
-  sym__word_common = 59,
-  sym_keycode = 60,
-  sym_uppercase_name = 61,
-  sym__uppercase_words = 62,
-  sym_block = 63,
-  sym_codeblock = 64,
-  sym__blank = 65,
-  sym_line = 66,
-  sym_line_li = 67,
-  sym_line_code = 68,
-  sym__line_noli = 69,
-  sym_column_heading = 70,
-  sym_h1 = 71,
-  sym_h2 = 72,
-  sym_h3 = 73,
-  sym_tag = 74,
-  sym_url = 75,
-  sym_optionlink = 76,
-  sym_taglink = 77,
-  sym_codespan = 78,
-  sym_argument = 79,
-  aux_sym_help_file_repeat1 = 80,
-  aux_sym_help_file_repeat2 = 81,
-  aux_sym_uppercase_name_repeat1 = 82,
-  aux_sym_block_repeat1 = 83,
-  aux_sym_block_repeat2 = 84,
-  aux_sym_codeblock_repeat1 = 85,
-  aux_sym_line_li_repeat1 = 86,
-  aux_sym_line_li_repeat2 = 87,
-  alias_sym_code = 88,
+  anon_sym_RPAREN = 17,
+  anon_sym_LBRACK = 18,
+  anon_sym_RBRACK = 19,
+  aux_sym__word_common_token6 = 20,
+  anon_sym_TILDE = 21,
+  anon_sym_GT = 22,
+  anon_sym_COMMA = 23,
+  aux_sym_keycode_token1 = 24,
+  aux_sym_keycode_token2 = 25,
+  aux_sym_keycode_token3 = 26,
+  aux_sym_keycode_token4 = 27,
+  aux_sym_keycode_token5 = 28,
+  aux_sym_keycode_token6 = 29,
+  aux_sym_keycode_token7 = 30,
+  aux_sym_keycode_token8 = 31,
+  aux_sym_uppercase_name_token1 = 32,
+  aux_sym_uppercase_name_token2 = 33,
+  anon_sym_LT = 34,
+  aux_sym_codeblock_token1 = 35,
+  anon_sym_LF = 36,
+  anon_sym_LF2 = 37,
+  aux_sym_line_li_token1 = 38,
+  aux_sym_line_code_token1 = 39,
+  aux_sym_h1_token1 = 40,
+  aux_sym_h2_token1 = 41,
+  anon_sym_STAR = 42,
+  aux_sym_tag_token1 = 43,
+  anon_sym_STAR2 = 44,
+  sym_url_word = 45,
+  aux_sym_optionlink_token1 = 46,
+  aux_sym_taglink_token1 = 47,
+  anon_sym_LBRACE2 = 48,
+  anon_sym_RBRACE2 = 49,
+  anon_sym_LPAREN2 = 50,
+  anon_sym_RPAREN2 = 51,
+  anon_sym_BQUOTE = 52,
+  anon_sym_PIPE2 = 53,
+  anon_sym_BQUOTE2 = 54,
+  aux_sym_codespan_token1 = 55,
+  aux_sym_argument_token1 = 56,
+  sym_help_file = 57,
+  sym__atom = 58,
+  sym_word = 59,
+  sym__atom_noli = 60,
+  sym_word_noli = 61,
+  sym__atom_common = 62,
+  sym__word_common = 63,
+  sym_keycode = 64,
+  sym_uppercase_name = 65,
+  sym__uppercase_words = 66,
+  sym_block = 67,
+  sym_codeblock = 68,
+  sym__blank = 69,
+  sym_line = 70,
+  sym_line_li = 71,
+  sym_line_code = 72,
+  sym__line_noli = 73,
+  sym_column_heading = 74,
+  sym_h1 = 75,
+  sym_h2 = 76,
+  sym_h3 = 77,
+  sym_tag = 78,
+  sym_url = 79,
+  sym_optionlink = 80,
+  sym_taglink = 81,
+  sym_codespan = 82,
+  sym_argument = 83,
+  aux_sym_help_file_repeat1 = 84,
+  aux_sym_help_file_repeat2 = 85,
+  aux_sym_uppercase_name_repeat1 = 86,
+  aux_sym_block_repeat1 = 87,
+  aux_sym_block_repeat2 = 88,
+  aux_sym_codeblock_repeat1 = 89,
+  aux_sym_line_li_repeat1 = 90,
+  aux_sym_line_li_repeat2 = 91,
+  alias_sym_code = 92,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -133,9 +137,13 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_LBRACE_RBRACE] = "{}",
   [aux_sym__word_common_token5] = "_word_common_token5",
   [anon_sym_LPAREN] = "(",
+  [anon_sym_RPAREN] = ")",
+  [anon_sym_LBRACK] = "[",
+  [anon_sym_RBRACK] = "]",
   [aux_sym__word_common_token6] = "_word_common_token6",
   [anon_sym_TILDE] = "~",
   [anon_sym_GT] = ">",
+  [anon_sym_COMMA] = ",",
   [aux_sym_keycode_token1] = "keycode_token1",
   [aux_sym_keycode_token2] = "keycode_token2",
   [aux_sym_keycode_token3] = "keycode_token3",
@@ -163,7 +171,7 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_LBRACE2] = "word",
   [anon_sym_RBRACE2] = "}",
   [anon_sym_LPAREN2] = "word",
-  [anon_sym_RPAREN] = "word",
+  [anon_sym_RPAREN2] = "word",
   [anon_sym_BQUOTE] = "`",
   [anon_sym_PIPE2] = "|",
   [anon_sym_BQUOTE2] = "`",
@@ -225,9 +233,13 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_LBRACE_RBRACE] = anon_sym_LBRACE_RBRACE,
   [aux_sym__word_common_token5] = aux_sym__word_common_token5,
   [anon_sym_LPAREN] = anon_sym_LPAREN,
+  [anon_sym_RPAREN] = anon_sym_RPAREN,
+  [anon_sym_LBRACK] = anon_sym_LBRACK,
+  [anon_sym_RBRACK] = anon_sym_RBRACK,
   [aux_sym__word_common_token6] = aux_sym__word_common_token6,
   [anon_sym_TILDE] = anon_sym_TILDE,
   [anon_sym_GT] = anon_sym_GT,
+  [anon_sym_COMMA] = anon_sym_COMMA,
   [aux_sym_keycode_token1] = aux_sym_keycode_token1,
   [aux_sym_keycode_token2] = aux_sym_keycode_token2,
   [aux_sym_keycode_token3] = aux_sym_keycode_token3,
@@ -255,7 +267,7 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_LBRACE2] = sym_word,
   [anon_sym_RBRACE2] = anon_sym_RBRACE,
   [anon_sym_LPAREN2] = sym_word,
-  [anon_sym_RPAREN] = sym_word,
+  [anon_sym_RPAREN2] = sym_word,
   [anon_sym_BQUOTE] = anon_sym_BQUOTE,
   [anon_sym_PIPE2] = anon_sym_PIPE,
   [anon_sym_BQUOTE2] = anon_sym_BQUOTE,
@@ -368,6 +380,18 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
+  [anon_sym_RPAREN] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_LBRACK] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_RBRACK] = {
+    .visible = true,
+    .named = false,
+  },
   [aux_sym__word_common_token6] = {
     .visible = false,
     .named = false,
@@ -377,6 +401,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [anon_sym_GT] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_COMMA] = {
     .visible = true,
     .named = false,
   },
@@ -488,7 +516,7 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [anon_sym_RPAREN] = {
+  [anon_sym_RPAREN2] = {
     .visible = true,
     .named = true,
   },
@@ -883,5450 +911,6863 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   switch (state) {
     case 0:
       if (eof) ADVANCE(32);
-      if (lookahead == '\n') ADVANCE(390);
-      if (lookahead == '\'') ADVANCE(253);
-      if (lookahead == '(') ADVANCE(481);
-      if (lookahead == ')') ADVANCE(483);
-      if (lookahead == '*') ADVANCE(404);
-      if (lookahead == '+') ADVANCE(232);
-      if (lookahead == '<') ADVANCE(387);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(238);
-      if (lookahead == 'C') ADVANCE(240);
-      if (lookahead == 'M') ADVANCE(236);
-      if (lookahead == '`') ADVANCE(485);
-      if (lookahead == 'h') ADVANCE(241);
-      if (lookahead == '{') ADVANCE(477);
-      if (lookahead == '|') ADVANCE(487);
-      if (lookahead == '}') ADVANCE(479);
-      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == '\n') ADVANCE(476);
+      if (lookahead == '\'') ADVANCE(306);
+      if (lookahead == '(') ADVANCE(574);
+      if (lookahead == ')') ADVANCE(576);
+      if (lookahead == '*') ADVANCE(490);
+      if (lookahead == '+') ADVANCE(285);
+      if (lookahead == ',') ADVANCE(364);
+      if (lookahead == '<') ADVANCE(473);
+      if (lookahead == '>') ADVANCE(359);
+      if (lookahead == 'A') ADVANCE(290);
+      if (lookahead == 'C') ADVANCE(292);
+      if (lookahead == 'M') ADVANCE(288);
+      if (lookahead == '[') ADVANCE(341);
+      if (lookahead == ']') ADVANCE(346);
+      if (lookahead == '`') ADVANCE(578);
+      if (lookahead == 'h') ADVANCE(294);
+      if (lookahead == '{') ADVANCE(570);
+      if (lookahead == '|') ADVANCE(580);
+      if (lookahead == '}') ADVANCE(572);
+      if (lookahead == '~') ADVANCE(354);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(29)
       if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(233);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
+          lookahead == 8226) ADVANCE(286);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(295);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(244);
-      if (lookahead != 0) ADVANCE(232);
+          lookahead == '_') ADVANCE(297);
+      if (lookahead != 0) ADVANCE(285);
       END_STATE();
     case 1:
-      if (lookahead == '\t') ADVANCE(261);
-      if (lookahead == ' ') ADVANCE(393);
-      if (lookahead == '-') ADVANCE(226);
+      if (lookahead == '\t') ADVANCE(314);
+      if (lookahead == ' ') ADVANCE(479);
+      if (lookahead == '-') ADVANCE(279);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(227);
+          lookahead != '\n' &&
+          lookahead != '(') ADVANCE(280);
       END_STATE();
     case 2:
-      if (lookahead == '\t') ADVANCE(261);
-      if (lookahead == ' ') ADVANCE(393);
+      if (lookahead == '\t') ADVANCE(314);
+      if (lookahead == ' ') ADVANCE(479);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(227);
+          lookahead != '\n' &&
+          lookahead != '(') ADVANCE(280);
       END_STATE();
     case 3:
-      if (lookahead == '\t') ADVANCE(23);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == ' ') ADVANCE(392);
-      if (lookahead != 0) ADVANCE(216);
+      if (lookahead == '\t') ADVANCE(315);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == ' ') ADVANCE(478);
+      if (lookahead == '(') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(269);
       END_STATE();
     case 4:
-      if (lookahead == '\t') ADVANCE(262);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == ' ') ADVANCE(392);
-      if (lookahead != 0) ADVANCE(216);
-      END_STATE();
-    case 5:
-      if (lookahead == '\n') ADVANCE(390);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == '*') ADVANCE(397);
-      if (lookahead == '<') ADVANCE(93);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(47);
-      if (lookahead == 'C') ADVANCE(50);
-      if (lookahead == 'M') ADVANCE(46);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(55);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == '\n') ADVANCE(476);
+      if (lookahead == '\'') ADVANCE(281);
+      if (lookahead == '(') ADVANCE(329);
+      if (lookahead == ')') ADVANCE(335);
+      if (lookahead == '*') ADVANCE(483);
+      if (lookahead == ',') ADVANCE(364);
+      if (lookahead == '<') ADVANCE(145);
+      if (lookahead == '>') ADVANCE(359);
+      if (lookahead == 'A') ADVANCE(56);
+      if (lookahead == 'C') ADVANCE(63);
+      if (lookahead == 'M') ADVANCE(53);
+      if (lookahead == '[') ADVANCE(341);
+      if (lookahead == ']') ADVANCE(346);
+      if (lookahead == '`') ADVANCE(581);
+      if (lookahead == 'h') ADVANCE(72);
+      if (lookahead == '{') ADVANCE(317);
+      if (lookahead == '|') ADVANCE(312);
+      if (lookahead == '}') ADVANCE(319);
+      if (lookahead == '~') ADVANCE(354);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(8)
+          lookahead == ' ') SKIP(7)
       if (lookahead == '-' ||
           lookahead == 8226) ADVANCE(33);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (lookahead != 0) ADVANCE(95);
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+      if (lookahead != 0) ADVANCE(146);
       END_STATE();
-    case 6:
-      if (lookahead == '\n') ADVANCE(390);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == '*') ADVANCE(397);
-      if (lookahead == '<') ADVANCE(93);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(47);
-      if (lookahead == 'C') ADVANCE(50);
-      if (lookahead == 'M') ADVANCE(46);
-      if (lookahead == '`') ADVANCE(488);
+    case 5:
+      if (lookahead == '\n') ADVANCE(476);
+      if (lookahead == '\'') ADVANCE(281);
+      if (lookahead == '(') ADVANCE(329);
+      if (lookahead == ')') ADVANCE(335);
+      if (lookahead == '*') ADVANCE(483);
+      if (lookahead == ',') ADVANCE(364);
+      if (lookahead == '<') ADVANCE(145);
+      if (lookahead == '>') ADVANCE(359);
+      if (lookahead == 'A') ADVANCE(56);
+      if (lookahead == 'C') ADVANCE(63);
+      if (lookahead == 'M') ADVANCE(53);
+      if (lookahead == '[') ADVANCE(341);
+      if (lookahead == ']') ADVANCE(346);
+      if (lookahead == '`') ADVANCE(581);
       if (lookahead == 'h') ADVANCE(38);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == '{') ADVANCE(317);
+      if (lookahead == '|') ADVANCE(312);
+      if (lookahead == '}') ADVANCE(319);
+      if (lookahead == '~') ADVANCE(354);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(8)
+          lookahead == ' ') SKIP(7)
       if (lookahead == '-' ||
           lookahead == 8226) ADVANCE(33);
       if (('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
-      if (lookahead != 0) ADVANCE(95);
+      if (lookahead != 0) ADVANCE(146);
+      END_STATE();
+    case 6:
+      if (lookahead == '\n') ADVANCE(477);
+      if (lookahead == '\'') ADVANCE(306);
+      if (lookahead == '(') ADVANCE(329);
+      if (lookahead == ')') ADVANCE(335);
+      if (lookahead == '*') ADVANCE(483);
+      if (lookahead == ',') ADVANCE(364);
+      if (lookahead == '<') ADVANCE(145);
+      if (lookahead == '>') ADVANCE(359);
+      if (lookahead == 'A') ADVANCE(56);
+      if (lookahead == 'C') ADVANCE(63);
+      if (lookahead == 'M') ADVANCE(53);
+      if (lookahead == '[') ADVANCE(341);
+      if (lookahead == ']') ADVANCE(346);
+      if (lookahead == '`') ADVANCE(581);
+      if (lookahead == 'h') ADVANCE(72);
+      if (lookahead == '{') ADVANCE(317);
+      if (lookahead == '|') ADVANCE(312);
+      if (lookahead == '}') ADVANCE(319);
+      if (lookahead == '~') ADVANCE(354);
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(7)
+      if (lookahead == '-' ||
+          lookahead == 8226) ADVANCE(33);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+      if (lookahead != 0) ADVANCE(146);
       END_STATE();
     case 7:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(253);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == '*') ADVANCE(397);
-      if (lookahead == '<') ADVANCE(93);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(47);
-      if (lookahead == 'C') ADVANCE(50);
-      if (lookahead == 'M') ADVANCE(46);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(55);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == '\n') ADVANCE(477);
+      if (lookahead == '\'') ADVANCE(281);
+      if (lookahead == '(') ADVANCE(329);
+      if (lookahead == ')') ADVANCE(335);
+      if (lookahead == '*') ADVANCE(483);
+      if (lookahead == ',') ADVANCE(364);
+      if (lookahead == '<') ADVANCE(145);
+      if (lookahead == '>') ADVANCE(359);
+      if (lookahead == 'A') ADVANCE(56);
+      if (lookahead == 'C') ADVANCE(63);
+      if (lookahead == 'M') ADVANCE(53);
+      if (lookahead == '[') ADVANCE(341);
+      if (lookahead == ']') ADVANCE(346);
+      if (lookahead == '`') ADVANCE(581);
+      if (lookahead == 'h') ADVANCE(72);
+      if (lookahead == '{') ADVANCE(317);
+      if (lookahead == '|') ADVANCE(312);
+      if (lookahead == '}') ADVANCE(319);
+      if (lookahead == '~') ADVANCE(354);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(8)
+          lookahead == ' ') SKIP(7)
       if (lookahead == '-' ||
           lookahead == 8226) ADVANCE(33);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (lookahead != 0) ADVANCE(95);
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+      if (lookahead != 0) ADVANCE(146);
       END_STATE();
     case 8:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == '*') ADVANCE(397);
-      if (lookahead == '<') ADVANCE(93);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(47);
-      if (lookahead == 'C') ADVANCE(50);
-      if (lookahead == 'M') ADVANCE(46);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(55);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == '\n') ADVANCE(477);
+      if (lookahead == '\'') ADVANCE(281);
+      if (lookahead == '(') ADVANCE(329);
+      if (lookahead == ')') ADVANCE(335);
+      if (lookahead == '*') ADVANCE(485);
+      if (lookahead == '+') ADVANCE(25);
+      if (lookahead == ',') ADVANCE(364);
+      if (lookahead == '<') ADVANCE(266);
+      if (lookahead == '>') ADVANCE(359);
+      if (lookahead == 'A') ADVANCE(208);
+      if (lookahead == 'C') ADVANCE(211);
+      if (lookahead == 'M') ADVANCE(207);
+      if (lookahead == '[') ADVANCE(341);
+      if (lookahead == ']') ADVANCE(346);
+      if (lookahead == '`') ADVANCE(581);
+      if (lookahead == 'h') ADVANCE(216);
+      if (lookahead == '{') ADVANCE(317);
+      if (lookahead == '|') ADVANCE(312);
+      if (lookahead == '}') ADVANCE(319);
+      if (lookahead == '~') ADVANCE(354);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(8)
       if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(33);
+          lookahead == 8226) ADVANCE(2);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (lookahead != 0) ADVANCE(95);
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (lookahead != 0) ADVANCE(267);
       END_STATE();
     case 9:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == '*') ADVANCE(399);
+      if (lookahead == '\n') ADVANCE(477);
+      if (lookahead == '\'') ADVANCE(281);
+      if (lookahead == '(') ADVANCE(332);
+      if (lookahead == ')') ADVANCE(338);
+      if (lookahead == '*') ADVANCE(485);
       if (lookahead == '+') ADVANCE(25);
-      if (lookahead == '<') ADVANCE(212);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(155);
-      if (lookahead == 'C') ADVANCE(158);
-      if (lookahead == 'M') ADVANCE(154);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(163);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
-      if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(9)
-      if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(2);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0) ADVANCE(214);
-      END_STATE();
-    case 10:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(280);
-      if (lookahead == '*') ADVANCE(399);
-      if (lookahead == '+') ADVANCE(25);
+      if (lookahead == ',') ADVANCE(364);
       if (lookahead == '-') ADVANCE(1);
-      if (lookahead == '<') ADVANCE(388);
-      if (lookahead == '=') ADVANCE(181);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(166);
-      if (lookahead == 'C') ADVANCE(167);
-      if (lookahead == 'M') ADVANCE(165);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(163);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == '.') ADVANCE(222);
+      if (lookahead == '<') ADVANCE(474);
+      if (lookahead == '=') ADVANCE(235);
+      if (lookahead == '>') ADVANCE(359);
+      if (lookahead == 'A') ADVANCE(219);
+      if (lookahead == 'C') ADVANCE(220);
+      if (lookahead == 'M') ADVANCE(218);
+      if (lookahead == '[') ADVANCE(341);
+      if (lookahead == ']') ADVANCE(346);
+      if (lookahead == '`') ADVANCE(581);
+      if (lookahead == 'h') ADVANCE(216);
+      if (lookahead == '{') ADVANCE(317);
+      if (lookahead == '|') ADVANCE(312);
+      if (lookahead == '}') ADVANCE(319);
+      if (lookahead == '~') ADVANCE(354);
       if (lookahead == 8226) ADVANCE(2);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(15);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(213);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+          lookahead == ' ') ADVANCE(14);
+      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(217);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(168);
-      if (lookahead != 0) ADVANCE(214);
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(221);
+      if (lookahead != 0) ADVANCE(267);
+      END_STATE();
+    case 10:
+      if (lookahead == '\n') ADVANCE(477);
+      if (lookahead == '\'') ADVANCE(281);
+      if (lookahead == '(') ADVANCE(332);
+      if (lookahead == ')') ADVANCE(338);
+      if (lookahead == '*') ADVANCE(485);
+      if (lookahead == '+') ADVANCE(25);
+      if (lookahead == ',') ADVANCE(364);
+      if (lookahead == '.') ADVANCE(222);
+      if (lookahead == '<') ADVANCE(474);
+      if (lookahead == '>') ADVANCE(359);
+      if (lookahead == 'A') ADVANCE(219);
+      if (lookahead == 'C') ADVANCE(220);
+      if (lookahead == 'M') ADVANCE(218);
+      if (lookahead == '[') ADVANCE(341);
+      if (lookahead == ']') ADVANCE(346);
+      if (lookahead == '`') ADVANCE(581);
+      if (lookahead == 'h') ADVANCE(216);
+      if (lookahead == '{') ADVANCE(317);
+      if (lookahead == '|') ADVANCE(312);
+      if (lookahead == '}') ADVANCE(319);
+      if (lookahead == '~') ADVANCE(354);
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(8)
+      if (lookahead == '-' ||
+          lookahead == 8226) ADVANCE(2);
+      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(221);
+      if (lookahead != 0) ADVANCE(267);
       END_STATE();
     case 11:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(280);
-      if (lookahead == '*') ADVANCE(399);
+      if (lookahead == '\n') ADVANCE(477);
+      if (lookahead == '\'') ADVANCE(281);
+      if (lookahead == '(') ADVANCE(332);
+      if (lookahead == ')') ADVANCE(338);
+      if (lookahead == '*') ADVANCE(485);
       if (lookahead == '+') ADVANCE(25);
-      if (lookahead == '<') ADVANCE(388);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(166);
-      if (lookahead == 'C') ADVANCE(167);
-      if (lookahead == 'M') ADVANCE(165);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(163);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == ',') ADVANCE(364);
+      if (lookahead == '.') ADVANCE(222);
+      if (lookahead == '<') ADVANCE(474);
+      if (lookahead == '>') ADVANCE(359);
+      if (lookahead == 'A') ADVANCE(219);
+      if (lookahead == 'C') ADVANCE(220);
+      if (lookahead == 'M') ADVANCE(218);
+      if (lookahead == '[') ADVANCE(341);
+      if (lookahead == ']') ADVANCE(346);
+      if (lookahead == '`') ADVANCE(581);
+      if (lookahead == 'h') ADVANCE(216);
+      if (lookahead == '{') ADVANCE(317);
+      if (lookahead == '|') ADVANCE(312);
+      if (lookahead == '}') ADVANCE(319);
+      if (lookahead == '~') ADVANCE(354);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(9)
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(213);
+          lookahead == ' ') ADVANCE(14);
       if (lookahead == '-' ||
           lookahead == 8226) ADVANCE(2);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(217);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(168);
-      if (lookahead != 0) ADVANCE(214);
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(221);
+      if (lookahead != 0) ADVANCE(267);
       END_STATE();
     case 12:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(280);
-      if (lookahead == '*') ADVANCE(399);
-      if (lookahead == '+') ADVANCE(25);
-      if (lookahead == '<') ADVANCE(388);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(166);
-      if (lookahead == 'C') ADVANCE(167);
-      if (lookahead == 'M') ADVANCE(165);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(163);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == '\n') ADVANCE(477);
+      if (lookahead == '\'') ADVANCE(281);
+      if (lookahead == '(') ADVANCE(333);
+      if (lookahead == ')') ADVANCE(340);
+      if (lookahead == '*') ADVANCE(488);
+      if (lookahead == ',') ADVANCE(367);
+      if (lookahead == '<') ADVANCE(300);
+      if (lookahead == '>') ADVANCE(363);
+      if (lookahead == 'A') ADVANCE(291);
+      if (lookahead == 'C') ADVANCE(293);
+      if (lookahead == 'M') ADVANCE(289);
+      if (lookahead == '[') ADVANCE(344);
+      if (lookahead == ']') ADVANCE(350);
+      if (lookahead == '`') ADVANCE(584);
+      if (lookahead == 'h') ADVANCE(298);
+      if (lookahead == '{') ADVANCE(318);
+      if (lookahead == '|') ADVANCE(313);
+      if (lookahead == '}') ADVANCE(321);
+      if (lookahead == '~') ADVANCE(358);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(15);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(213);
+          lookahead == ' ') SKIP(7)
       if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(2);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+          lookahead == 8226) ADVANCE(287);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(299);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(168);
-      if (lookahead != 0) ADVANCE(214);
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(296);
+      if (lookahead != 0) ADVANCE(301);
       END_STATE();
     case 13:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(279);
-      if (lookahead == '*') ADVANCE(401);
-      if (lookahead == '<') ADVANCE(247);
-      if (lookahead == '>') ADVANCE(293);
-      if (lookahead == 'A') ADVANCE(237);
-      if (lookahead == 'C') ADVANCE(239);
-      if (lookahead == 'M') ADVANCE(235);
-      if (lookahead == '`') ADVANCE(491);
-      if (lookahead == 'h') ADVANCE(245);
-      if (lookahead == '{') ADVANCE(265);
-      if (lookahead == '|') ADVANCE(260);
-      if (lookahead == '}') ADVANCE(268);
-      if (lookahead == '~') ADVANCE(288);
+      if (lookahead == '\n') ADVANCE(477);
+      if (lookahead == '\'') ADVANCE(281);
+      if (lookahead == '(') ADVANCE(334);
+      if (lookahead == ')') ADVANCE(339);
+      if (lookahead == '*') ADVANCE(483);
+      if (lookahead == ',') ADVANCE(364);
+      if (lookahead == '.') ADVANCE(86);
+      if (lookahead == '<') ADVANCE(145);
+      if (lookahead == '>') ADVANCE(359);
+      if (lookahead == 'A') ADVANCE(88);
+      if (lookahead == 'C') ADVANCE(89);
+      if (lookahead == 'M') ADVANCE(87);
+      if (lookahead == '[') ADVANCE(341);
+      if (lookahead == ']') ADVANCE(346);
+      if (lookahead == '`') ADVANCE(581);
+      if (lookahead == 'h') ADVANCE(72);
+      if (lookahead == '{') ADVANCE(317);
+      if (lookahead == '|') ADVANCE(312);
+      if (lookahead == '}') ADVANCE(319);
+      if (lookahead == '~') ADVANCE(354);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(8)
-      if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(234);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(246);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(243);
-      if (lookahead != 0) ADVANCE(248);
-      END_STATE();
-    case 14:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(281);
-      if (lookahead == '*') ADVANCE(397);
-      if (lookahead == '<') ADVANCE(93);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(58);
-      if (lookahead == 'C') ADVANCE(59);
-      if (lookahead == 'M') ADVANCE(57);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(55);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
-      if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(14)
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(94);
+          lookahead == ' ') SKIP(13)
       if (lookahead == '-' ||
           lookahead == 8226) ADVANCE(33);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(60);
-      if (lookahead != 0) ADVANCE(95);
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(90);
+      if (lookahead != 0) ADVANCE(146);
+      END_STATE();
+    case 14:
+      if (lookahead == '\n') ADVANCE(477);
+      if (lookahead == '\'') ADVANCE(282);
+      if (lookahead == '(') ADVANCE(330);
+      if (lookahead == ')') ADVANCE(336);
+      if (lookahead == '*') ADVANCE(484);
+      if (lookahead == '+') ADVANCE(21);
+      if (lookahead == ',') ADVANCE(365);
+      if (lookahead == '<') ADVANCE(196);
+      if (lookahead == '>') ADVANCE(360);
+      if (lookahead == 'A') ADVANCE(157);
+      if (lookahead == 'C') ADVANCE(160);
+      if (lookahead == 'M') ADVANCE(156);
+      if (lookahead == '[') ADVANCE(342);
+      if (lookahead == ']') ADVANCE(347);
+      if (lookahead == '`') ADVANCE(582);
+      if (lookahead == 'h') ADVANCE(165);
+      if (lookahead == '{') ADVANCE(316);
+      if (lookahead == '|') ADVANCE(310);
+      if (lookahead == '}') ADVANCE(320);
+      if (lookahead == '~') ADVANCE(355);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(14);
+      if (lookahead == '-' ||
+          lookahead == 8226) ADVANCE(3);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(166);
+      if (lookahead != 0) ADVANCE(197);
       END_STATE();
     case 15:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(229);
-      if (lookahead == '(') ADVANCE(277);
-      if (lookahead == '*') ADVANCE(398);
-      if (lookahead == '+') ADVANCE(3);
-      if (lookahead == '<') ADVANCE(143);
-      if (lookahead == '>') ADVANCE(291);
-      if (lookahead == 'A') ADVANCE(104);
-      if (lookahead == 'C') ADVANCE(107);
-      if (lookahead == 'M') ADVANCE(103);
-      if (lookahead == '`') ADVANCE(489);
-      if (lookahead == 'h') ADVANCE(112);
-      if (lookahead == '{') ADVANCE(263);
-      if (lookahead == '|') ADVANCE(257);
-      if (lookahead == '}') ADVANCE(267);
-      if (lookahead == '~') ADVANCE(286);
+      if (lookahead == '\n') ADVANCE(477);
+      if (lookahead == '\'') ADVANCE(284);
+      if (lookahead == '(') ADVANCE(575);
+      if (lookahead == ')') ADVANCE(577);
+      if (lookahead == '*') ADVANCE(487);
+      if (lookahead == ',') ADVANCE(368);
+      if (lookahead == '<') ADVANCE(560);
+      if (lookahead == '>') ADVANCE(362);
+      if (lookahead == 'A') ADVANCE(524);
+      if (lookahead == 'C') ADVANCE(527);
+      if (lookahead == 'M') ADVANCE(520);
+      if (lookahead == '[') ADVANCE(345);
+      if (lookahead == ']') ADVANCE(349);
+      if (lookahead == '`') ADVANCE(579);
+      if (lookahead == 'h') ADVANCE(554);
+      if (lookahead == '{') ADVANCE(571);
+      if (lookahead == '|') ADVANCE(312);
+      if (lookahead == '}') ADVANCE(573);
+      if (lookahead == '~') ADVANCE(357);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(15);
+          lookahead == ' ') SKIP(7)
       if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(4);
+          lookahead == 8226) ADVANCE(507);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(561);
+      if (lookahead != 0) ADVANCE(562);
       END_STATE();
     case 16:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(231);
-      if (lookahead == '(') ADVANCE(482);
-      if (lookahead == ')') ADVANCE(484);
-      if (lookahead == '*') ADVANCE(402);
-      if (lookahead == '<') ADVANCE(474);
-      if (lookahead == '>') ADVANCE(294);
-      if (lookahead == 'A') ADVANCE(425);
-      if (lookahead == 'C') ADVANCE(428);
-      if (lookahead == 'M') ADVANCE(424);
-      if (lookahead == '`') ADVANCE(486);
-      if (lookahead == 'h') ADVANCE(433);
-      if (lookahead == '{') ADVANCE(478);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(480);
-      if (lookahead == '~') ADVANCE(289);
+      if (lookahead == '\n') ADVANCE(477);
+      if (lookahead == '\'') ADVANCE(283);
+      if (lookahead == '(') ADVANCE(331);
+      if (lookahead == ')') ADVANCE(337);
+      if (lookahead == '*') ADVANCE(486);
+      if (lookahead == ',') ADVANCE(366);
+      if (lookahead == '<') ADVANCE(636);
+      if (lookahead == '>') ADVANCE(361);
+      if (lookahead == 'A') ADVANCE(607);
+      if (lookahead == 'C') ADVANCE(610);
+      if (lookahead == 'M') ADVANCE(603);
+      if (lookahead == '[') ADVANCE(343);
+      if (lookahead == ']') ADVANCE(348);
+      if (lookahead == '`') ADVANCE(583);
+      if (lookahead == 'h') ADVANCE(633);
+      if (lookahead == '{') ADVANCE(317);
+      if (lookahead == '|') ADVANCE(311);
+      if (lookahead == '}') ADVANCE(319);
+      if (lookahead == '~') ADVANCE(356);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(8)
+          lookahead == ' ') SKIP(7)
       if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(417);
+          lookahead == 8226) ADVANCE(586);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0) ADVANCE(476);
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(637);
+      if (lookahead != 0) ADVANCE(638);
       END_STATE();
     case 17:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(230);
-      if (lookahead == '(') ADVANCE(278);
-      if (lookahead == '*') ADVANCE(400);
-      if (lookahead == '<') ADVANCE(545);
-      if (lookahead == '>') ADVANCE(292);
-      if (lookahead == 'A') ADVANCE(506);
-      if (lookahead == 'C') ADVANCE(509);
-      if (lookahead == 'M') ADVANCE(505);
-      if (lookahead == '`') ADVANCE(490);
-      if (lookahead == 'h') ADVANCE(514);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(258);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(287);
+      if (lookahead == '\n') ADVANCE(477);
+      if (lookahead == '<') ADVANCE(472);
+      if (lookahead == '`') ADVANCE(578);
+      if (lookahead == '|') ADVANCE(580);
+      if (lookahead == '}') ADVANCE(572);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(8)
-      if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(493);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(515);
-      if (lookahead != 0) ADVANCE(546);
+          lookahead == ' ') SKIP(18)
+      if (lookahead == '*' ||
+          lookahead == '+' ||
+          lookahead == '-' ||
+          lookahead == 8226) ADVANCE(24);
       END_STATE();
     case 18:
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '<') ADVANCE(386);
-      if (lookahead == '`') ADVANCE(485);
-      if (lookahead == '|') ADVANCE(487);
-      if (lookahead == '}') ADVANCE(479);
+      if (lookahead == '\n') ADVANCE(477);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(19)
+          lookahead == ' ') SKIP(18)
       if (lookahead == '*' ||
           lookahead == '+' ||
           lookahead == '-' ||
           lookahead == 8226) ADVANCE(24);
       END_STATE();
     case 19:
-      if (lookahead == '\n') ADVANCE(391);
+      if (lookahead == '\n') ADVANCE(482);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(19)
-      if (lookahead == '*' ||
-          lookahead == '+' ||
-          lookahead == '-' ||
-          lookahead == 8226) ADVANCE(24);
+          lookahead == ' ') ADVANCE(19);
       END_STATE();
     case 20:
-      if (lookahead == '\n') ADVANCE(396);
+      if (lookahead == '\n') ADVANCE(481);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(20);
       END_STATE();
     case 21:
-      if (lookahead == '\n') ADVANCE(395);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == ' ') ADVANCE(478);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
+          lookahead == '(') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(269);
       END_STATE();
     case 22:
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '>') ADVANCE(301);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '>') ADVANCE(375);
       if (lookahead != 0) ADVANCE(23);
       END_STATE();
     case 23:
-      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\n') ADVANCE(480);
       if (lookahead != 0) ADVANCE(23);
       END_STATE();
     case 24:
-      if (lookahead == ' ') ADVANCE(393);
+      if (lookahead == ' ') ADVANCE(479);
       END_STATE();
     case 25:
-      if (lookahead == ' ') ADVANCE(393);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(227);
-      END_STATE();
-    case 26:
-      if (lookahead == '*') ADVANCE(404);
+      if (lookahead == ' ') ADVANCE(479);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(403);
+          lookahead != '(') ADVANCE(280);
+      END_STATE();
+    case 26:
+      if (lookahead == '*') ADVANCE(490);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(489);
       END_STATE();
     case 27:
-      if (lookahead == '>') ADVANCE(299);
+      if (lookahead == '>') ADVANCE(373);
       END_STATE();
     case 28:
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '`') ADVANCE(492);
+          lookahead != '`') ADVANCE(585);
       END_STATE();
     case 29:
       if (eof) ADVANCE(32);
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == '*') ADVANCE(397);
-      if (lookahead == '+') ADVANCE(95);
-      if (lookahead == '<') ADVANCE(93);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(47);
-      if (lookahead == 'C') ADVANCE(50);
-      if (lookahead == 'M') ADVANCE(46);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(55);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(256);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == '\n') ADVANCE(477);
+      if (lookahead == '\'') ADVANCE(281);
+      if (lookahead == '(') ADVANCE(329);
+      if (lookahead == ')') ADVANCE(335);
+      if (lookahead == '*') ADVANCE(483);
+      if (lookahead == '+') ADVANCE(146);
+      if (lookahead == ',') ADVANCE(364);
+      if (lookahead == '<') ADVANCE(125);
+      if (lookahead == '>') ADVANCE(359);
+      if (lookahead == 'A') ADVANCE(54);
+      if (lookahead == 'C') ADVANCE(60);
+      if (lookahead == 'M') ADVANCE(52);
+      if (lookahead == '[') ADVANCE(341);
+      if (lookahead == ']') ADVANCE(346);
+      if (lookahead == '`') ADVANCE(581);
+      if (lookahead == 'h') ADVANCE(68);
+      if (lookahead == '{') ADVANCE(317);
+      if (lookahead == '|') ADVANCE(309);
+      if (lookahead == '}') ADVANCE(319);
+      if (lookahead == '~') ADVANCE(354);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(29)
       if (lookahead == '-' ||
           lookahead == 8226) ADVANCE(33);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (lookahead != 0) ADVANCE(95);
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(69);
+      if (lookahead != 0) ADVANCE(126);
       END_STATE();
     case 30:
       if (eof) ADVANCE(32);
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(276);
-      if (lookahead == '*') ADVANCE(399);
+      if (lookahead == '\n') ADVANCE(477);
+      if (lookahead == '\'') ADVANCE(281);
+      if (lookahead == '(') ADVANCE(329);
+      if (lookahead == ')') ADVANCE(335);
+      if (lookahead == '*') ADVANCE(485);
       if (lookahead == '+') ADVANCE(25);
-      if (lookahead == '<') ADVANCE(212);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(155);
-      if (lookahead == 'C') ADVANCE(158);
-      if (lookahead == 'M') ADVANCE(154);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(163);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == ',') ADVANCE(364);
+      if (lookahead == '<') ADVANCE(266);
+      if (lookahead == '>') ADVANCE(359);
+      if (lookahead == 'A') ADVANCE(208);
+      if (lookahead == 'C') ADVANCE(211);
+      if (lookahead == 'M') ADVANCE(207);
+      if (lookahead == '[') ADVANCE(341);
+      if (lookahead == ']') ADVANCE(346);
+      if (lookahead == '`') ADVANCE(581);
+      if (lookahead == 'h') ADVANCE(216);
+      if (lookahead == '{') ADVANCE(317);
+      if (lookahead == '|') ADVANCE(312);
+      if (lookahead == '}') ADVANCE(319);
+      if (lookahead == '~') ADVANCE(354);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(30)
       if (lookahead == '-' ||
           lookahead == 8226) ADVANCE(2);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0) ADVANCE(214);
+          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (lookahead != 0) ADVANCE(267);
       END_STATE();
     case 31:
       if (eof) ADVANCE(32);
-      if (lookahead == '\n') ADVANCE(391);
-      if (lookahead == '\'') ADVANCE(228);
-      if (lookahead == '(') ADVANCE(280);
-      if (lookahead == '*') ADVANCE(399);
+      if (lookahead == '\n') ADVANCE(477);
+      if (lookahead == '\'') ADVANCE(281);
+      if (lookahead == '(') ADVANCE(332);
+      if (lookahead == ')') ADVANCE(338);
+      if (lookahead == '*') ADVANCE(485);
       if (lookahead == '+') ADVANCE(25);
+      if (lookahead == ',') ADVANCE(364);
       if (lookahead == '-') ADVANCE(1);
-      if (lookahead == '<') ADVANCE(388);
-      if (lookahead == '=') ADVANCE(181);
-      if (lookahead == '>') ADVANCE(290);
-      if (lookahead == 'A') ADVANCE(166);
-      if (lookahead == 'C') ADVANCE(167);
-      if (lookahead == 'M') ADVANCE(165);
-      if (lookahead == '`') ADVANCE(488);
-      if (lookahead == 'h') ADVANCE(163);
-      if (lookahead == '{') ADVANCE(264);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(266);
-      if (lookahead == '~') ADVANCE(285);
+      if (lookahead == '.') ADVANCE(222);
+      if (lookahead == '<') ADVANCE(474);
+      if (lookahead == '=') ADVANCE(235);
+      if (lookahead == '>') ADVANCE(359);
+      if (lookahead == 'A') ADVANCE(219);
+      if (lookahead == 'C') ADVANCE(220);
+      if (lookahead == 'M') ADVANCE(218);
+      if (lookahead == '[') ADVANCE(341);
+      if (lookahead == ']') ADVANCE(346);
+      if (lookahead == '`') ADVANCE(581);
+      if (lookahead == 'h') ADVANCE(216);
+      if (lookahead == '{') ADVANCE(317);
+      if (lookahead == '|') ADVANCE(312);
+      if (lookahead == '}') ADVANCE(319);
+      if (lookahead == '~') ADVANCE(354);
       if (lookahead == 8226) ADVANCE(2);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(30)
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(213);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(164);
+      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(217);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(168);
-      if (lookahead != 0) ADVANCE(214);
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(221);
+      if (lookahead != 0) ADVANCE(267);
       END_STATE();
     case 32:
       ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 33:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\t') ADVANCE(261);
+      if (lookahead == '\t') ADVANCE(314);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
       END_STATE();
     case 34:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(389);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == ':') ADVANCE(92);
+      if (lookahead == '\n') ADVANCE(475);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == ':') ADVANCE(83);
       if (lookahead == 's') ADVANCE(35);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 35:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(389);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == ':') ADVANCE(92);
+      if (lookahead == '\n') ADVANCE(475);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == ':') ADVANCE(83);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 36:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(389);
-      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == '\n') ADVANCE(475);
+      if (lookahead == '(') ADVANCE(351);
       if (lookahead == 'p') ADVANCE(34);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 37:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(389);
-      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == '\n') ADVANCE(475);
+      if (lookahead == '(') ADVANCE(351);
       if (lookahead == 't') ADVANCE(36);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 38:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(389);
-      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == '\n') ADVANCE(475);
+      if (lookahead == '(') ADVANCE(351);
       if (lookahead == 't') ADVANCE(37);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 39:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(389);
-      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == '\n') ADVANCE(475);
+      if (lookahead == '(') ADVANCE(351);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 40:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == '-') ADVANCE(89);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == '-') ADVANCE(76);
+      if (lookahead == '[') ADVANCE(146);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(126);
       END_STATE();
     case 41:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == '-') ADVANCE(66);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == '-') ADVANCE(78);
+      if (lookahead == '[') ADVANCE(146);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(126);
       END_STATE();
     case 42:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == '-') ADVANCE(90);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == '-') ADVANCE(77);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 43:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == ':') ADVANCE(92);
-      if (lookahead == 's') ADVANCE(44);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == '-') ADVANCE(79);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 44:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == ':') ADVANCE(92);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == '-') ADVANCE(80);
+      if (lookahead == '[') ADVANCE(146);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(126);
       END_STATE();
     case 45:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'A') ADVANCE(42);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == '-') ADVANCE(81);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 46:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'E') ADVANCE(52);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == ':') ADVANCE(82);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == 's') ADVANCE(47);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(126);
       END_STATE();
     case 47:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'L') ADVANCE(51);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == ':') ADVANCE(82);
+      if (lookahead == '[') ADVANCE(146);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(126);
       END_STATE();
     case 48:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'L') ADVANCE(41);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == ':') ADVANCE(83);
+      if (lookahead == 's') ADVANCE(49);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 49:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'R') ADVANCE(48);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == ':') ADVANCE(83);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 50:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'T') ADVANCE(49);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'A') ADVANCE(44);
+      if (lookahead == '[') ADVANCE(146);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(126);
       END_STATE();
     case 51:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'T') ADVANCE(40);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'A') ADVANCE(45);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 52:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'T') ADVANCE(45);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'E') ADVANCE(62);
+      if (lookahead == '[') ADVANCE(146);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(126);
       END_STATE();
     case 53:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'p') ADVANCE(43);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'E') ADVANCE(65);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 54:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 't') ADVANCE(53);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'L') ADVANCE(61);
+      if (lookahead == '[') ADVANCE(146);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(126);
       END_STATE();
     case 55:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 't') ADVANCE(54);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'L') ADVANCE(41);
+      if (lookahead == '[') ADVANCE(146);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(126);
       END_STATE();
     case 56:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'L') ADVANCE(64);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 57:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == 'E') ADVANCE(375);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'L') ADVANCE(43);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 58:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == 'L') ADVANCE(374);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'R') ADVANCE(55);
+      if (lookahead == '[') ADVANCE(146);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(126);
       END_STATE();
     case 59:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == 'T') ADVANCE(373);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'R') ADVANCE(57);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 60:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'T') ADVANCE(58);
+      if (lookahead == '[') ADVANCE(146);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(126);
       END_STATE();
     case 61:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '-') ADVANCE(64);
-      if (lookahead == '>') ADVANCE(295);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'T') ADVANCE(40);
+      if (lookahead == '[') ADVANCE(146);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(63);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(126);
       END_STATE();
     case 62:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '-') ADVANCE(91);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'T') ADVANCE(50);
+      if (lookahead == '[') ADVANCE(146);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(126);
       END_STATE();
     case 63:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '>') ADVANCE(295);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'T') ADVANCE(59);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(63);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 64:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '>') ADVANCE(298);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(27);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'T') ADVANCE(42);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(63);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(65);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 65:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '>') ADVANCE(299);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'T') ADVANCE(51);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 66:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'B') ADVANCE(325);
-      if (lookahead == 'D') ADVANCE(319);
-      if (lookahead == 'I') ADVANCE(322);
-      if (lookahead == 'P') ADVANCE(314);
-      if (lookahead == 'S') ADVANCE(311);
-      if (lookahead == '{') ADVANCE(317);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(302);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == 'p') ADVANCE(46);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(302);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(126);
       END_STATE();
     case 67:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'D') ADVANCE(81);
-      if (lookahead == 'U') ADVANCE(82);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == 't') ADVANCE(66);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(126);
       END_STATE();
     case 68:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'F') ADVANCE(70);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == 't') ADVANCE(67);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(126);
       END_STATE();
     case 69:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'I') ADVANCE(68);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == '[') ADVANCE(146);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(126);
       END_STATE();
     case 70:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'T') ADVANCE(62);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'p') ADVANCE(48);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 71:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'a') ADVANCE(78);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 't') ADVANCE(70);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 72:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'a') ADVANCE(84);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 't') ADVANCE(71);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 73:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'e') ADVANCE(71);
+      if (lookahead == '(') ADVANCE(351);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
+          lookahead != ' ') ADVANCE(146);
       END_STATE();
     case 74:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'e') ADVANCE(83);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
-      END_STATE();
-    case 75:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'e') ADVANCE(67);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
-      END_STATE();
-    case 76:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'g') ADVANCE(75);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
-      END_STATE();
-    case 77:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'h') ADVANCE(72);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
-      END_STATE();
-    case 78:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'k') ADVANCE(333);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
-      END_STATE();
-    case 79:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'l') ADVANCE(333);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
-      END_STATE();
-    case 80:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'n') ADVANCE(333);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
-      END_STATE();
-    case 81:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'o') ADVANCE(87);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
-      END_STATE();
-    case 82:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'p') ADVANCE(333);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
-      END_STATE();
-    case 83:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'r') ADVANCE(86);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
-      END_STATE();
-    case 84:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'r') ADVANCE(88);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
-      END_STATE();
-    case 85:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 's') ADVANCE(74);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
-      END_STATE();
-    case 86:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 't') ADVANCE(333);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
-      END_STATE();
-    case 87:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'w') ADVANCE(80);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
-      END_STATE();
-    case 88:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '}') ADVANCE(335);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
-      END_STATE();
-    case 89:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(341);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(341);
-      END_STATE();
-    case 90:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(337);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(337);
-      END_STATE();
-    case 91:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(329);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(329);
-      END_STATE();
-    case 92:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(95);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(406);
-      END_STATE();
-    case 93:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'A' ||
-          lookahead == 'C' ||
-          lookahead == 'D' ||
-          lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(61);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(63);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
-      END_STATE();
-    case 94:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
-      END_STATE();
-    case 95:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(95);
-      END_STATE();
-    case 96:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(395);
-      if (lookahead == '=') ADVANCE(96);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(214);
-      END_STATE();
-    case 97:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == '-') ADVANCE(119);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 98:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == '-') ADVANCE(145);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 99:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == '-') ADVANCE(146);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 100:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == ':') ADVANCE(142);
-      if (lookahead == 's') ADVANCE(101);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 101:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == ':') ADVANCE(142);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 102:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == 'A') ADVANCE(99);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 103:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == 'E') ADVANCE(109);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 104:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == 'L') ADVANCE(108);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 105:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == 'L') ADVANCE(97);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 106:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == 'R') ADVANCE(105);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 107:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == 'T') ADVANCE(106);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 108:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == 'T') ADVANCE(98);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 109:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == 'T') ADVANCE(102);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 110:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == 'p') ADVANCE(100);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 111:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == 't') ADVANCE(110);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 112:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == 't') ADVANCE(111);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 113:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '(') ADVANCE(283);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 114:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '-') ADVANCE(117);
-      if (lookahead == '>') ADVANCE(297);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 115:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '-') ADVANCE(147);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 116:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '>') ADVANCE(297);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 117:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '>') ADVANCE(296);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
-      if (lookahead != 0) ADVANCE(118);
-      END_STATE();
-    case 118:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '>') ADVANCE(300);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 119:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'B') ADVANCE(308);
-      if (lookahead == 'D') ADVANCE(306);
-      if (lookahead == 'I') ADVANCE(307);
-      if (lookahead == 'P') ADVANCE(304);
-      if (lookahead == 'S') ADVANCE(303);
-      if (lookahead == '{') ADVANCE(305);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(310);
-      if (lookahead != 0) ADVANCE(309);
-      END_STATE();
-    case 120:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'D') ADVANCE(134);
-      if (lookahead == 'U') ADVANCE(135);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 121:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'F') ADVANCE(123);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 122:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'I') ADVANCE(121);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 123:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'T') ADVANCE(115);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 124:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'a') ADVANCE(131);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 125:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'a') ADVANCE(137);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 126:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'e') ADVANCE(124);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 127:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'e') ADVANCE(136);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 128:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'e') ADVANCE(120);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 129:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'g') ADVANCE(128);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 130:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'h') ADVANCE(125);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 131:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'k') ADVANCE(334);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 132:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'l') ADVANCE(334);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 133:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'n') ADVANCE(334);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 134:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'o') ADVANCE(140);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 135:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'p') ADVANCE(334);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 136:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'r') ADVANCE(139);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 137:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'r') ADVANCE(141);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 138:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 's') ADVANCE(127);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 139:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 't') ADVANCE(334);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 140:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'w') ADVANCE(133);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 141:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '}') ADVANCE(336);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 142:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(144);
-      if (lookahead != 0) ADVANCE(405);
-      END_STATE();
-    case 143:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead == 'A' ||
-          lookahead == 'C' ||
-          lookahead == 'D' ||
-          lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(114);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 144:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 145:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(343);
-      if (lookahead != 0) ADVANCE(342);
-      END_STATE();
-    case 146:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(339);
-      if (lookahead != 0) ADVANCE(338);
-      END_STATE();
-    case 147:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(331);
-      if (lookahead != 0) ADVANCE(330);
-      END_STATE();
-    case 148:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == '-') ADVANCE(208);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 149:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == '-') ADVANCE(185);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 150:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == '-') ADVANCE(209);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 151:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == ':') ADVANCE(211);
-      if (lookahead == 's') ADVANCE(152);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 152:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == ':') ADVANCE(211);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 153:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'A') ADVANCE(150);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 154:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'E') ADVANCE(160);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 155:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'L') ADVANCE(159);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 156:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'L') ADVANCE(149);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 157:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'R') ADVANCE(156);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 158:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'T') ADVANCE(157);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 159:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'T') ADVANCE(148);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 160:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'T') ADVANCE(153);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 161:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'p') ADVANCE(151);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 162:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 't') ADVANCE(161);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 163:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 't') ADVANCE(162);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 164:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 165:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == 'E') ADVANCE(352);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 166:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == 'L') ADVANCE(351);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 167:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == 'T') ADVANCE(350);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 168:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 169:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '-') ADVANCE(183);
-      if (lookahead == '>') ADVANCE(295);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 170:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '-') ADVANCE(210);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 171:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(96);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 172:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(171);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 173:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(172);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 174:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(173);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 175:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(174);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 176:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(175);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 177:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(176);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 178:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(177);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 179:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(178);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 180:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(179);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 181:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(180);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 182:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '>') ADVANCE(295);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 183:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '>') ADVANCE(298);
+      if (lookahead == '(') ADVANCE(147);
+      if (lookahead == '>') ADVANCE(372);
+      if (lookahead == '[') ADVANCE(98);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(27);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(95);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(184);
+          lookahead != '\n') ADVANCE(97);
+      END_STATE();
+    case 75:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(147);
+      if (lookahead == '>') ADVANCE(372);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(27);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(96);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(98);
+      END_STATE();
+    case 76:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(424);
+      if (lookahead == '[') ADVANCE(424);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(424);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(424);
+      END_STATE();
+    case 77:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(424);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(424);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(424);
+      END_STATE();
+    case 78:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(376);
+      if (lookahead == 'B') ADVANCE(406);
+      if (lookahead == 'D') ADVANCE(400);
+      if (lookahead == 'I') ADVANCE(403);
+      if (lookahead == 'P') ADVANCE(394);
+      if (lookahead == 'S') ADVANCE(391);
+      if (lookahead == '[') ADVANCE(376);
+      if (lookahead == '{') ADVANCE(397);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(376);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(376);
+      END_STATE();
+    case 79:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(376);
+      if (lookahead == 'B') ADVANCE(408);
+      if (lookahead == 'D') ADVANCE(402);
+      if (lookahead == 'I') ADVANCE(405);
+      if (lookahead == 'P') ADVANCE(396);
+      if (lookahead == 'S') ADVANCE(393);
+      if (lookahead == '{') ADVANCE(399);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(376);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(376);
+      END_STATE();
+    case 80:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(419);
+      if (lookahead == '[') ADVANCE(419);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(419);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(419);
+      END_STATE();
+    case 81:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(419);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(419);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(419);
+      END_STATE();
+    case 82:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(496);
+      if (lookahead == '[') ADVANCE(494);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(126);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(493);
+      END_STATE();
+    case 83:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(496);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(146);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(494);
+      END_STATE();
+    case 84:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(410);
+      if (lookahead == '[') ADVANCE(410);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(410);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(410);
+      END_STATE();
+    case 85:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(410);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(410);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(410);
+      END_STATE();
+    case 86:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(471);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(457);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(146);
+      END_STATE();
+    case 87:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'E') ADVANCE(465);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(457);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(466);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(146);
+      END_STATE();
+    case 88:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'L') ADVANCE(464);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(457);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(466);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(146);
+      END_STATE();
+    case 89:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'T') ADVANCE(463);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(457);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(466);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(146);
+      END_STATE();
+    case 90:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(457);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(466);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(146);
+      END_STATE();
+    case 91:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '-') ADVANCE(74);
+      if (lookahead == '>') ADVANCE(369);
+      if (lookahead == '[') ADVANCE(146);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(95);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 92:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '-') ADVANCE(75);
+      if (lookahead == '>') ADVANCE(369);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(96);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 93:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '-') ADVANCE(84);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 94:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '-') ADVANCE(85);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 95:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '>') ADVANCE(369);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(95);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 96:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '>') ADVANCE(369);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(96);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 97:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '>') ADVANCE(373);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 98:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '>') ADVANCE(373);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 99:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'D') ADVANCE(117);
+      if (lookahead == 'U') ADVANCE(118);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 100:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'D') ADVANCE(137);
+      if (lookahead == 'U') ADVANCE(138);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 101:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'F') ADVANCE(105);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 102:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'F') ADVANCE(106);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 103:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'I') ADVANCE(101);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 104:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'I') ADVANCE(102);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 105:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'T') ADVANCE(93);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 106:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'T') ADVANCE(94);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 107:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == 'a') ADVANCE(114);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 108:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == 'a') ADVANCE(120);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 109:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == 'e') ADVANCE(107);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 110:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == 'e') ADVANCE(119);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 111:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == 'e') ADVANCE(99);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 112:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == 'g') ADVANCE(111);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 113:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == 'h') ADVANCE(108);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 114:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == 'k') ADVANCE(415);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 115:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == 'l') ADVANCE(415);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 116:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == 'n') ADVANCE(415);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 117:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == 'o') ADVANCE(123);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 118:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == 'p') ADVANCE(415);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 119:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == 'r') ADVANCE(122);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 120:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == 'r') ADVANCE(124);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 121:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == 's') ADVANCE(110);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 122:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == 't') ADVANCE(415);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 123:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == 'w') ADVANCE(116);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 124:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == '}') ADVANCE(417);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 125:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead == 'A' ||
+          lookahead == 'C' ||
+          lookahead == 'D' ||
+          lookahead == 'M' ||
+          lookahead == 'S') ADVANCE(91);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(95);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 126:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '[') ADVANCE(146);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(126);
+      END_STATE();
+    case 127:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'a') ADVANCE(134);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 128:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'a') ADVANCE(140);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 129:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'e') ADVANCE(127);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 130:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'e') ADVANCE(139);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 131:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'e') ADVANCE(100);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 132:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'g') ADVANCE(131);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 133:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'h') ADVANCE(128);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 134:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'k') ADVANCE(415);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 135:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'l') ADVANCE(415);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 136:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'n') ADVANCE(415);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 137:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'o') ADVANCE(143);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 138:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'p') ADVANCE(415);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 139:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'r') ADVANCE(142);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 140:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'r') ADVANCE(144);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 141:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 's') ADVANCE(130);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 142:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 't') ADVANCE(415);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 143:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'w') ADVANCE(136);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 144:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '}') ADVANCE(417);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 145:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'A' ||
+          lookahead == 'C' ||
+          lookahead == 'D' ||
+          lookahead == 'M' ||
+          lookahead == 'S') ADVANCE(92);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(96);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 146:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(146);
+      END_STATE();
+    case 147:
+      ACCEPT_TOKEN(aux_sym_word_token2);
+      if (lookahead == '>') ADVANCE(373);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(148);
+      END_STATE();
+    case 148:
+      ACCEPT_TOKEN(aux_sym_word_token2);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(148);
+      END_STATE();
+    case 149:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(481);
+      if (lookahead == '=') ADVANCE(149);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(20);
+      if (lookahead != 0 &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 150:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '(') ADVANCE(352);
+      if (lookahead == '-') ADVANCE(172);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(166);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 151:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '(') ADVANCE(352);
+      if (lookahead == '-') ADVANCE(198);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(166);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 152:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '(') ADVANCE(352);
+      if (lookahead == '-') ADVANCE(199);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(166);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 153:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '(') ADVANCE(352);
+      if (lookahead == ':') ADVANCE(195);
+      if (lookahead == 's') ADVANCE(154);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(166);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 154:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '(') ADVANCE(352);
+      if (lookahead == ':') ADVANCE(195);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(166);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 155:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '(') ADVANCE(352);
+      if (lookahead == 'A') ADVANCE(152);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(166);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 156:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '(') ADVANCE(352);
+      if (lookahead == 'E') ADVANCE(162);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(166);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 157:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '(') ADVANCE(352);
+      if (lookahead == 'L') ADVANCE(161);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(166);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 158:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '(') ADVANCE(352);
+      if (lookahead == 'L') ADVANCE(150);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(166);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 159:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '(') ADVANCE(352);
+      if (lookahead == 'R') ADVANCE(158);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(166);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 160:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '(') ADVANCE(352);
+      if (lookahead == 'T') ADVANCE(159);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(166);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 161:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '(') ADVANCE(352);
+      if (lookahead == 'T') ADVANCE(151);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(166);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 162:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '(') ADVANCE(352);
+      if (lookahead == 'T') ADVANCE(155);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(166);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 163:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '(') ADVANCE(352);
+      if (lookahead == 'p') ADVANCE(153);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(166);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 164:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '(') ADVANCE(352);
+      if (lookahead == 't') ADVANCE(163);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(166);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 165:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '(') ADVANCE(352);
+      if (lookahead == 't') ADVANCE(164);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(166);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 166:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '(') ADVANCE(352);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(166);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 167:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '-') ADVANCE(170);
+      if (lookahead == '>') ADVANCE(371);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(169);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 168:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '-') ADVANCE(200);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 169:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '>') ADVANCE(371);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(169);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 170:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '>') ADVANCE(370);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(22);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(169);
+      if (lookahead != 0) ADVANCE(171);
+      END_STATE();
+    case 171:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '>') ADVANCE(374);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 172:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'B') ADVANCE(382);
+      if (lookahead == 'D') ADVANCE(380);
+      if (lookahead == 'I') ADVANCE(381);
+      if (lookahead == 'P') ADVANCE(378);
+      if (lookahead == 'S') ADVANCE(377);
+      if (lookahead == '{') ADVANCE(379);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(384);
+      if (lookahead != 0) ADVANCE(383);
+      END_STATE();
+    case 173:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'D') ADVANCE(187);
+      if (lookahead == 'U') ADVANCE(188);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 174:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'F') ADVANCE(176);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 175:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'I') ADVANCE(174);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 176:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'T') ADVANCE(168);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 177:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'a') ADVANCE(184);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 178:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'a') ADVANCE(190);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 179:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'e') ADVANCE(177);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 180:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'e') ADVANCE(189);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 181:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'e') ADVANCE(173);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 182:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'g') ADVANCE(181);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 183:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'h') ADVANCE(178);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
       END_STATE();
     case 184:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '>') ADVANCE(299);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'k') ADVANCE(416);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
       END_STATE();
     case 185:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'B') ADVANCE(327);
-      if (lookahead == 'D') ADVANCE(321);
-      if (lookahead == 'I') ADVANCE(324);
-      if (lookahead == 'P') ADVANCE(316);
-      if (lookahead == 'S') ADVANCE(312);
-      if (lookahead == '{') ADVANCE(318);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'l') ADVANCE(416);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(302);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(302);
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
       END_STATE();
     case 186:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'D') ADVANCE(200);
-      if (lookahead == 'U') ADVANCE(201);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'n') ADVANCE(416);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
       END_STATE();
     case 187:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'F') ADVANCE(189);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'o') ADVANCE(193);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
       END_STATE();
     case 188:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'I') ADVANCE(187);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'p') ADVANCE(416);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
       END_STATE();
     case 189:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'T') ADVANCE(170);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'r') ADVANCE(192);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
       END_STATE();
     case 190:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'a') ADVANCE(197);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'r') ADVANCE(194);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
       END_STATE();
     case 191:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'a') ADVANCE(203);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 's') ADVANCE(180);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
       END_STATE();
     case 192:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'e') ADVANCE(190);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 't') ADVANCE(416);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
       END_STATE();
     case 193:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'e') ADVANCE(202);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'w') ADVANCE(186);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
       END_STATE();
     case 194:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'e') ADVANCE(186);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '}') ADVANCE(418);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
       END_STATE();
     case 195:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'g') ADVANCE(194);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead == '(' ||
+          lookahead == '[') ADVANCE(492);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(197);
+      if (lookahead != 0) ADVANCE(491);
       END_STATE();
     case 196:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'h') ADVANCE(191);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead == 'A' ||
+          lookahead == 'C' ||
+          lookahead == 'D' ||
+          lookahead == 'M' ||
+          lookahead == 'S') ADVANCE(167);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(169);
+      if (lookahead != 0) ADVANCE(197);
       END_STATE();
     case 197:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'k') ADVANCE(333);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
       END_STATE();
     case 198:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'l') ADVANCE(333);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(426);
+      if (lookahead != 0) ADVANCE(425);
       END_STATE();
     case 199:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'n') ADVANCE(333);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(421);
+      if (lookahead != 0) ADVANCE(420);
       END_STATE();
     case 200:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'o') ADVANCE(206);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(412);
+      if (lookahead != 0) ADVANCE(411);
       END_STATE();
     case 201:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'p') ADVANCE(333);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == '-') ADVANCE(263);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(267);
       END_STATE();
     case 202:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'r') ADVANCE(205);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == '-') ADVANCE(239);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(267);
       END_STATE();
     case 203:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'r') ADVANCE(207);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == '-') ADVANCE(264);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(267);
       END_STATE();
     case 204:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 's') ADVANCE(193);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == ':') ADVANCE(262);
+      if (lookahead == 's') ADVANCE(205);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(267);
       END_STATE();
     case 205:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 't') ADVANCE(333);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == ':') ADVANCE(262);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(267);
       END_STATE();
     case 206:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'w') ADVANCE(199);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'A') ADVANCE(203);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(267);
       END_STATE();
     case 207:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '}') ADVANCE(335);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'E') ADVANCE(213);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(267);
       END_STATE();
     case 208:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(341);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(341);
-      END_STATE();
-    case 209:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(337);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(337);
-      END_STATE();
-    case 210:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(329);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(329);
-      END_STATE();
-    case 211:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(214);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'L') ADVANCE(212);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(406);
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 209:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'L') ADVANCE(202);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 210:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'R') ADVANCE(209);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 211:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'T') ADVANCE(210);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(267);
       END_STATE();
     case 212:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'T') ADVANCE(201);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 213:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'T') ADVANCE(206);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 214:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'p') ADVANCE(204);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 215:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 't') ADVANCE(214);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 216:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 't') ADVANCE(215);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 217:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(351);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 218:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == 'E') ADVANCE(441);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(451);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(450);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 219:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == 'L') ADVANCE(440);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(451);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(450);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 220:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == 'T') ADVANCE(439);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(451);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(450);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 221:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(451);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(450);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 222:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(451);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 223:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '-') ADVANCE(237);
+      if (lookahead == '>') ADVANCE(369);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(236);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 224:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '-') ADVANCE(265);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 225:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '=') ADVANCE(149);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 226:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '=') ADVANCE(225);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 227:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '=') ADVANCE(226);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 228:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '=') ADVANCE(227);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 229:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '=') ADVANCE(228);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 230:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '=') ADVANCE(229);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 231:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '=') ADVANCE(230);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 232:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '=') ADVANCE(231);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 233:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '=') ADVANCE(232);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 234:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '=') ADVANCE(233);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 235:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '=') ADVANCE(234);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 236:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '>') ADVANCE(369);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(236);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 237:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '>') ADVANCE(372);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(27);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(236);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(238);
+      END_STATE();
+    case 238:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '>') ADVANCE(373);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 239:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'B') ADVANCE(407);
+      if (lookahead == 'D') ADVANCE(401);
+      if (lookahead == 'I') ADVANCE(404);
+      if (lookahead == 'P') ADVANCE(395);
+      if (lookahead == 'S') ADVANCE(392);
+      if (lookahead == '{') ADVANCE(398);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(376);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(376);
+      END_STATE();
+    case 240:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'D') ADVANCE(254);
+      if (lookahead == 'U') ADVANCE(255);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 241:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'F') ADVANCE(243);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 242:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'I') ADVANCE(241);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 243:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'T') ADVANCE(224);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 244:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'a') ADVANCE(251);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 245:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'a') ADVANCE(257);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 246:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'e') ADVANCE(244);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 247:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'e') ADVANCE(256);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 248:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'e') ADVANCE(240);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 249:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'g') ADVANCE(248);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 250:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'h') ADVANCE(245);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 251:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'k') ADVANCE(415);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 252:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'l') ADVANCE(415);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 253:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'n') ADVANCE(415);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 254:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'o') ADVANCE(260);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 255:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'p') ADVANCE(415);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 256:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'r') ADVANCE(259);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 257:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'r') ADVANCE(261);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 258:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 's') ADVANCE(247);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 259:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 't') ADVANCE(415);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 260:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'w') ADVANCE(253);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 261:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '}') ADVANCE(417);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
+      END_STATE();
+    case 262:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(' ||
+          lookahead == '[') ADVANCE(496);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(267);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(495);
+      END_STATE();
+    case 263:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(424);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(424);
+      END_STATE();
+    case 264:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(419);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(419);
+      END_STATE();
+    case 265:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(410);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(410);
+      END_STATE();
+    case 266:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(169);
+          lookahead == 'S') ADVANCE(223);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(236);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
       END_STATE();
-    case 213:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 214:
+    case 267:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(214);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(267);
       END_STATE();
-    case 215:
+    case 268:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '\n') ADVANCE(396);
-      if (lookahead == '-') ADVANCE(215);
+      if (lookahead == '\n') ADVANCE(482);
+      if (lookahead == '-') ADVANCE(268);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(20);
-      if (lookahead != 0) ADVANCE(227);
+          lookahead == ' ') ADVANCE(19);
+      if (lookahead != 0 &&
+          lookahead != '(') ADVANCE(280);
       END_STATE();
-    case 216:
+    case 269:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\n') ADVANCE(480);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(216);
+          lookahead == ' ' ||
+          lookahead == '(') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(269);
       END_STATE();
-    case 217:
+    case 270:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(215);
+      if (lookahead == '-') ADVANCE(268);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(227);
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(280);
       END_STATE();
-    case 218:
+    case 271:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(217);
+      if (lookahead == '-') ADVANCE(270);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(227);
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(280);
       END_STATE();
-    case 219:
+    case 272:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(218);
+      if (lookahead == '-') ADVANCE(271);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(227);
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(280);
       END_STATE();
-    case 220:
+    case 273:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(219);
+      if (lookahead == '-') ADVANCE(272);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(227);
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(280);
       END_STATE();
-    case 221:
+    case 274:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(220);
+      if (lookahead == '-') ADVANCE(273);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(227);
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(280);
       END_STATE();
-    case 222:
+    case 275:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(221);
+      if (lookahead == '-') ADVANCE(274);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(227);
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(280);
       END_STATE();
-    case 223:
+    case 276:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(222);
+      if (lookahead == '-') ADVANCE(275);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(227);
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(280);
       END_STATE();
-    case 224:
+    case 277:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(223);
+      if (lookahead == '-') ADVANCE(276);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(227);
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(280);
       END_STATE();
-    case 225:
+    case 278:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(224);
+      if (lookahead == '-') ADVANCE(277);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(227);
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(280);
       END_STATE();
-    case 226:
+    case 279:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(225);
+      if (lookahead == '-') ADVANCE(278);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(227);
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(280);
       END_STATE();
-    case 227:
+    case 280:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(227);
+          lookahead != ' ' &&
+          lookahead != '(') ADVANCE(280);
       END_STATE();
-    case 228:
+    case 281:
       ACCEPT_TOKEN(anon_sym_SQUOTE);
       END_STATE();
-    case 229:
+    case 282:
       ACCEPT_TOKEN(anon_sym_SQUOTE);
-      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\n') ADVANCE(480);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
       END_STATE();
-    case 230:
+    case 283:
       ACCEPT_TOKEN(anon_sym_SQUOTE);
-      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 231:
+    case 284:
       ACCEPT_TOKEN(anon_sym_SQUOTE);
+      if (lookahead == '(') ADVANCE(569);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(562);
       END_STATE();
-    case 232:
+    case 285:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
       END_STATE();
-    case 233:
+    case 286:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '\t') ADVANCE(261);
+      if (lookahead == '\t') ADVANCE(314);
       END_STATE();
-    case 234:
+    case 287:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '\t') ADVANCE(261);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
+      if (lookahead == '\t') ADVANCE(314);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(305);
       END_STATE();
-    case 235:
+    case 288:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'E') ADVANCE(52);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(249);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
-      END_STATE();
-    case 236:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'E') ADVANCE(52);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'E') ADVANCE(62);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
       END_STATE();
-    case 237:
+    case 289:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'L') ADVANCE(51);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(249);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'E') ADVANCE(65);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(302);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(73);
       END_STATE();
-    case 238:
+    case 290:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'L') ADVANCE(51);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      END_STATE();
-    case 239:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'T') ADVANCE(49);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(249);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
-      END_STATE();
-    case 240:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'T') ADVANCE(49);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'L') ADVANCE(61);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
       END_STATE();
-    case 241:
+    case 291:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 't') ADVANCE(410);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(411);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'L') ADVANCE(64);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(302);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(73);
       END_STATE();
-    case 242:
+    case 292:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(411);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
-      END_STATE();
-    case 243:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(249);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
-      END_STATE();
-    case 244:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(282);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'T') ADVANCE(58);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
       END_STATE();
-    case 245:
+    case 293:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(251);
-      if (lookahead == 't') ADVANCE(415);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(416);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'T') ADVANCE(59);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(302);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(249);
+          lookahead == '_') ADVANCE(73);
+      END_STATE();
+    case 294:
+      ACCEPT_TOKEN(aux_sym__word_common_token1);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 't') ADVANCE(500);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(501);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(69);
+      END_STATE();
+    case 295:
+      ACCEPT_TOKEN(aux_sym__word_common_token1);
+      if (lookahead == '(') ADVANCE(351);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(501);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(69);
+      END_STATE();
+    case 296:
+      ACCEPT_TOKEN(aux_sym__word_common_token1);
+      if (lookahead == '(') ADVANCE(351);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(302);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
+      END_STATE();
+    case 297:
+      ACCEPT_TOKEN(aux_sym__word_common_token1);
+      if (lookahead == '(') ADVANCE(351);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
+      END_STATE();
+    case 298:
+      ACCEPT_TOKEN(aux_sym__word_common_token1);
+      if (lookahead == '(') ADVANCE(305);
+      if (lookahead == 't') ADVANCE(505);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(506);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(302);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(251);
+          lookahead != '\'') ADVANCE(305);
       END_STATE();
-    case 246:
+    case 299:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(251);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(416);
+      if (lookahead == '(') ADVANCE(305);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(506);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(249);
+          lookahead == '_') ADVANCE(302);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(251);
+          lookahead != '\'') ADVANCE(305);
       END_STATE();
-    case 247:
+    case 300:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(61);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(250);
+          lookahead == 'S') ADVANCE(92);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(304);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(63);
+          lookahead == '_') ADVANCE(96);
       END_STATE();
-    case 248:
+    case 301:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(305);
       END_STATE();
-    case 249:
+    case 302:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == '(') ADVANCE(282);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(249);
+      if (lookahead == '(') ADVANCE(351);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(302);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(73);
       END_STATE();
-    case 250:
+    case 303:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == '>') ADVANCE(295);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(250);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(63);
-      END_STATE();
-    case 251:
-      ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
-      END_STATE();
-    case 252:
-      ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(252);
+      if (lookahead == '(') ADVANCE(496);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(303);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != ')' &&
-          lookahead != ']') ADVANCE(406);
-      END_STATE();
-    case 253:
-      ACCEPT_TOKEN(anon_sym_SQUOTE2);
-      END_STATE();
-    case 254:
-      ACCEPT_TOKEN(aux_sym__word_common_token3);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '|') ADVANCE(254);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 255:
-      ACCEPT_TOKEN(aux_sym__word_common_token3);
-      if (lookahead == '|') ADVANCE(255);
-      END_STATE();
-    case 256:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      END_STATE();
-    case 257:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '|') ADVANCE(254);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 258:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '|') ADVANCE(543);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          (lookahead < '{' || '}' < lookahead)) ADVANCE(546);
-      END_STATE();
-    case 259:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '|') ADVANCE(255);
-      END_STATE();
-    case 260:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '|') ADVANCE(255);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
-      END_STATE();
-    case 261:
-      ACCEPT_TOKEN(aux_sym__word_common_token4);
-      END_STATE();
-    case 262:
-      ACCEPT_TOKEN(aux_sym__word_common_token4);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead != 0) ADVANCE(23);
-      END_STATE();
-    case 263:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '{') ADVANCE(272);
-      if (lookahead == '}') ADVANCE(270);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 264:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
-      if (lookahead == '{') ADVANCE(274);
-      if (lookahead == '}') ADVANCE(269);
-      END_STATE();
-    case 265:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
-      if (lookahead == '{') ADVANCE(274);
-      if (lookahead == '}') ADVANCE(269);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
-      END_STATE();
-    case 266:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
-      END_STATE();
-    case 267:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 268:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
-      END_STATE();
-    case 269:
-      ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
-      END_STATE();
-    case 270:
-      ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 271:
-      ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 272:
-      ACCEPT_TOKEN(aux_sym__word_common_token5);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '{') ADVANCE(272);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(273);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 273:
-      ACCEPT_TOKEN(aux_sym__word_common_token5);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(273);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 274:
-      ACCEPT_TOKEN(aux_sym__word_common_token5);
-      if (lookahead == '{') ADVANCE(274);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(275);
-      END_STATE();
-    case 275:
-      ACCEPT_TOKEN(aux_sym__word_common_token5);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(275);
-      END_STATE();
-    case 276:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      END_STATE();
-    case 277:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 278:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 279:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
-      END_STATE();
-    case 280:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
-      END_STATE();
-    case 281:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      END_STATE();
-    case 282:
-      ACCEPT_TOKEN(aux_sym__word_common_token6);
-      END_STATE();
-    case 283:
-      ACCEPT_TOKEN(aux_sym__word_common_token6);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 284:
-      ACCEPT_TOKEN(aux_sym__word_common_token6);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      END_STATE();
-    case 285:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      END_STATE();
-    case 286:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 287:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 288:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
-      END_STATE();
-    case 289:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 290:
-      ACCEPT_TOKEN(anon_sym_GT);
-      END_STATE();
-    case 291:
-      ACCEPT_TOKEN(anon_sym_GT);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 292:
-      ACCEPT_TOKEN(anon_sym_GT);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 293:
-      ACCEPT_TOKEN(anon_sym_GT);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
-      END_STATE();
-    case 294:
-      ACCEPT_TOKEN(anon_sym_GT);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 295:
-      ACCEPT_TOKEN(aux_sym_keycode_token1);
-      END_STATE();
-    case 296:
-      ACCEPT_TOKEN(aux_sym_keycode_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '>') ADVANCE(300);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 297:
-      ACCEPT_TOKEN(aux_sym_keycode_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 298:
-      ACCEPT_TOKEN(aux_sym_keycode_token1);
-      if (lookahead == '>') ADVANCE(299);
-      END_STATE();
-    case 299:
-      ACCEPT_TOKEN(aux_sym_keycode_token2);
-      END_STATE();
-    case 300:
-      ACCEPT_TOKEN(aux_sym_keycode_token2);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 301:
-      ACCEPT_TOKEN(aux_sym_keycode_token2);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead != 0) ADVANCE(23);
-      END_STATE();
-    case 302:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      END_STATE();
-    case 303:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'H') ADVANCE(122);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead != ']') ADVANCE(494);
       END_STATE();
     case 304:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'a') ADVANCE(129);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+      ACCEPT_TOKEN(aux_sym__word_common_token2);
+      if (lookahead == '>') ADVANCE(369);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(304);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(96);
       END_STATE();
     case 305:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'c') ADVANCE(130);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+      ACCEPT_TOKEN(aux_sym__word_common_token2);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(305);
       END_STATE();
     case 306:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'e') ADVANCE(132);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+      ACCEPT_TOKEN(anon_sym_SQUOTE2);
       END_STATE();
     case 307:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'n') ADVANCE(138);
+      ACCEPT_TOKEN(aux_sym__word_common_token3);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '|') ADVANCE(307);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
       END_STATE();
     case 308:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == 'r') ADVANCE(126);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+      ACCEPT_TOKEN(aux_sym__word_common_token3);
+      if (lookahead == '|') ADVANCE(308);
       END_STATE();
     case 309:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+      ACCEPT_TOKEN(anon_sym_PIPE);
       END_STATE();
     case 310:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead != 0) ADVANCE(23);
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '|') ADVANCE(307);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
       END_STATE();
     case 311:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'H') ADVANCE(69);
-      END_STATE();
-    case 312:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'H') ADVANCE(188);
-      END_STATE();
-    case 313:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'H') ADVANCE(380);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      END_STATE();
-    case 314:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'a') ADVANCE(76);
-      END_STATE();
-    case 315:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'a') ADVANCE(76);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      END_STATE();
-    case 316:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'a') ADVANCE(195);
-      END_STATE();
-    case 317:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'c') ADVANCE(77);
-      END_STATE();
-    case 318:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'c') ADVANCE(196);
-      END_STATE();
-    case 319:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'e') ADVANCE(79);
-      END_STATE();
-    case 320:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'e') ADVANCE(79);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      END_STATE();
-    case 321:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'e') ADVANCE(198);
-      END_STATE();
-    case 322:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'n') ADVANCE(85);
-      END_STATE();
-    case 323:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'n') ADVANCE(85);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      END_STATE();
-    case 324:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'n') ADVANCE(204);
-      END_STATE();
-    case 325:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'r') ADVANCE(73);
-      END_STATE();
-    case 326:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'r') ADVANCE(73);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      END_STATE();
-    case 327:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'r') ADVANCE(192);
-      END_STATE();
-    case 328:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      END_STATE();
-    case 329:
-      ACCEPT_TOKEN(aux_sym_keycode_token4);
-      END_STATE();
-    case 330:
-      ACCEPT_TOKEN(aux_sym_keycode_token4);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 331:
-      ACCEPT_TOKEN(aux_sym_keycode_token4);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead != 0) ADVANCE(23);
-      END_STATE();
-    case 332:
-      ACCEPT_TOKEN(aux_sym_keycode_token4);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      END_STATE();
-    case 333:
-      ACCEPT_TOKEN(aux_sym_keycode_token5);
-      END_STATE();
-    case 334:
-      ACCEPT_TOKEN(aux_sym_keycode_token5);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 335:
-      ACCEPT_TOKEN(aux_sym_keycode_token6);
-      END_STATE();
-    case 336:
-      ACCEPT_TOKEN(aux_sym_keycode_token6);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 337:
-      ACCEPT_TOKEN(aux_sym_keycode_token7);
-      END_STATE();
-    case 338:
-      ACCEPT_TOKEN(aux_sym_keycode_token7);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 339:
-      ACCEPT_TOKEN(aux_sym_keycode_token7);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead != 0) ADVANCE(23);
-      END_STATE();
-    case 340:
-      ACCEPT_TOKEN(aux_sym_keycode_token7);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      END_STATE();
-    case 341:
-      ACCEPT_TOKEN(aux_sym_keycode_token8);
-      END_STATE();
-    case 342:
-      ACCEPT_TOKEN(aux_sym_keycode_token8);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 343:
-      ACCEPT_TOKEN(aux_sym_keycode_token8);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead != 0) ADVANCE(23);
-      END_STATE();
-    case 344:
-      ACCEPT_TOKEN(aux_sym_keycode_token8);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      END_STATE();
-    case 345:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == '-') ADVANCE(364);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
-      END_STATE();
-    case 346:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == '-') ADVANCE(355);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
-      END_STATE();
-    case 347:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == '-') ADVANCE(365);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
-      END_STATE();
-    case 348:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == 'A') ADVANCE(347);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
-      END_STATE();
-    case 349:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == 'L') ADVANCE(346);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
-      END_STATE();
-    case 350:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == 'R') ADVANCE(349);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
-      END_STATE();
-    case 351:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == 'T') ADVANCE(345);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
-      END_STATE();
-    case 352:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == 'T') ADVANCE(348);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
-      END_STATE();
-    case 353:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(367);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(367);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(353);
-      END_STATE();
-    case 354:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '-') ADVANCE(366);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
-      END_STATE();
-    case 355:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'B') ADVANCE(363);
-      if (lookahead == 'D') ADVANCE(361);
-      if (lookahead == 'I') ADVANCE(362);
-      if (lookahead == 'P') ADVANCE(360);
-      if (lookahead == 'S') ADVANCE(357);
-      if (lookahead == '{') ADVANCE(318);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(302);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(302);
-      END_STATE();
-    case 356:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'F') ADVANCE(359);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
-      END_STATE();
-    case 357:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'H') ADVANCE(358);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
-      END_STATE();
-    case 358:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'I') ADVANCE(356);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
-      END_STATE();
-    case 359:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'T') ADVANCE(354);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
-      END_STATE();
-    case 360:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'a') ADVANCE(195);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
-      END_STATE();
-    case 361:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'e') ADVANCE(198);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
-      END_STATE();
-    case 362:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'n') ADVANCE(204);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
-      END_STATE();
-    case 363:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'r') ADVANCE(192);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
-      END_STATE();
-    case 364:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(341);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(341);
-      END_STATE();
-    case 365:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(337);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(337);
-      END_STATE();
-    case 366:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(329);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(329);
-      END_STATE();
-    case 367:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(367);
-      END_STATE();
-    case 368:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == '-') ADVANCE(382);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
-      END_STATE();
-    case 369:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == '-') ADVANCE(378);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
-      END_STATE();
-    case 370:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == '-') ADVANCE(383);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
-      END_STATE();
-    case 371:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == 'A') ADVANCE(370);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
-      END_STATE();
-    case 372:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == 'L') ADVANCE(369);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
-      END_STATE();
-    case 373:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == 'R') ADVANCE(372);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
-      END_STATE();
-    case 374:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == 'T') ADVANCE(368);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
-      END_STATE();
-    case 375:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == 'T') ADVANCE(371);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
-      END_STATE();
-    case 376:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(284);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(376);
-      END_STATE();
-    case 377:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '-') ADVANCE(384);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      END_STATE();
-    case 378:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == 'B') ADVANCE(326);
-      if (lookahead == 'D') ADVANCE(320);
-      if (lookahead == 'I') ADVANCE(323);
-      if (lookahead == 'P') ADVANCE(315);
-      if (lookahead == 'S') ADVANCE(313);
-      if (lookahead == '{') ADVANCE(317);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(302);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(328);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(302);
-      END_STATE();
-    case 379:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == 'F') ADVANCE(381);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      END_STATE();
-    case 380:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == 'I') ADVANCE(379);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      END_STATE();
-    case 381:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == 'T') ADVANCE(377);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      END_STATE();
-    case 382:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(341);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(344);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(341);
-      END_STATE();
-    case 383:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(337);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(340);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(337);
-      END_STATE();
-    case 384:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(329);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(332);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(329);
-      END_STATE();
-    case 385:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(385);
-      END_STATE();
-    case 386:
-      ACCEPT_TOKEN(anon_sym_LT);
-      END_STATE();
-    case 387:
-      ACCEPT_TOKEN(anon_sym_LT);
-      if (lookahead == 'A' ||
-          lookahead == 'C' ||
-          lookahead == 'D' ||
-          lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(61);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(63);
-      END_STATE();
-    case 388:
-      ACCEPT_TOKEN(anon_sym_LT);
-      if (lookahead == 'A' ||
-          lookahead == 'C' ||
-          lookahead == 'D' ||
-          lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(169);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
-      END_STATE();
-    case 389:
-      ACCEPT_TOKEN(aux_sym_codeblock_token1);
-      END_STATE();
-    case 390:
-      ACCEPT_TOKEN(anon_sym_LF);
-      END_STATE();
-    case 391:
-      ACCEPT_TOKEN(anon_sym_LF2);
-      END_STATE();
-    case 392:
-      ACCEPT_TOKEN(aux_sym_line_li_token1);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == ' ') ADVANCE(392);
-      if (lookahead != 0) ADVANCE(23);
-      END_STATE();
-    case 393:
-      ACCEPT_TOKEN(aux_sym_line_li_token1);
-      if (lookahead == ' ') ADVANCE(393);
-      END_STATE();
-    case 394:
-      ACCEPT_TOKEN(aux_sym_line_code_token1);
-      END_STATE();
-    case 395:
-      ACCEPT_TOKEN(aux_sym_h1_token1);
-      END_STATE();
-    case 396:
-      ACCEPT_TOKEN(aux_sym_h2_token1);
-      END_STATE();
-    case 397:
-      ACCEPT_TOKEN(anon_sym_STAR);
-      END_STATE();
-    case 398:
-      ACCEPT_TOKEN(anon_sym_STAR);
-      if (lookahead == '\t') ADVANCE(23);
-      if (lookahead == '\n') ADVANCE(394);
-      if (lookahead == ' ') ADVANCE(392);
-      if (lookahead != 0) ADVANCE(216);
-      END_STATE();
-    case 399:
-      ACCEPT_TOKEN(anon_sym_STAR);
-      if (lookahead == ' ') ADVANCE(393);
-      END_STATE();
-    case 400:
-      ACCEPT_TOKEN(anon_sym_STAR);
-      if (lookahead == ' ') ADVANCE(548);
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == '|') ADVANCE(635);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          (lookahead < '{' || '}' < lookahead)) ADVANCE(638);
       END_STATE();
-    case 401:
-      ACCEPT_TOKEN(anon_sym_STAR);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
+    case 312:
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == '|') ADVANCE(308);
       END_STATE();
-    case 402:
-      ACCEPT_TOKEN(anon_sym_STAR);
+    case 313:
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == '|') ADVANCE(308);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(305);
+      END_STATE();
+    case 314:
+      ACCEPT_TOKEN(aux_sym__word_common_token4);
+      END_STATE();
+    case 315:
+      ACCEPT_TOKEN(aux_sym__word_common_token4);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead != 0) ADVANCE(23);
+      END_STATE();
+    case 316:
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '{') ADVANCE(325);
+      if (lookahead == '}') ADVANCE(323);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 317:
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      if (lookahead == '{') ADVANCE(327);
+      if (lookahead == '}') ADVANCE(322);
+      END_STATE();
+    case 318:
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      if (lookahead == '{') ADVANCE(327);
+      if (lookahead == '}') ADVANCE(322);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(305);
+      END_STATE();
+    case 319:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
+      END_STATE();
+    case 320:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 321:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(305);
+      END_STATE();
+    case 322:
+      ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
+      END_STATE();
+    case 323:
+      ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 324:
+      ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(569);
+      END_STATE();
+    case 325:
+      ACCEPT_TOKEN(aux_sym__word_common_token5);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '{') ADVANCE(325);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(326);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 326:
+      ACCEPT_TOKEN(aux_sym__word_common_token5);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(326);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 327:
+      ACCEPT_TOKEN(aux_sym__word_common_token5);
+      if (lookahead == '{') ADVANCE(327);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(328);
+      END_STATE();
+    case 328:
+      ACCEPT_TOKEN(aux_sym__word_common_token5);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(328);
+      END_STATE();
+    case 329:
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      END_STATE();
+    case 330:
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 331:
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(642);
+      END_STATE();
+    case 332:
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(451);
+      END_STATE();
+    case 333:
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(305);
+      END_STATE();
+    case 334:
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(471);
+      END_STATE();
+    case 335:
+      ACCEPT_TOKEN(anon_sym_RPAREN);
+      END_STATE();
+    case 336:
+      ACCEPT_TOKEN(anon_sym_RPAREN);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 337:
+      ACCEPT_TOKEN(anon_sym_RPAREN);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 338:
+      ACCEPT_TOKEN(anon_sym_RPAREN);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(451);
+      END_STATE();
+    case 339:
+      ACCEPT_TOKEN(anon_sym_RPAREN);
+      if (lookahead == '(') ADVANCE(471);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(457);
+      END_STATE();
+    case 340:
+      ACCEPT_TOKEN(anon_sym_RPAREN);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(305);
+      END_STATE();
+    case 341:
+      ACCEPT_TOKEN(anon_sym_LBRACK);
+      END_STATE();
+    case 342:
+      ACCEPT_TOKEN(anon_sym_LBRACK);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 343:
+      ACCEPT_TOKEN(anon_sym_LBRACK);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(642);
+      END_STATE();
+    case 344:
+      ACCEPT_TOKEN(anon_sym_LBRACK);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(305);
+      END_STATE();
+    case 345:
+      ACCEPT_TOKEN(anon_sym_LBRACK);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(569);
+      END_STATE();
+    case 346:
+      ACCEPT_TOKEN(anon_sym_RBRACK);
+      END_STATE();
+    case 347:
+      ACCEPT_TOKEN(anon_sym_RBRACK);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 348:
+      ACCEPT_TOKEN(anon_sym_RBRACK);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 349:
+      ACCEPT_TOKEN(anon_sym_RBRACK);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 350:
+      ACCEPT_TOKEN(anon_sym_RBRACK);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(305);
+      END_STATE();
+    case 351:
+      ACCEPT_TOKEN(aux_sym__word_common_token6);
+      END_STATE();
+    case 352:
+      ACCEPT_TOKEN(aux_sym__word_common_token6);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead != 0) ADVANCE(23);
+      END_STATE();
+    case 353:
+      ACCEPT_TOKEN(aux_sym__word_common_token6);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(471);
+      END_STATE();
+    case 354:
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      END_STATE();
+    case 355:
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 356:
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 357:
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 358:
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(305);
+      END_STATE();
+    case 359:
+      ACCEPT_TOKEN(anon_sym_GT);
+      END_STATE();
+    case 360:
+      ACCEPT_TOKEN(anon_sym_GT);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 361:
+      ACCEPT_TOKEN(anon_sym_GT);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 362:
+      ACCEPT_TOKEN(anon_sym_GT);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 363:
+      ACCEPT_TOKEN(anon_sym_GT);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(305);
+      END_STATE();
+    case 364:
+      ACCEPT_TOKEN(anon_sym_COMMA);
+      END_STATE();
+    case 365:
+      ACCEPT_TOKEN(anon_sym_COMMA);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 366:
+      ACCEPT_TOKEN(anon_sym_COMMA);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(642);
+      END_STATE();
+    case 367:
+      ACCEPT_TOKEN(anon_sym_COMMA);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(305);
+      END_STATE();
+    case 368:
+      ACCEPT_TOKEN(anon_sym_COMMA);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(569);
+      END_STATE();
+    case 369:
+      ACCEPT_TOKEN(aux_sym_keycode_token1);
+      END_STATE();
+    case 370:
+      ACCEPT_TOKEN(aux_sym_keycode_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '>') ADVANCE(374);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 371:
+      ACCEPT_TOKEN(aux_sym_keycode_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 372:
+      ACCEPT_TOKEN(aux_sym_keycode_token1);
+      if (lookahead == '>') ADVANCE(373);
+      END_STATE();
+    case 373:
+      ACCEPT_TOKEN(aux_sym_keycode_token2);
+      END_STATE();
+    case 374:
+      ACCEPT_TOKEN(aux_sym_keycode_token2);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 375:
+      ACCEPT_TOKEN(aux_sym_keycode_token2);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead != 0) ADVANCE(23);
+      END_STATE();
+    case 376:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      END_STATE();
+    case 377:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'H') ADVANCE(175);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 378:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'a') ADVANCE(182);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 379:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'c') ADVANCE(183);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 380:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'e') ADVANCE(185);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 381:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'n') ADVANCE(191);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 382:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == 'r') ADVANCE(179);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 383:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 384:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead != 0) ADVANCE(23);
+      END_STATE();
+    case 385:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '(') ADVANCE(471);
+      if (lookahead == 'H') ADVANCE(455);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(457);
+      END_STATE();
+    case 386:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '(') ADVANCE(471);
+      if (lookahead == 'a') ADVANCE(132);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(457);
+      END_STATE();
+    case 387:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '(') ADVANCE(471);
+      if (lookahead == 'e') ADVANCE(135);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(457);
+      END_STATE();
+    case 388:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '(') ADVANCE(471);
+      if (lookahead == 'n') ADVANCE(141);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(457);
+      END_STATE();
+    case 389:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '(') ADVANCE(471);
+      if (lookahead == 'r') ADVANCE(129);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(457);
+      END_STATE();
+    case 390:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '(') ADVANCE(471);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(457);
+      END_STATE();
+    case 391:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'H') ADVANCE(103);
+      END_STATE();
+    case 392:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'H') ADVANCE(242);
+      END_STATE();
+    case 393:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'H') ADVANCE(104);
+      END_STATE();
+    case 394:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'a') ADVANCE(112);
+      END_STATE();
+    case 395:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'a') ADVANCE(249);
+      END_STATE();
+    case 396:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'a') ADVANCE(132);
+      END_STATE();
+    case 397:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'c') ADVANCE(113);
+      END_STATE();
+    case 398:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'c') ADVANCE(250);
+      END_STATE();
+    case 399:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'c') ADVANCE(133);
+      END_STATE();
+    case 400:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'e') ADVANCE(115);
+      END_STATE();
+    case 401:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'e') ADVANCE(252);
+      END_STATE();
+    case 402:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'e') ADVANCE(135);
       END_STATE();
     case 403:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'n') ADVANCE(121);
+      END_STATE();
+    case 404:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'n') ADVANCE(258);
+      END_STATE();
+    case 405:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'n') ADVANCE(141);
+      END_STATE();
+    case 406:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'r') ADVANCE(109);
+      END_STATE();
+    case 407:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'r') ADVANCE(246);
+      END_STATE();
+    case 408:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == 'r') ADVANCE(129);
+      END_STATE();
+    case 409:
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(471);
+      END_STATE();
+    case 410:
+      ACCEPT_TOKEN(aux_sym_keycode_token4);
+      END_STATE();
+    case 411:
+      ACCEPT_TOKEN(aux_sym_keycode_token4);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 412:
+      ACCEPT_TOKEN(aux_sym_keycode_token4);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead != 0) ADVANCE(23);
+      END_STATE();
+    case 413:
+      ACCEPT_TOKEN(aux_sym_keycode_token4);
+      if (lookahead == '(') ADVANCE(471);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(457);
+      END_STATE();
+    case 414:
+      ACCEPT_TOKEN(aux_sym_keycode_token4);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(471);
+      END_STATE();
+    case 415:
+      ACCEPT_TOKEN(aux_sym_keycode_token5);
+      END_STATE();
+    case 416:
+      ACCEPT_TOKEN(aux_sym_keycode_token5);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 417:
+      ACCEPT_TOKEN(aux_sym_keycode_token6);
+      END_STATE();
+    case 418:
+      ACCEPT_TOKEN(aux_sym_keycode_token6);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 419:
+      ACCEPT_TOKEN(aux_sym_keycode_token7);
+      END_STATE();
+    case 420:
+      ACCEPT_TOKEN(aux_sym_keycode_token7);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 421:
+      ACCEPT_TOKEN(aux_sym_keycode_token7);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead != 0) ADVANCE(23);
+      END_STATE();
+    case 422:
+      ACCEPT_TOKEN(aux_sym_keycode_token7);
+      if (lookahead == '(') ADVANCE(471);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(457);
+      END_STATE();
+    case 423:
+      ACCEPT_TOKEN(aux_sym_keycode_token7);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(471);
+      END_STATE();
+    case 424:
+      ACCEPT_TOKEN(aux_sym_keycode_token8);
+      END_STATE();
+    case 425:
+      ACCEPT_TOKEN(aux_sym_keycode_token8);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
+      END_STATE();
+    case 426:
+      ACCEPT_TOKEN(aux_sym_keycode_token8);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead != 0) ADVANCE(23);
+      END_STATE();
+    case 427:
+      ACCEPT_TOKEN(aux_sym_keycode_token8);
+      if (lookahead == '(') ADVANCE(471);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(457);
+      END_STATE();
+    case 428:
+      ACCEPT_TOKEN(aux_sym_keycode_token8);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(471);
+      END_STATE();
+    case 429:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == '-') ADVANCE(447);
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(451);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(450);
+      END_STATE();
+    case 430:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == '-') ADVANCE(434);
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(451);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(450);
+      END_STATE();
+    case 431:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == '-') ADVANCE(448);
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(451);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(450);
+      END_STATE();
+    case 432:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == '-') ADVANCE(449);
+      if (lookahead == ')' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(451);
+      END_STATE();
+    case 433:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == 'A') ADVANCE(431);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(451);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(450);
+      END_STATE();
+    case 434:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == 'B') ADVANCE(446);
+      if (lookahead == 'D') ADVANCE(444);
+      if (lookahead == 'I') ADVANCE(445);
+      if (lookahead == 'P') ADVANCE(443);
+      if (lookahead == 'S') ADVANCE(436);
+      if (lookahead == '{') ADVANCE(398);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(376);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(451);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(376);
+      END_STATE();
+    case 435:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == 'F') ADVANCE(442);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(451);
+      END_STATE();
+    case 436:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == 'H') ADVANCE(437);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(451);
+      END_STATE();
+    case 437:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == 'I') ADVANCE(435);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(451);
+      END_STATE();
+    case 438:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == 'L') ADVANCE(430);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(451);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(450);
+      END_STATE();
+    case 439:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == 'R') ADVANCE(438);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(451);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(450);
+      END_STATE();
+    case 440:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == 'T') ADVANCE(429);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(451);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(450);
+      END_STATE();
+    case 441:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == 'T') ADVANCE(433);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(451);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(450);
+      END_STATE();
+    case 442:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == 'T') ADVANCE(432);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(451);
+      END_STATE();
+    case 443:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == 'a') ADVANCE(249);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(451);
+      END_STATE();
+    case 444:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == 'e') ADVANCE(252);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(451);
+      END_STATE();
+    case 445:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == 'n') ADVANCE(258);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(451);
+      END_STATE();
+    case 446:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == 'r') ADVANCE(246);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(451);
+      END_STATE();
+    case 447:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(424);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(451);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(424);
+      END_STATE();
+    case 448:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(419);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(451);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(419);
+      END_STATE();
+    case 449:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(410);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(451);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(410);
+      END_STATE();
+    case 450:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(451);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(450);
+      END_STATE();
+    case 451:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(452);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(451);
+      END_STATE();
+    case 452:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(452);
+      END_STATE();
+    case 453:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(471);
+      if (lookahead == '-') ADVANCE(470);
+      if (lookahead == ')' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(457);
+      END_STATE();
+    case 454:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(471);
+      if (lookahead == 'F') ADVANCE(456);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(457);
+      END_STATE();
+    case 455:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(471);
+      if (lookahead == 'I') ADVANCE(454);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(457);
+      END_STATE();
+    case 456:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(471);
+      if (lookahead == 'T') ADVANCE(453);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(457);
+      END_STATE();
+    case 457:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(471);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(457);
+      END_STATE();
+    case 458:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == '-') ADVANCE(467);
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(457);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(466);
+      END_STATE();
+    case 459:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == '-') ADVANCE(468);
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(457);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(466);
+      END_STATE();
+    case 460:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == '-') ADVANCE(469);
+      if (lookahead == ')' ||
+          lookahead == '.') ADVANCE(457);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(466);
+      END_STATE();
+    case 461:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'A') ADVANCE(460);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(457);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(466);
+      END_STATE();
+    case 462:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'L') ADVANCE(459);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(457);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(466);
+      END_STATE();
+    case 463:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'R') ADVANCE(462);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(457);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(466);
+      END_STATE();
+    case 464:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'T') ADVANCE(458);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(457);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(466);
+      END_STATE();
+    case 465:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'T') ADVANCE(461);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(457);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(466);
+      END_STATE();
+    case 466:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.') ADVANCE(457);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(466);
+      END_STATE();
+    case 467:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(428);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(424);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(427);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(424);
+      END_STATE();
+    case 468:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(409);
+      if (lookahead == 'B') ADVANCE(389);
+      if (lookahead == 'D') ADVANCE(387);
+      if (lookahead == 'I') ADVANCE(388);
+      if (lookahead == 'P') ADVANCE(386);
+      if (lookahead == 'S') ADVANCE(385);
+      if (lookahead == '{') ADVANCE(399);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(376);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(390);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(376);
+      END_STATE();
+    case 469:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(423);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(419);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(422);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(419);
+      END_STATE();
+    case 470:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(414);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(410);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(413);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(410);
+      END_STATE();
+    case 471:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(471);
+      END_STATE();
+    case 472:
+      ACCEPT_TOKEN(anon_sym_LT);
+      END_STATE();
+    case 473:
+      ACCEPT_TOKEN(anon_sym_LT);
+      if (lookahead == 'A' ||
+          lookahead == 'C' ||
+          lookahead == 'D' ||
+          lookahead == 'M' ||
+          lookahead == 'S') ADVANCE(91);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(95);
+      END_STATE();
+    case 474:
+      ACCEPT_TOKEN(anon_sym_LT);
+      if (lookahead == 'A' ||
+          lookahead == 'C' ||
+          lookahead == 'D' ||
+          lookahead == 'M' ||
+          lookahead == 'S') ADVANCE(223);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(236);
+      END_STATE();
+    case 475:
+      ACCEPT_TOKEN(aux_sym_codeblock_token1);
+      END_STATE();
+    case 476:
+      ACCEPT_TOKEN(anon_sym_LF);
+      END_STATE();
+    case 477:
+      ACCEPT_TOKEN(anon_sym_LF2);
+      END_STATE();
+    case 478:
+      ACCEPT_TOKEN(aux_sym_line_li_token1);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == ' ') ADVANCE(478);
+      if (lookahead != 0) ADVANCE(23);
+      END_STATE();
+    case 479:
+      ACCEPT_TOKEN(aux_sym_line_li_token1);
+      if (lookahead == ' ') ADVANCE(479);
+      END_STATE();
+    case 480:
+      ACCEPT_TOKEN(aux_sym_line_code_token1);
+      END_STATE();
+    case 481:
+      ACCEPT_TOKEN(aux_sym_h1_token1);
+      END_STATE();
+    case 482:
+      ACCEPT_TOKEN(aux_sym_h2_token1);
+      END_STATE();
+    case 483:
+      ACCEPT_TOKEN(anon_sym_STAR);
+      END_STATE();
+    case 484:
+      ACCEPT_TOKEN(anon_sym_STAR);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == ' ') ADVANCE(478);
+      if (lookahead == '\t' ||
+          lookahead == '(') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(269);
+      END_STATE();
+    case 485:
+      ACCEPT_TOKEN(anon_sym_STAR);
+      if (lookahead == ' ') ADVANCE(479);
+      END_STATE();
+    case 486:
+      ACCEPT_TOKEN(anon_sym_STAR);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 487:
+      ACCEPT_TOKEN(anon_sym_STAR);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 488:
+      ACCEPT_TOKEN(anon_sym_STAR);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(305);
+      END_STATE();
+    case 489:
       ACCEPT_TOKEN(aux_sym_tag_token1);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(403);
+          lookahead != '*') ADVANCE(489);
       END_STATE();
-    case 404:
+    case 490:
       ACCEPT_TOKEN(anon_sym_STAR2);
       END_STATE();
-    case 405:
+    case 491:
       ACCEPT_TOKEN(sym_url_word);
-      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\n') ADVANCE(480);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(23);
+      if (lookahead == '(' ||
+          lookahead == '[') ADVANCE(492);
       if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(144);
-      if (lookahead != 0) ADVANCE(405);
+          lookahead == ']') ADVANCE(197);
+      if (lookahead != 0) ADVANCE(491);
       END_STATE();
-    case 406:
+    case 492:
+      ACCEPT_TOKEN(sym_url_word);
+      if (lookahead == '\n') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == ')' ||
+          lookahead == ']') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(492);
+      END_STATE();
+    case 493:
+      ACCEPT_TOKEN(sym_url_word);
+      if (lookahead == '(') ADVANCE(496);
+      if (lookahead == '[') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != ')' &&
+          lookahead != ']') ADVANCE(493);
+      END_STATE();
+    case 494:
+      ACCEPT_TOKEN(sym_url_word);
+      if (lookahead == '(') ADVANCE(496);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != ')' &&
+          lookahead != ']') ADVANCE(494);
+      END_STATE();
+    case 495:
+      ACCEPT_TOKEN(sym_url_word);
+      if (lookahead == '(' ||
+          lookahead == '[') ADVANCE(496);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != ')' &&
+          lookahead != ']') ADVANCE(495);
+      END_STATE();
+    case 496:
       ACCEPT_TOKEN(sym_url_word);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != ')' &&
-          lookahead != ']') ADVANCE(406);
+          lookahead != ']') ADVANCE(496);
       END_STATE();
-    case 407:
+    case 497:
       ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == ':') ADVANCE(92);
-      if (lookahead == 's') ADVANCE(408);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(411);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == ':') ADVANCE(82);
+      if (lookahead == 's') ADVANCE(498);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(501);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(69);
       END_STATE();
-    case 408:
+    case 498:
       ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == ':') ADVANCE(92);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(411);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == ':') ADVANCE(82);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(501);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(69);
       END_STATE();
-    case 409:
+    case 499:
       ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 'p') ADVANCE(407);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(411);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 'p') ADVANCE(497);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(501);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(69);
       END_STATE();
-    case 410:
+    case 500:
       ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (lookahead == 't') ADVANCE(409);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(411);
+      if (lookahead == '(') ADVANCE(351);
+      if (lookahead == 't') ADVANCE(499);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(501);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(69);
       END_STATE();
-    case 411:
+    case 501:
       ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(282);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(411);
+      if (lookahead == '(') ADVANCE(351);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(501);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(56);
+          lookahead == '_') ADVANCE(69);
       END_STATE();
-    case 412:
+    case 502:
       ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(251);
-      if (lookahead == ':') ADVANCE(252);
-      if (lookahead == 's') ADVANCE(413);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(416);
+      if (lookahead == '(') ADVANCE(305);
+      if (lookahead == ':') ADVANCE(303);
+      if (lookahead == 's') ADVANCE(503);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(506);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(249);
+          lookahead == '_') ADVANCE(302);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(251);
+          lookahead != '\'') ADVANCE(305);
       END_STATE();
-    case 413:
+    case 503:
       ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(251);
-      if (lookahead == ':') ADVANCE(252);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(416);
+      if (lookahead == '(') ADVANCE(305);
+      if (lookahead == ':') ADVANCE(303);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(506);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(249);
+          lookahead == '_') ADVANCE(302);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(251);
+          lookahead != '\'') ADVANCE(305);
       END_STATE();
-    case 414:
+    case 504:
       ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(251);
-      if (lookahead == 'p') ADVANCE(412);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(416);
+      if (lookahead == '(') ADVANCE(305);
+      if (lookahead == 'p') ADVANCE(502);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(506);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(249);
+          lookahead == '_') ADVANCE(302);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(251);
+          lookahead != '\'') ADVANCE(305);
       END_STATE();
-    case 415:
+    case 505:
       ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(251);
-      if (lookahead == 't') ADVANCE(414);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(416);
+      if (lookahead == '(') ADVANCE(305);
+      if (lookahead == 't') ADVANCE(504);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(506);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(249);
+          lookahead == '_') ADVANCE(302);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(251);
+          lookahead != '\'') ADVANCE(305);
       END_STATE();
-    case 416:
+    case 506:
       ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(251);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(416);
+      if (lookahead == '(') ADVANCE(305);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(506);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(249);
+          lookahead == '_') ADVANCE(302);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(251);
+          lookahead != '\'') ADVANCE(305);
       END_STATE();
-    case 417:
+    case 507:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '\t') ADVANCE(261);
+      if (lookahead == '\t') ADVANCE(314);
+      if (lookahead == '(') ADVANCE(569);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(562);
       END_STATE();
-    case 418:
+    case 508:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == '-') ADVANCE(469);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 419:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == '-') ADVANCE(440);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == '-') ADVANCE(563);
+      if (lookahead == '>') ADVANCE(562);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(562);
       END_STATE();
-    case 420:
+    case 509:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == '-') ADVANCE(470);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == '-') ADVANCE(556);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(561);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(562);
       END_STATE();
-    case 421:
+    case 510:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == ':') ADVANCE(471);
-      if (lookahead == 's') ADVANCE(422);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == '-') ADVANCE(518);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(561);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(562);
       END_STATE();
-    case 422:
+    case 511:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == ':') ADVANCE(471);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == '-') ADVANCE(557);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(561);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(562);
       END_STATE();
-    case 423:
+    case 512:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == 'A') ADVANCE(420);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == '-') ADVANCE(558);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(562);
       END_STATE();
-    case 424:
+    case 513:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == 'E') ADVANCE(430);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == ':') ADVANCE(564);
+      if (lookahead == 's') ADVANCE(514);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(561);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(562);
       END_STATE();
-    case 425:
+    case 514:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == 'L') ADVANCE(429);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == ':') ADVANCE(564);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(561);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(562);
       END_STATE();
-    case 426:
+    case 515:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == 'L') ADVANCE(419);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 427:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == 'R') ADVANCE(426);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 428:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == 'T') ADVANCE(427);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 429:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == 'T') ADVANCE(418);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 430:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == 'T') ADVANCE(423);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 431:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == 'p') ADVANCE(421);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 432:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == 't') ADVANCE(431);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 433:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (lookahead == 't') ADVANCE(432);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 434:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(476);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(434);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 435:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '-') ADVANCE(439);
-      if (lookahead == '>') ADVANCE(476);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(437);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 436:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '-') ADVANCE(472);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 437:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '>') ADVANCE(476);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == '>') ADVANCE(562);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(437);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(562);
       END_STATE();
-    case 438:
+    case 516:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '>') ADVANCE(476);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == '>') ADVANCE(562);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(562);
       END_STATE();
-    case 439:
+    case 517:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '>') ADVANCE(438);
-      if (lookahead == '|') ADVANCE(65);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'A') ADVANCE(511);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(561);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 518:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'B') ADVANCE(550);
+      if (lookahead == 'D') ADVANCE(535);
+      if (lookahead == 'I') ADVANCE(544);
+      if (lookahead == 'P') ADVANCE(531);
+      if (lookahead == 'S') ADVANCE(522);
+      if (lookahead == '{') ADVANCE(534);
+      if (lookahead == '|') ADVANCE(376);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(376);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(562);
+      END_STATE();
+    case 519:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'D') ADVANCE(545);
+      if (lookahead == 'U') ADVANCE(546);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 520:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'E') ADVANCE(529);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(561);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 521:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'F') ADVANCE(530);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 522:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'H') ADVANCE(523);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 523:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'I') ADVANCE(521);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 524:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'L') ADVANCE(528);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(561);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 525:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'L') ADVANCE(510);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(561);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 526:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'R') ADVANCE(525);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(561);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 527:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'T') ADVANCE(526);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(561);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 528:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'T') ADVANCE(509);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(561);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 529:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'T') ADVANCE(517);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(561);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 530:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'T') ADVANCE(512);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 531:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'a') ADVANCE(539);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 532:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'a') ADVANCE(541);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 533:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'a') ADVANCE(549);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 534:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'c') ADVANCE(540);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 535:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'e') ADVANCE(542);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 536:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'e') ADVANCE(519);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 537:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'e') ADVANCE(548);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 538:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'e') ADVANCE(532);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 539:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'g') ADVANCE(536);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 540:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'h') ADVANCE(533);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 541:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'k') ADVANCE(562);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 542:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'l') ADVANCE(562);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 543:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'n') ADVANCE(562);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 544:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'n') ADVANCE(551);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 545:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'o') ADVANCE(555);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 546:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'p') ADVANCE(562);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 547:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'p') ADVANCE(513);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(561);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 548:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'r') ADVANCE(552);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 549:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'r') ADVANCE(559);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 550:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'r') ADVANCE(538);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 551:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 's') ADVANCE(537);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 552:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 't') ADVANCE(562);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 553:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 't') ADVANCE(547);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(561);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 554:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 't') ADVANCE(553);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(561);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 555:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'w') ADVANCE(543);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 556:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == '|') ADVANCE(424);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(424);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(562);
+      END_STATE();
+    case 557:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == '|') ADVANCE(419);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(419);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(562);
+      END_STATE();
+    case 558:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == '|') ADVANCE(410);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(410);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(562);
+      END_STATE();
+    case 559:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == '}') ADVANCE(562);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 560:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead == 'A' ||
+          lookahead == 'C' ||
+          lookahead == 'D' ||
+          lookahead == 'M' ||
+          lookahead == 'S') ADVANCE(508);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 561:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(561);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 562:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(569);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(562);
+      END_STATE();
+    case 563:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(') ADVANCE(565);
+      if (lookahead == '>') ADVANCE(516);
+      if (lookahead == '|') ADVANCE(98);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(27);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(437);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(438);
+          lookahead != '\n') ADVANCE(516);
       END_STATE();
-    case 440:
+    case 564:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'B') ADVANCE(464);
-      if (lookahead == 'D') ADVANCE(450);
-      if (lookahead == 'I') ADVANCE(459);
-      if (lookahead == 'P') ADVANCE(446);
-      if (lookahead == 'S') ADVANCE(443);
-      if (lookahead == '{') ADVANCE(449);
-      if (lookahead == '|') ADVANCE(302);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(302);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(476);
-      END_STATE();
-    case 441:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'D') ADVANCE(460);
-      if (lookahead == 'U') ADVANCE(461);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 442:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'F') ADVANCE(445);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 443:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'H') ADVANCE(444);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 444:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'I') ADVANCE(442);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 445:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'T') ADVANCE(436);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 446:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'a') ADVANCE(454);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 447:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'a') ADVANCE(456);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 448:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'a') ADVANCE(463);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 449:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'c') ADVANCE(455);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 450:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'e') ADVANCE(457);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 451:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'e') ADVANCE(441);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 452:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'e') ADVANCE(462);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 453:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'e') ADVANCE(447);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 454:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'g') ADVANCE(451);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 455:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'h') ADVANCE(448);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 456:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'k') ADVANCE(476);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 457:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'l') ADVANCE(476);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 458:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'n') ADVANCE(476);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 459:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'n') ADVANCE(465);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 460:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'o') ADVANCE(467);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 461:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'p') ADVANCE(476);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 462:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'r') ADVANCE(466);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 463:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'r') ADVANCE(473);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 464:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'r') ADVANCE(453);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 465:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 's') ADVANCE(452);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 466:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 't') ADVANCE(476);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 467:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'w') ADVANCE(458);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 468:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '{') ADVANCE(468);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(475);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
-      END_STATE();
-    case 469:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '|') ADVANCE(341);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(341);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(476);
-      END_STATE();
-    case 470:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '|') ADVANCE(337);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(337);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(476);
-      END_STATE();
-    case 471:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '|') ADVANCE(406);
+      if (lookahead == '(') ADVANCE(567);
+      if (lookahead == '|') ADVANCE(494);
       if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(476);
+          lookahead == ']') ADVANCE(562);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(471);
+          lookahead != ' ') ADVANCE(564);
       END_STATE();
-    case 472:
+    case 565:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '|') ADVANCE(329);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(329);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(476);
-      END_STATE();
-    case 473:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '}') ADVANCE(476);
+      if (lookahead == '>') ADVANCE(569);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(569);
       END_STATE();
-    case 474:
+    case 566:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'A' ||
-          lookahead == 'C' ||
-          lookahead == 'D' ||
-          lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(435);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(437);
+      if (lookahead == '{') ADVANCE(566);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(568);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(569);
       END_STATE();
-    case 475:
+    case 567:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(475);
+      if (lookahead == '|') ADVANCE(496);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(569);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(567);
+      END_STATE();
+    case 568:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(568);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(569);
       END_STATE();
-    case 476:
+    case 569:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(569);
       END_STATE();
-    case 477:
+    case 570:
       ACCEPT_TOKEN(anon_sym_LBRACE2);
-      if (lookahead == '{') ADVANCE(274);
-      if (lookahead == '}') ADVANCE(269);
+      if (lookahead == '{') ADVANCE(327);
+      if (lookahead == '}') ADVANCE(322);
       END_STATE();
-    case 478:
+    case 571:
       ACCEPT_TOKEN(anon_sym_LBRACE2);
-      if (lookahead == '{') ADVANCE(468);
-      if (lookahead == '}') ADVANCE(271);
+      if (lookahead == '{') ADVANCE(566);
+      if (lookahead == '}') ADVANCE(324);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(569);
       END_STATE();
-    case 479:
+    case 572:
       ACCEPT_TOKEN(anon_sym_RBRACE2);
       END_STATE();
-    case 480:
+    case 573:
       ACCEPT_TOKEN(anon_sym_RBRACE2);
+      if (lookahead == '(') ADVANCE(569);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(562);
       END_STATE();
-    case 481:
+    case 574:
       ACCEPT_TOKEN(anon_sym_LPAREN2);
       END_STATE();
-    case 482:
+    case 575:
       ACCEPT_TOKEN(anon_sym_LPAREN2);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(569);
       END_STATE();
-    case 483:
-      ACCEPT_TOKEN(anon_sym_RPAREN);
+    case 576:
+      ACCEPT_TOKEN(anon_sym_RPAREN2);
       END_STATE();
-    case 484:
-      ACCEPT_TOKEN(anon_sym_RPAREN);
+    case 577:
+      ACCEPT_TOKEN(anon_sym_RPAREN2);
+      if (lookahead == '(') ADVANCE(569);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(562);
       END_STATE();
-    case 485:
+    case 578:
       ACCEPT_TOKEN(anon_sym_BQUOTE);
       END_STATE();
-    case 486:
+    case 579:
       ACCEPT_TOKEN(anon_sym_BQUOTE);
+      if (lookahead == '(') ADVANCE(569);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(476);
+          lookahead != '|') ADVANCE(562);
       END_STATE();
-    case 487:
+    case 580:
       ACCEPT_TOKEN(anon_sym_PIPE2);
       END_STATE();
-    case 488:
+    case 581:
       ACCEPT_TOKEN(anon_sym_BQUOTE2);
       END_STATE();
-    case 489:
+    case 582:
       ACCEPT_TOKEN(anon_sym_BQUOTE2);
-      if (lookahead == '\n') ADVANCE(394);
+      if (lookahead == '\n') ADVANCE(480);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if (lookahead != 0) ADVANCE(144);
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(197);
       END_STATE();
-    case 490:
+    case 583:
       ACCEPT_TOKEN(anon_sym_BQUOTE2);
-      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 491:
+    case 584:
       ACCEPT_TOKEN(anon_sym_BQUOTE2);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(251);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(305);
       END_STATE();
-    case 492:
+    case 585:
       ACCEPT_TOKEN(aux_sym_codespan_token1);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '`') ADVANCE(492);
+          lookahead != '`') ADVANCE(585);
       END_STATE();
-    case 493:
+    case 586:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '\t') ADVANCE(261);
-      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '\t') ADVANCE(314);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 494:
+    case 587:
       ACCEPT_TOKEN(aux_sym_argument_token1);
       if (lookahead == '\t') ADVANCE(27);
-      if (lookahead == ' ') ADVANCE(547);
-      if (lookahead == '>') ADVANCE(519);
+      if (lookahead == ' ') ADVANCE(643);
+      if (lookahead == '(') ADVANCE(640);
+      if (lookahead == '>') ADVANCE(600);
       if (lookahead == '{' ||
-          lookahead == '}') ADVANCE(65);
+          lookahead == '}') ADVANCE(98);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(518);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(599);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(519);
+          lookahead != '\n') ADVANCE(600);
       END_STATE();
-    case 495:
+    case 588:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '\t') ADVANCE(341);
-      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '\t') ADVANCE(424);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
       if (lookahead == '{' ||
-          lookahead == '}') ADVANCE(341);
+          lookahead == '}') ADVANCE(424);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(546);
+          lookahead != '\n') ADVANCE(638);
       END_STATE();
-    case 496:
+    case 589:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '\t') ADVANCE(302);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'B') ADVANCE(539);
-      if (lookahead == 'D') ADVANCE(527);
-      if (lookahead == 'I') ADVANCE(535);
-      if (lookahead == 'P') ADVANCE(525);
-      if (lookahead == 'S') ADVANCE(522);
-      if (lookahead == '{') ADVANCE(317);
-      if (lookahead == '}') ADVANCE(302);
+      if (lookahead == '\t') ADVANCE(376);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'B') ADVANCE(629);
+      if (lookahead == 'D') ADVANCE(616);
+      if (lookahead == 'I') ADVANCE(624);
+      if (lookahead == 'P') ADVANCE(614);
+      if (lookahead == 'S') ADVANCE(605);
+      if (lookahead == '{') ADVANCE(399);
+      if (lookahead == '}') ADVANCE(376);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(546);
+          lookahead != '\n') ADVANCE(638);
       END_STATE();
-    case 497:
+    case 590:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '\t') ADVANCE(337);
-      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '\t') ADVANCE(419);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
       if (lookahead == '{' ||
-          lookahead == '}') ADVANCE(337);
+          lookahead == '}') ADVANCE(419);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(546);
+          lookahead != '\n') ADVANCE(638);
       END_STATE();
-    case 498:
+    case 591:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '\t') ADVANCE(329);
-      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == '\t') ADVANCE(410);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
       if (lookahead == '{' ||
-          lookahead == '}') ADVANCE(329);
+          lookahead == '}') ADVANCE(410);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(546);
+          lookahead != '\n') ADVANCE(638);
       END_STATE();
-    case 499:
+    case 592:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == '-') ADVANCE(495);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == '-') ADVANCE(587);
+      if (lookahead == '>') ADVANCE(638);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(599);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 500:
+    case 593:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == '-') ADVANCE(496);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == '-') ADVANCE(588);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(637);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 501:
+    case 594:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == '-') ADVANCE(497);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == '-') ADVANCE(589);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(637);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 502:
+    case 595:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == ':') ADVANCE(544);
-      if (lookahead == 's') ADVANCE(503);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == '-') ADVANCE(590);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(637);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 503:
+    case 596:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == ':') ADVANCE(544);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == '-') ADVANCE(591);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 504:
+    case 597:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == 'A') ADVANCE(501);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == ':') ADVANCE(639);
+      if (lookahead == 's') ADVANCE(598);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(637);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 598:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == ':') ADVANCE(639);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(637);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 599:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == '>') ADVANCE(638);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(599);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 600:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == '>') ADVANCE(638);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 601:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'A') ADVANCE(595);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(637);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 505:
+    case 602:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == 'E') ADVANCE(511);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'D') ADVANCE(625);
+      if (lookahead == 'U') ADVANCE(626);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 603:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'E') ADVANCE(612);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(637);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 506:
+    case 604:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == 'L') ADVANCE(510);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'F') ADVANCE(613);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 605:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'H') ADVANCE(606);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 606:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'I') ADVANCE(604);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 607:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'L') ADVANCE(611);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(637);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 507:
+    case 608:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == 'L') ADVANCE(500);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'L') ADVANCE(594);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(637);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 508:
+    case 609:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == 'R') ADVANCE(507);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'R') ADVANCE(608);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(637);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 509:
+    case 610:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == 'T') ADVANCE(508);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'T') ADVANCE(609);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(637);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 510:
+    case 611:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == 'T') ADVANCE(499);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'T') ADVANCE(593);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(637);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 511:
+    case 612:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == 'T') ADVANCE(504);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'T') ADVANCE(601);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(637);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 512:
+    case 613:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == 'p') ADVANCE(502);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'T') ADVANCE(596);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 614:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'a') ADVANCE(620);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 615:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'a') ADVANCE(621);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 616:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'e') ADVANCE(622);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 617:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'e') ADVANCE(602);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 618:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'e') ADVANCE(628);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 619:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'e') ADVANCE(615);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 620:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'g') ADVANCE(617);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 621:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'k') ADVANCE(638);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 622:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'l') ADVANCE(638);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 623:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'n') ADVANCE(638);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 624:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'n') ADVANCE(630);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 625:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'o') ADVANCE(634);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 626:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'p') ADVANCE(638);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 627:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'p') ADVANCE(597);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(637);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 513:
+    case 628:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == 't') ADVANCE(512);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'r') ADVANCE(631);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 629:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'r') ADVANCE(619);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 630:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 's') ADVANCE(618);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 631:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 't') ADVANCE(638);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(638);
+      END_STATE();
+    case 632:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 't') ADVANCE(627);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(637);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 514:
+    case 633:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (lookahead == 't') ADVANCE(513);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 't') ADVANCE(632);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(637);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 515:
+    case 634:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '(') ADVANCE(546);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(515);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == 'w') ADVANCE(623);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 516:
+    case 635:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '-') ADVANCE(494);
-      if (lookahead == '>') ADVANCE(546);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(518);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (lookahead == '|') ADVANCE(635);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          (lookahead < '{' || '}' < lookahead)) ADVANCE(638);
       END_STATE();
-    case 517:
+    case 636:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '-') ADVANCE(498);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 518:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '>') ADVANCE(546);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(518);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 519:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '>') ADVANCE(546);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 520:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'D') ADVANCE(536);
-      if (lookahead == 'U') ADVANCE(537);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 521:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'F') ADVANCE(524);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 522:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'H') ADVANCE(523);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 523:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'I') ADVANCE(521);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 524:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'T') ADVANCE(517);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 525:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'a') ADVANCE(531);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 526:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'a') ADVANCE(532);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 527:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'e') ADVANCE(533);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 528:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'e') ADVANCE(520);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 529:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'e') ADVANCE(538);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 530:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'e') ADVANCE(526);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 531:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'g') ADVANCE(528);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 532:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'k') ADVANCE(546);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 533:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'l') ADVANCE(546);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 534:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'n') ADVANCE(546);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 535:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'n') ADVANCE(540);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 536:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'o') ADVANCE(542);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 537:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'p') ADVANCE(546);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 538:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'r') ADVANCE(541);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 539:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'r') ADVANCE(530);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 540:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 's') ADVANCE(529);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 541:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 't') ADVANCE(546);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 542:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == 'w') ADVANCE(534);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
-      END_STATE();
-    case 543:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == '|') ADVANCE(543);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          (lookahead < '{' || '}' < lookahead)) ADVANCE(546);
-      END_STATE();
-    case 544:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(546);
-      if (lookahead == '{' ||
-          lookahead == '}') ADVANCE(406);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(544);
-      END_STATE();
-    case 545:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(516);
+          lookahead == 'S') ADVANCE(592);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(518);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(599);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 546:
+    case 637:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ' ') ADVANCE(548);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(637);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(546);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 547:
+    case 638:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '>') ADVANCE(548);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(642);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(548);
+          lookahead != '}') ADVANCE(638);
       END_STATE();
-    case 548:
+    case 639:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '(') ADVANCE(641);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(638);
+      if (lookahead == '{' ||
+          lookahead == '}') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n') ADVANCE(639);
+      END_STATE();
+    case 640:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == '>') ADVANCE(642);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(642);
+      END_STATE();
+    case 641:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(642);
+      if (lookahead == '{' ||
+          lookahead == '}') ADVANCE(496);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n') ADVANCE(641);
+      END_STATE();
+    case 642:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ' ') ADVANCE(644);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(642);
+      END_STATE();
+    case 643:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '>') ADVANCE(644);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(644);
+      END_STATE();
+    case 644:
       ACCEPT_TOKEN(aux_sym_argument_token1);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(548);
+          lookahead != '}') ADVANCE(644);
       END_STATE();
     default:
       return false;
@@ -6342,34 +7783,34 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [5] = {.lex_state = 31},
   [6] = {.lex_state = 31},
   [7] = {.lex_state = 31},
-  [8] = {.lex_state = 11},
-  [9] = {.lex_state = 11},
-  [10] = {.lex_state = 11},
-  [11] = {.lex_state = 11},
-  [12] = {.lex_state = 11},
-  [13] = {.lex_state = 11},
-  [14] = {.lex_state = 11},
-  [15] = {.lex_state = 11},
-  [16] = {.lex_state = 11},
-  [17] = {.lex_state = 8},
-  [18] = {.lex_state = 8},
-  [19] = {.lex_state = 8},
-  [20] = {.lex_state = 8},
-  [21] = {.lex_state = 8},
-  [22] = {.lex_state = 8},
-  [23] = {.lex_state = 8},
-  [24] = {.lex_state = 8},
-  [25] = {.lex_state = 8},
-  [26] = {.lex_state = 8},
-  [27] = {.lex_state = 8},
-  [28] = {.lex_state = 8},
-  [29] = {.lex_state = 8},
-  [30] = {.lex_state = 8},
-  [31] = {.lex_state = 8},
+  [8] = {.lex_state = 10},
+  [9] = {.lex_state = 10},
+  [10] = {.lex_state = 10},
+  [11] = {.lex_state = 10},
+  [12] = {.lex_state = 10},
+  [13] = {.lex_state = 10},
+  [14] = {.lex_state = 10},
+  [15] = {.lex_state = 10},
+  [16] = {.lex_state = 10},
+  [17] = {.lex_state = 7},
+  [18] = {.lex_state = 7},
+  [19] = {.lex_state = 7},
+  [20] = {.lex_state = 7},
+  [21] = {.lex_state = 7},
+  [22] = {.lex_state = 7},
+  [23] = {.lex_state = 7},
+  [24] = {.lex_state = 7},
+  [25] = {.lex_state = 7},
+  [26] = {.lex_state = 7},
+  [27] = {.lex_state = 7},
+  [28] = {.lex_state = 7},
+  [29] = {.lex_state = 7},
+  [30] = {.lex_state = 7},
+  [31] = {.lex_state = 7},
   [32] = {.lex_state = 31},
   [33] = {.lex_state = 31},
-  [34] = {.lex_state = 10},
-  [35] = {.lex_state = 10},
+  [34] = {.lex_state = 9},
+  [35] = {.lex_state = 9},
   [36] = {.lex_state = 31},
   [37] = {.lex_state = 31},
   [38] = {.lex_state = 31},
@@ -6379,13 +7820,13 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [42] = {.lex_state = 31},
   [43] = {.lex_state = 31},
   [44] = {.lex_state = 31},
-  [45] = {.lex_state = 12},
+  [45] = {.lex_state = 11},
   [46] = {.lex_state = 31},
   [47] = {.lex_state = 31},
-  [48] = {.lex_state = 10},
-  [49] = {.lex_state = 10},
-  [50] = {.lex_state = 12},
-  [51] = {.lex_state = 16},
+  [48] = {.lex_state = 9},
+  [49] = {.lex_state = 9},
+  [50] = {.lex_state = 11},
+  [51] = {.lex_state = 15},
   [52] = {.lex_state = 31},
   [53] = {.lex_state = 31},
   [54] = {.lex_state = 31},
@@ -6396,50 +7837,50 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [59] = {.lex_state = 31},
   [60] = {.lex_state = 31},
   [61] = {.lex_state = 31},
-  [62] = {.lex_state = 12},
-  [63] = {.lex_state = 12},
-  [64] = {.lex_state = 11},
-  [65] = {.lex_state = 13},
-  [66] = {.lex_state = 11},
-  [67] = {.lex_state = 11},
-  [68] = {.lex_state = 6},
-  [69] = {.lex_state = 14},
-  [70] = {.lex_state = 14},
-  [71] = {.lex_state = 14},
-  [72] = {.lex_state = 14},
-  [73] = {.lex_state = 14},
-  [74] = {.lex_state = 6},
-  [75] = {.lex_state = 5},
-  [76] = {.lex_state = 7},
-  [77] = {.lex_state = 17},
-  [78] = {.lex_state = 5},
-  [79] = {.lex_state = 14},
-  [80] = {.lex_state = 8},
-  [81] = {.lex_state = 8},
-  [82] = {.lex_state = 8},
-  [83] = {.lex_state = 8},
-  [84] = {.lex_state = 8},
-  [85] = {.lex_state = 8},
-  [86] = {.lex_state = 8},
-  [87] = {.lex_state = 8},
-  [88] = {.lex_state = 8},
-  [89] = {.lex_state = 8},
-  [90] = {.lex_state = 8},
-  [91] = {.lex_state = 18},
-  [92] = {.lex_state = 18},
-  [93] = {.lex_state = 18},
-  [94] = {.lex_state = 10},
-  [95] = {.lex_state = 10},
+  [62] = {.lex_state = 11},
+  [63] = {.lex_state = 11},
+  [64] = {.lex_state = 10},
+  [65] = {.lex_state = 12},
+  [66] = {.lex_state = 10},
+  [67] = {.lex_state = 10},
+  [68] = {.lex_state = 5},
+  [69] = {.lex_state = 13},
+  [70] = {.lex_state = 13},
+  [71] = {.lex_state = 13},
+  [72] = {.lex_state = 13},
+  [73] = {.lex_state = 13},
+  [74] = {.lex_state = 5},
+  [75] = {.lex_state = 4},
+  [76] = {.lex_state = 6},
+  [77] = {.lex_state = 16},
+  [78] = {.lex_state = 4},
+  [79] = {.lex_state = 13},
+  [80] = {.lex_state = 7},
+  [81] = {.lex_state = 7},
+  [82] = {.lex_state = 7},
+  [83] = {.lex_state = 7},
+  [84] = {.lex_state = 7},
+  [85] = {.lex_state = 7},
+  [86] = {.lex_state = 7},
+  [87] = {.lex_state = 7},
+  [88] = {.lex_state = 7},
+  [89] = {.lex_state = 7},
+  [90] = {.lex_state = 7},
+  [91] = {.lex_state = 17},
+  [92] = {.lex_state = 17},
+  [93] = {.lex_state = 17},
+  [94] = {.lex_state = 9},
+  [95] = {.lex_state = 9},
   [96] = {.lex_state = 31},
   [97] = {.lex_state = 0},
-  [98] = {.lex_state = 7},
+  [98] = {.lex_state = 6},
   [99] = {.lex_state = 31},
-  [100] = {.lex_state = 18},
+  [100] = {.lex_state = 17},
   [101] = {.lex_state = 26},
   [102] = {.lex_state = 28},
   [103] = {.lex_state = 26},
-  [104] = {.lex_state = 18},
-  [105] = {.lex_state = 18},
+  [104] = {.lex_state = 17},
+  [105] = {.lex_state = 17},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -6459,9 +7900,13 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_LBRACE_RBRACE] = ACTIONS(1),
     [aux_sym__word_common_token5] = ACTIONS(1),
     [anon_sym_LPAREN] = ACTIONS(1),
+    [anon_sym_RPAREN] = ACTIONS(1),
+    [anon_sym_LBRACK] = ACTIONS(1),
+    [anon_sym_RBRACK] = ACTIONS(1),
     [aux_sym__word_common_token6] = ACTIONS(1),
     [anon_sym_TILDE] = ACTIONS(1),
     [anon_sym_GT] = ACTIONS(1),
+    [anon_sym_COMMA] = ACTIONS(1),
     [aux_sym_keycode_token1] = ACTIONS(1),
     [aux_sym_keycode_token2] = ACTIONS(1),
     [aux_sym_keycode_token3] = ACTIONS(1),
@@ -6480,7 +7925,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_LBRACE2] = ACTIONS(1),
     [anon_sym_RBRACE2] = ACTIONS(1),
     [anon_sym_LPAREN2] = ACTIONS(1),
-    [anon_sym_RPAREN] = ACTIONS(1),
+    [anon_sym_RPAREN2] = ACTIONS(1),
     [anon_sym_BQUOTE] = ACTIONS(1),
     [anon_sym_PIPE2] = ACTIONS(1),
     [anon_sym_BQUOTE2] = ACTIONS(1),
@@ -6526,9 +7971,13 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_LBRACE_RBRACE] = ACTIONS(9),
     [aux_sym__word_common_token5] = ACTIONS(9),
     [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_RPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(9),
+    [anon_sym_RBRACK] = ACTIONS(9),
     [aux_sym__word_common_token6] = ACTIONS(5),
     [anon_sym_TILDE] = ACTIONS(9),
     [anon_sym_GT] = ACTIONS(15),
+    [anon_sym_COMMA] = ACTIONS(9),
     [aux_sym_keycode_token1] = ACTIONS(17),
     [aux_sym_keycode_token2] = ACTIONS(17),
     [aux_sym_keycode_token3] = ACTIONS(17),
@@ -6587,9 +8036,13 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_LBRACE_RBRACE] = ACTIONS(9),
     [aux_sym__word_common_token5] = ACTIONS(9),
     [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_RPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(9),
+    [anon_sym_RBRACK] = ACTIONS(9),
     [aux_sym__word_common_token6] = ACTIONS(5),
     [anon_sym_TILDE] = ACTIONS(9),
     [anon_sym_GT] = ACTIONS(15),
+    [anon_sym_COMMA] = ACTIONS(9),
     [aux_sym_keycode_token1] = ACTIONS(17),
     [aux_sym_keycode_token2] = ACTIONS(17),
     [aux_sym_keycode_token3] = ACTIONS(17),
@@ -6646,9 +8099,13 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_LBRACE_RBRACE] = ACTIONS(49),
     [aux_sym__word_common_token5] = ACTIONS(49),
     [anon_sym_LPAREN] = ACTIONS(43),
+    [anon_sym_RPAREN] = ACTIONS(43),
+    [anon_sym_LBRACK] = ACTIONS(49),
+    [anon_sym_RBRACK] = ACTIONS(49),
     [aux_sym__word_common_token6] = ACTIONS(43),
     [anon_sym_TILDE] = ACTIONS(49),
     [anon_sym_GT] = ACTIONS(58),
+    [anon_sym_COMMA] = ACTIONS(49),
     [aux_sym_keycode_token1] = ACTIONS(61),
     [aux_sym_keycode_token2] = ACTIONS(61),
     [aux_sym_keycode_token3] = ACTIONS(61),
@@ -6704,9 +8161,13 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_LBRACE_RBRACE] = ACTIONS(9),
     [aux_sym__word_common_token5] = ACTIONS(9),
     [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_RPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(9),
+    [anon_sym_RBRACK] = ACTIONS(9),
     [aux_sym__word_common_token6] = ACTIONS(5),
     [anon_sym_TILDE] = ACTIONS(9),
     [anon_sym_GT] = ACTIONS(15),
+    [anon_sym_COMMA] = ACTIONS(9),
     [aux_sym_keycode_token1] = ACTIONS(17),
     [aux_sym_keycode_token2] = ACTIONS(17),
     [aux_sym_keycode_token3] = ACTIONS(17),
@@ -6762,9 +8223,13 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_LBRACE_RBRACE] = ACTIONS(9),
     [aux_sym__word_common_token5] = ACTIONS(9),
     [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_RPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(9),
+    [anon_sym_RBRACK] = ACTIONS(9),
     [aux_sym__word_common_token6] = ACTIONS(5),
     [anon_sym_TILDE] = ACTIONS(9),
     [anon_sym_GT] = ACTIONS(15),
+    [anon_sym_COMMA] = ACTIONS(9),
     [aux_sym_keycode_token1] = ACTIONS(17),
     [aux_sym_keycode_token2] = ACTIONS(17),
     [aux_sym_keycode_token3] = ACTIONS(17),
@@ -6818,9 +8283,13 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_LBRACE_RBRACE] = ACTIONS(9),
     [aux_sym__word_common_token5] = ACTIONS(9),
     [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_RPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(9),
+    [anon_sym_RBRACK] = ACTIONS(9),
     [aux_sym__word_common_token6] = ACTIONS(5),
     [anon_sym_TILDE] = ACTIONS(9),
     [anon_sym_GT] = ACTIONS(15),
+    [anon_sym_COMMA] = ACTIONS(9),
     [aux_sym_keycode_token1] = ACTIONS(17),
     [aux_sym_keycode_token2] = ACTIONS(17),
     [aux_sym_keycode_token3] = ACTIONS(17),
@@ -6872,9 +8341,13 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_LBRACE_RBRACE] = ACTIONS(103),
     [aux_sym__word_common_token5] = ACTIONS(103),
     [anon_sym_LPAREN] = ACTIONS(97),
+    [anon_sym_RPAREN] = ACTIONS(97),
+    [anon_sym_LBRACK] = ACTIONS(103),
+    [anon_sym_RBRACK] = ACTIONS(103),
     [aux_sym__word_common_token6] = ACTIONS(97),
     [anon_sym_TILDE] = ACTIONS(103),
     [anon_sym_GT] = ACTIONS(112),
+    [anon_sym_COMMA] = ACTIONS(103),
     [aux_sym_keycode_token1] = ACTIONS(115),
     [aux_sym_keycode_token2] = ACTIONS(115),
     [aux_sym_keycode_token3] = ACTIONS(115),
@@ -6893,559 +8366,451 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_url_word] = ACTIONS(137),
     [anon_sym_BQUOTE2] = ACTIONS(140),
   },
+  [8] = {
+    [sym__atom_noli] = STATE(17),
+    [sym_word_noli] = STATE(17),
+    [sym__atom_common] = STATE(17),
+    [sym__word_common] = STATE(80),
+    [sym_keycode] = STATE(17),
+    [sym__uppercase_words] = STATE(17),
+    [sym__line_noli] = STATE(67),
+    [sym_tag] = STATE(17),
+    [sym_url] = STATE(17),
+    [sym_optionlink] = STATE(17),
+    [sym_taglink] = STATE(17),
+    [sym_codespan] = STATE(17),
+    [sym_argument] = STATE(17),
+    [aux_sym_line_li_repeat2] = STATE(8),
+    [aux_sym_word_noli_token1] = ACTIONS(143),
+    [aux_sym_word_noli_token2] = ACTIONS(143),
+    [anon_sym_SQUOTE] = ACTIONS(146),
+    [aux_sym__word_common_token3] = ACTIONS(149),
+    [anon_sym_PIPE] = ACTIONS(152),
+    [aux_sym__word_common_token4] = ACTIONS(149),
+    [anon_sym_LBRACE] = ACTIONS(155),
+    [anon_sym_RBRACE] = ACTIONS(149),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(149),
+    [aux_sym__word_common_token5] = ACTIONS(149),
+    [anon_sym_LPAREN] = ACTIONS(143),
+    [anon_sym_RPAREN] = ACTIONS(143),
+    [anon_sym_LBRACK] = ACTIONS(149),
+    [anon_sym_RBRACK] = ACTIONS(149),
+    [aux_sym__word_common_token6] = ACTIONS(143),
+    [anon_sym_TILDE] = ACTIONS(149),
+    [anon_sym_GT] = ACTIONS(149),
+    [anon_sym_COMMA] = ACTIONS(149),
+    [aux_sym_keycode_token1] = ACTIONS(158),
+    [aux_sym_keycode_token2] = ACTIONS(158),
+    [aux_sym_keycode_token3] = ACTIONS(158),
+    [aux_sym_keycode_token4] = ACTIONS(158),
+    [aux_sym_keycode_token5] = ACTIONS(161),
+    [aux_sym_keycode_token6] = ACTIONS(161),
+    [aux_sym_keycode_token7] = ACTIONS(158),
+    [aux_sym_keycode_token8] = ACTIONS(158),
+    [aux_sym_uppercase_name_token1] = ACTIONS(164),
+    [anon_sym_LT] = ACTIONS(167),
+    [anon_sym_LF2] = ACTIONS(169),
+    [aux_sym_line_li_token1] = ACTIONS(169),
+    [anon_sym_STAR] = ACTIONS(171),
+    [sym_url_word] = ACTIONS(174),
+    [anon_sym_BQUOTE2] = ACTIONS(177),
+  },
+  [9] = {
+    [sym__atom_noli] = STATE(17),
+    [sym_word_noli] = STATE(17),
+    [sym__atom_common] = STATE(17),
+    [sym__word_common] = STATE(80),
+    [sym_keycode] = STATE(17),
+    [sym__uppercase_words] = STATE(17),
+    [sym__line_noli] = STATE(67),
+    [sym_tag] = STATE(17),
+    [sym_url] = STATE(17),
+    [sym_optionlink] = STATE(17),
+    [sym_taglink] = STATE(17),
+    [sym_codespan] = STATE(17),
+    [sym_argument] = STATE(17),
+    [aux_sym_line_li_repeat2] = STATE(8),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(5),
+    [anon_sym_SQUOTE] = ACTIONS(7),
+    [aux_sym__word_common_token3] = ACTIONS(9),
+    [anon_sym_PIPE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(9),
+    [anon_sym_LBRACE] = ACTIONS(13),
+    [anon_sym_RBRACE] = ACTIONS(9),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(9),
+    [aux_sym__word_common_token5] = ACTIONS(9),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_RPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(9),
+    [anon_sym_RBRACK] = ACTIONS(9),
+    [aux_sym__word_common_token6] = ACTIONS(5),
+    [anon_sym_TILDE] = ACTIONS(9),
+    [anon_sym_GT] = ACTIONS(9),
+    [anon_sym_COMMA] = ACTIONS(9),
+    [aux_sym_keycode_token1] = ACTIONS(17),
+    [aux_sym_keycode_token2] = ACTIONS(17),
+    [aux_sym_keycode_token3] = ACTIONS(17),
+    [aux_sym_keycode_token4] = ACTIONS(17),
+    [aux_sym_keycode_token5] = ACTIONS(19),
+    [aux_sym_keycode_token6] = ACTIONS(19),
+    [aux_sym_keycode_token7] = ACTIONS(17),
+    [aux_sym_keycode_token8] = ACTIONS(17),
+    [aux_sym_uppercase_name_token1] = ACTIONS(180),
+    [anon_sym_LT] = ACTIONS(182),
+    [anon_sym_LF2] = ACTIONS(184),
+    [aux_sym_line_li_token1] = ACTIONS(184),
+    [anon_sym_STAR] = ACTIONS(33),
+    [sym_url_word] = ACTIONS(35),
+    [anon_sym_BQUOTE2] = ACTIONS(37),
+  },
+  [10] = {
+    [sym__atom_noli] = STATE(17),
+    [sym_word_noli] = STATE(17),
+    [sym__atom_common] = STATE(17),
+    [sym__word_common] = STATE(80),
+    [sym_keycode] = STATE(17),
+    [sym__uppercase_words] = STATE(17),
+    [sym__line_noli] = STATE(67),
+    [sym_tag] = STATE(17),
+    [sym_url] = STATE(17),
+    [sym_optionlink] = STATE(17),
+    [sym_taglink] = STATE(17),
+    [sym_codespan] = STATE(17),
+    [sym_argument] = STATE(17),
+    [aux_sym_line_li_repeat2] = STATE(8),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(5),
+    [anon_sym_SQUOTE] = ACTIONS(7),
+    [aux_sym__word_common_token3] = ACTIONS(9),
+    [anon_sym_PIPE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(9),
+    [anon_sym_LBRACE] = ACTIONS(13),
+    [anon_sym_RBRACE] = ACTIONS(9),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(9),
+    [aux_sym__word_common_token5] = ACTIONS(9),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_RPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(9),
+    [anon_sym_RBRACK] = ACTIONS(9),
+    [aux_sym__word_common_token6] = ACTIONS(5),
+    [anon_sym_TILDE] = ACTIONS(9),
+    [anon_sym_GT] = ACTIONS(9),
+    [anon_sym_COMMA] = ACTIONS(9),
+    [aux_sym_keycode_token1] = ACTIONS(17),
+    [aux_sym_keycode_token2] = ACTIONS(17),
+    [aux_sym_keycode_token3] = ACTIONS(17),
+    [aux_sym_keycode_token4] = ACTIONS(17),
+    [aux_sym_keycode_token5] = ACTIONS(19),
+    [aux_sym_keycode_token6] = ACTIONS(19),
+    [aux_sym_keycode_token7] = ACTIONS(17),
+    [aux_sym_keycode_token8] = ACTIONS(17),
+    [aux_sym_uppercase_name_token1] = ACTIONS(180),
+    [anon_sym_LT] = ACTIONS(186),
+    [anon_sym_LF2] = ACTIONS(188),
+    [aux_sym_line_li_token1] = ACTIONS(188),
+    [anon_sym_STAR] = ACTIONS(33),
+    [sym_url_word] = ACTIONS(35),
+    [anon_sym_BQUOTE2] = ACTIONS(37),
+  },
+  [11] = {
+    [sym__atom_noli] = STATE(17),
+    [sym_word_noli] = STATE(17),
+    [sym__atom_common] = STATE(17),
+    [sym__word_common] = STATE(80),
+    [sym_keycode] = STATE(17),
+    [sym__uppercase_words] = STATE(17),
+    [sym__line_noli] = STATE(67),
+    [sym_tag] = STATE(17),
+    [sym_url] = STATE(17),
+    [sym_optionlink] = STATE(17),
+    [sym_taglink] = STATE(17),
+    [sym_codespan] = STATE(17),
+    [sym_argument] = STATE(17),
+    [aux_sym_line_li_repeat2] = STATE(8),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(5),
+    [anon_sym_SQUOTE] = ACTIONS(7),
+    [aux_sym__word_common_token3] = ACTIONS(9),
+    [anon_sym_PIPE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(9),
+    [anon_sym_LBRACE] = ACTIONS(13),
+    [anon_sym_RBRACE] = ACTIONS(9),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(9),
+    [aux_sym__word_common_token5] = ACTIONS(9),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_RPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(9),
+    [anon_sym_RBRACK] = ACTIONS(9),
+    [aux_sym__word_common_token6] = ACTIONS(5),
+    [anon_sym_TILDE] = ACTIONS(9),
+    [anon_sym_GT] = ACTIONS(9),
+    [anon_sym_COMMA] = ACTIONS(9),
+    [aux_sym_keycode_token1] = ACTIONS(17),
+    [aux_sym_keycode_token2] = ACTIONS(17),
+    [aux_sym_keycode_token3] = ACTIONS(17),
+    [aux_sym_keycode_token4] = ACTIONS(17),
+    [aux_sym_keycode_token5] = ACTIONS(19),
+    [aux_sym_keycode_token6] = ACTIONS(19),
+    [aux_sym_keycode_token7] = ACTIONS(17),
+    [aux_sym_keycode_token8] = ACTIONS(17),
+    [aux_sym_uppercase_name_token1] = ACTIONS(180),
+    [anon_sym_LT] = ACTIONS(190),
+    [anon_sym_LF2] = ACTIONS(192),
+    [aux_sym_line_li_token1] = ACTIONS(192),
+    [anon_sym_STAR] = ACTIONS(33),
+    [sym_url_word] = ACTIONS(35),
+    [anon_sym_BQUOTE2] = ACTIONS(37),
+  },
+  [12] = {
+    [sym__atom_noli] = STATE(17),
+    [sym_word_noli] = STATE(17),
+    [sym__atom_common] = STATE(17),
+    [sym__word_common] = STATE(80),
+    [sym_keycode] = STATE(17),
+    [sym__uppercase_words] = STATE(17),
+    [sym__line_noli] = STATE(67),
+    [sym_tag] = STATE(17),
+    [sym_url] = STATE(17),
+    [sym_optionlink] = STATE(17),
+    [sym_taglink] = STATE(17),
+    [sym_codespan] = STATE(17),
+    [sym_argument] = STATE(17),
+    [aux_sym_line_li_repeat2] = STATE(8),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(5),
+    [anon_sym_SQUOTE] = ACTIONS(7),
+    [aux_sym__word_common_token3] = ACTIONS(9),
+    [anon_sym_PIPE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(9),
+    [anon_sym_LBRACE] = ACTIONS(13),
+    [anon_sym_RBRACE] = ACTIONS(9),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(9),
+    [aux_sym__word_common_token5] = ACTIONS(9),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_RPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(9),
+    [anon_sym_RBRACK] = ACTIONS(9),
+    [aux_sym__word_common_token6] = ACTIONS(5),
+    [anon_sym_TILDE] = ACTIONS(9),
+    [anon_sym_GT] = ACTIONS(9),
+    [anon_sym_COMMA] = ACTIONS(9),
+    [aux_sym_keycode_token1] = ACTIONS(17),
+    [aux_sym_keycode_token2] = ACTIONS(17),
+    [aux_sym_keycode_token3] = ACTIONS(17),
+    [aux_sym_keycode_token4] = ACTIONS(17),
+    [aux_sym_keycode_token5] = ACTIONS(19),
+    [aux_sym_keycode_token6] = ACTIONS(19),
+    [aux_sym_keycode_token7] = ACTIONS(17),
+    [aux_sym_keycode_token8] = ACTIONS(17),
+    [aux_sym_uppercase_name_token1] = ACTIONS(180),
+    [anon_sym_LT] = ACTIONS(194),
+    [anon_sym_LF2] = ACTIONS(196),
+    [aux_sym_line_li_token1] = ACTIONS(196),
+    [anon_sym_STAR] = ACTIONS(33),
+    [sym_url_word] = ACTIONS(35),
+    [anon_sym_BQUOTE2] = ACTIONS(37),
+  },
+  [13] = {
+    [sym__atom_noli] = STATE(17),
+    [sym_word_noli] = STATE(17),
+    [sym__atom_common] = STATE(17),
+    [sym__word_common] = STATE(80),
+    [sym_keycode] = STATE(17),
+    [sym__uppercase_words] = STATE(17),
+    [sym__line_noli] = STATE(67),
+    [sym_tag] = STATE(17),
+    [sym_url] = STATE(17),
+    [sym_optionlink] = STATE(17),
+    [sym_taglink] = STATE(17),
+    [sym_codespan] = STATE(17),
+    [sym_argument] = STATE(17),
+    [aux_sym_line_li_repeat2] = STATE(9),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(5),
+    [anon_sym_SQUOTE] = ACTIONS(7),
+    [aux_sym__word_common_token3] = ACTIONS(9),
+    [anon_sym_PIPE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(9),
+    [anon_sym_LBRACE] = ACTIONS(13),
+    [anon_sym_RBRACE] = ACTIONS(9),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(9),
+    [aux_sym__word_common_token5] = ACTIONS(9),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_RPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(9),
+    [anon_sym_RBRACK] = ACTIONS(9),
+    [aux_sym__word_common_token6] = ACTIONS(5),
+    [anon_sym_TILDE] = ACTIONS(9),
+    [anon_sym_GT] = ACTIONS(9),
+    [anon_sym_COMMA] = ACTIONS(9),
+    [aux_sym_keycode_token1] = ACTIONS(17),
+    [aux_sym_keycode_token2] = ACTIONS(17),
+    [aux_sym_keycode_token3] = ACTIONS(17),
+    [aux_sym_keycode_token4] = ACTIONS(17),
+    [aux_sym_keycode_token5] = ACTIONS(19),
+    [aux_sym_keycode_token6] = ACTIONS(19),
+    [aux_sym_keycode_token7] = ACTIONS(17),
+    [aux_sym_keycode_token8] = ACTIONS(17),
+    [aux_sym_uppercase_name_token1] = ACTIONS(180),
+    [anon_sym_LT] = ACTIONS(198),
+    [anon_sym_LF2] = ACTIONS(200),
+    [aux_sym_line_li_token1] = ACTIONS(200),
+    [anon_sym_STAR] = ACTIONS(33),
+    [sym_url_word] = ACTIONS(35),
+    [anon_sym_BQUOTE2] = ACTIONS(37),
+  },
+  [14] = {
+    [sym__atom_noli] = STATE(17),
+    [sym_word_noli] = STATE(17),
+    [sym__atom_common] = STATE(17),
+    [sym__word_common] = STATE(80),
+    [sym_keycode] = STATE(17),
+    [sym__uppercase_words] = STATE(17),
+    [sym__line_noli] = STATE(67),
+    [sym_tag] = STATE(17),
+    [sym_url] = STATE(17),
+    [sym_optionlink] = STATE(17),
+    [sym_taglink] = STATE(17),
+    [sym_codespan] = STATE(17),
+    [sym_argument] = STATE(17),
+    [aux_sym_line_li_repeat2] = STATE(10),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(5),
+    [anon_sym_SQUOTE] = ACTIONS(7),
+    [aux_sym__word_common_token3] = ACTIONS(9),
+    [anon_sym_PIPE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(9),
+    [anon_sym_LBRACE] = ACTIONS(13),
+    [anon_sym_RBRACE] = ACTIONS(9),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(9),
+    [aux_sym__word_common_token5] = ACTIONS(9),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_RPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(9),
+    [anon_sym_RBRACK] = ACTIONS(9),
+    [aux_sym__word_common_token6] = ACTIONS(5),
+    [anon_sym_TILDE] = ACTIONS(9),
+    [anon_sym_GT] = ACTIONS(9),
+    [anon_sym_COMMA] = ACTIONS(9),
+    [aux_sym_keycode_token1] = ACTIONS(17),
+    [aux_sym_keycode_token2] = ACTIONS(17),
+    [aux_sym_keycode_token3] = ACTIONS(17),
+    [aux_sym_keycode_token4] = ACTIONS(17),
+    [aux_sym_keycode_token5] = ACTIONS(19),
+    [aux_sym_keycode_token6] = ACTIONS(19),
+    [aux_sym_keycode_token7] = ACTIONS(17),
+    [aux_sym_keycode_token8] = ACTIONS(17),
+    [aux_sym_uppercase_name_token1] = ACTIONS(180),
+    [anon_sym_LT] = ACTIONS(202),
+    [anon_sym_LF2] = ACTIONS(204),
+    [aux_sym_line_li_token1] = ACTIONS(204),
+    [anon_sym_STAR] = ACTIONS(33),
+    [sym_url_word] = ACTIONS(35),
+    [anon_sym_BQUOTE2] = ACTIONS(37),
+  },
+  [15] = {
+    [sym__atom_noli] = STATE(17),
+    [sym_word_noli] = STATE(17),
+    [sym__atom_common] = STATE(17),
+    [sym__word_common] = STATE(80),
+    [sym_keycode] = STATE(17),
+    [sym__uppercase_words] = STATE(17),
+    [sym__line_noli] = STATE(67),
+    [sym_tag] = STATE(17),
+    [sym_url] = STATE(17),
+    [sym_optionlink] = STATE(17),
+    [sym_taglink] = STATE(17),
+    [sym_codespan] = STATE(17),
+    [sym_argument] = STATE(17),
+    [aux_sym_line_li_repeat2] = STATE(11),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(5),
+    [anon_sym_SQUOTE] = ACTIONS(7),
+    [aux_sym__word_common_token3] = ACTIONS(9),
+    [anon_sym_PIPE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(9),
+    [anon_sym_LBRACE] = ACTIONS(13),
+    [anon_sym_RBRACE] = ACTIONS(9),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(9),
+    [aux_sym__word_common_token5] = ACTIONS(9),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_RPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(9),
+    [anon_sym_RBRACK] = ACTIONS(9),
+    [aux_sym__word_common_token6] = ACTIONS(5),
+    [anon_sym_TILDE] = ACTIONS(9),
+    [anon_sym_GT] = ACTIONS(9),
+    [anon_sym_COMMA] = ACTIONS(9),
+    [aux_sym_keycode_token1] = ACTIONS(17),
+    [aux_sym_keycode_token2] = ACTIONS(17),
+    [aux_sym_keycode_token3] = ACTIONS(17),
+    [aux_sym_keycode_token4] = ACTIONS(17),
+    [aux_sym_keycode_token5] = ACTIONS(19),
+    [aux_sym_keycode_token6] = ACTIONS(19),
+    [aux_sym_keycode_token7] = ACTIONS(17),
+    [aux_sym_keycode_token8] = ACTIONS(17),
+    [aux_sym_uppercase_name_token1] = ACTIONS(180),
+    [anon_sym_LT] = ACTIONS(206),
+    [anon_sym_LF2] = ACTIONS(208),
+    [aux_sym_line_li_token1] = ACTIONS(208),
+    [anon_sym_STAR] = ACTIONS(33),
+    [sym_url_word] = ACTIONS(35),
+    [anon_sym_BQUOTE2] = ACTIONS(37),
+  },
+  [16] = {
+    [sym__atom_noli] = STATE(17),
+    [sym_word_noli] = STATE(17),
+    [sym__atom_common] = STATE(17),
+    [sym__word_common] = STATE(80),
+    [sym_keycode] = STATE(17),
+    [sym__uppercase_words] = STATE(17),
+    [sym__line_noli] = STATE(67),
+    [sym_tag] = STATE(17),
+    [sym_url] = STATE(17),
+    [sym_optionlink] = STATE(17),
+    [sym_taglink] = STATE(17),
+    [sym_codespan] = STATE(17),
+    [sym_argument] = STATE(17),
+    [aux_sym_line_li_repeat2] = STATE(12),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(5),
+    [anon_sym_SQUOTE] = ACTIONS(7),
+    [aux_sym__word_common_token3] = ACTIONS(9),
+    [anon_sym_PIPE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(9),
+    [anon_sym_LBRACE] = ACTIONS(13),
+    [anon_sym_RBRACE] = ACTIONS(9),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(9),
+    [aux_sym__word_common_token5] = ACTIONS(9),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_RPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(9),
+    [anon_sym_RBRACK] = ACTIONS(9),
+    [aux_sym__word_common_token6] = ACTIONS(5),
+    [anon_sym_TILDE] = ACTIONS(9),
+    [anon_sym_GT] = ACTIONS(9),
+    [anon_sym_COMMA] = ACTIONS(9),
+    [aux_sym_keycode_token1] = ACTIONS(17),
+    [aux_sym_keycode_token2] = ACTIONS(17),
+    [aux_sym_keycode_token3] = ACTIONS(17),
+    [aux_sym_keycode_token4] = ACTIONS(17),
+    [aux_sym_keycode_token5] = ACTIONS(19),
+    [aux_sym_keycode_token6] = ACTIONS(19),
+    [aux_sym_keycode_token7] = ACTIONS(17),
+    [aux_sym_keycode_token8] = ACTIONS(17),
+    [aux_sym_uppercase_name_token1] = ACTIONS(180),
+    [anon_sym_LT] = ACTIONS(210),
+    [anon_sym_LF2] = ACTIONS(212),
+    [aux_sym_line_li_token1] = ACTIONS(212),
+    [anon_sym_STAR] = ACTIONS(33),
+    [sym_url_word] = ACTIONS(35),
+    [anon_sym_BQUOTE2] = ACTIONS(37),
+  },
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 17,
-    ACTIONS(146), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(152), 1,
-      anon_sym_PIPE,
-    ACTIONS(155), 1,
-      anon_sym_LBRACE,
-    ACTIONS(164), 1,
-      aux_sym_uppercase_name_token1,
-    ACTIONS(167), 1,
-      anon_sym_LT,
-    ACTIONS(171), 1,
-      anon_sym_STAR,
-    ACTIONS(174), 1,
-      sym_url_word,
-    ACTIONS(177), 1,
-      anon_sym_BQUOTE2,
-    STATE(8), 1,
-      aux_sym_line_li_repeat2,
-    STATE(67), 1,
-      sym__line_noli,
-    STATE(80), 1,
-      sym__word_common,
-    ACTIONS(161), 2,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-    ACTIONS(169), 2,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-    ACTIONS(143), 4,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-    ACTIONS(158), 6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(149), 7,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-    STATE(17), 11,
-      sym__atom_noli,
-      sym_word_noli,
-      sym__atom_common,
-      sym_keycode,
-      sym__uppercase_words,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [78] = 17,
-    ACTIONS(7), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(33), 1,
-      anon_sym_STAR,
-    ACTIONS(35), 1,
-      sym_url_word,
-    ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
-    ACTIONS(180), 1,
-      aux_sym_uppercase_name_token1,
-    ACTIONS(182), 1,
-      anon_sym_LT,
-    STATE(8), 1,
-      aux_sym_line_li_repeat2,
-    STATE(67), 1,
-      sym__line_noli,
-    STATE(80), 1,
-      sym__word_common,
-    ACTIONS(19), 2,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-    ACTIONS(184), 2,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-    ACTIONS(5), 4,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-    ACTIONS(17), 6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(9), 7,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-    STATE(17), 11,
-      sym__atom_noli,
-      sym_word_noli,
-      sym__atom_common,
-      sym_keycode,
-      sym__uppercase_words,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [156] = 17,
-    ACTIONS(7), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(33), 1,
-      anon_sym_STAR,
-    ACTIONS(35), 1,
-      sym_url_word,
-    ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
-    ACTIONS(180), 1,
-      aux_sym_uppercase_name_token1,
-    ACTIONS(186), 1,
-      anon_sym_LT,
-    STATE(8), 1,
-      aux_sym_line_li_repeat2,
-    STATE(67), 1,
-      sym__line_noli,
-    STATE(80), 1,
-      sym__word_common,
-    ACTIONS(19), 2,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-    ACTIONS(188), 2,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-    ACTIONS(5), 4,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-    ACTIONS(17), 6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(9), 7,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-    STATE(17), 11,
-      sym__atom_noli,
-      sym_word_noli,
-      sym__atom_common,
-      sym_keycode,
-      sym__uppercase_words,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [234] = 17,
-    ACTIONS(7), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(33), 1,
-      anon_sym_STAR,
-    ACTIONS(35), 1,
-      sym_url_word,
-    ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
-    ACTIONS(180), 1,
-      aux_sym_uppercase_name_token1,
-    ACTIONS(190), 1,
-      anon_sym_LT,
-    STATE(8), 1,
-      aux_sym_line_li_repeat2,
-    STATE(67), 1,
-      sym__line_noli,
-    STATE(80), 1,
-      sym__word_common,
-    ACTIONS(19), 2,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-    ACTIONS(192), 2,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-    ACTIONS(5), 4,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-    ACTIONS(17), 6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(9), 7,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-    STATE(17), 11,
-      sym__atom_noli,
-      sym_word_noli,
-      sym__atom_common,
-      sym_keycode,
-      sym__uppercase_words,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [312] = 17,
-    ACTIONS(7), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(33), 1,
-      anon_sym_STAR,
-    ACTIONS(35), 1,
-      sym_url_word,
-    ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
-    ACTIONS(180), 1,
-      aux_sym_uppercase_name_token1,
-    ACTIONS(194), 1,
-      anon_sym_LT,
-    STATE(8), 1,
-      aux_sym_line_li_repeat2,
-    STATE(67), 1,
-      sym__line_noli,
-    STATE(80), 1,
-      sym__word_common,
-    ACTIONS(19), 2,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-    ACTIONS(196), 2,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-    ACTIONS(5), 4,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-    ACTIONS(17), 6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(9), 7,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-    STATE(17), 11,
-      sym__atom_noli,
-      sym_word_noli,
-      sym__atom_common,
-      sym_keycode,
-      sym__uppercase_words,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [390] = 17,
-    ACTIONS(7), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(33), 1,
-      anon_sym_STAR,
-    ACTIONS(35), 1,
-      sym_url_word,
-    ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
-    ACTIONS(180), 1,
-      aux_sym_uppercase_name_token1,
-    ACTIONS(198), 1,
-      anon_sym_LT,
-    STATE(9), 1,
-      aux_sym_line_li_repeat2,
-    STATE(67), 1,
-      sym__line_noli,
-    STATE(80), 1,
-      sym__word_common,
-    ACTIONS(19), 2,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-    ACTIONS(200), 2,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-    ACTIONS(5), 4,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-    ACTIONS(17), 6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(9), 7,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-    STATE(17), 11,
-      sym__atom_noli,
-      sym_word_noli,
-      sym__atom_common,
-      sym_keycode,
-      sym__uppercase_words,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [468] = 17,
-    ACTIONS(7), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(33), 1,
-      anon_sym_STAR,
-    ACTIONS(35), 1,
-      sym_url_word,
-    ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
-    ACTIONS(180), 1,
-      aux_sym_uppercase_name_token1,
-    ACTIONS(202), 1,
-      anon_sym_LT,
-    STATE(10), 1,
-      aux_sym_line_li_repeat2,
-    STATE(67), 1,
-      sym__line_noli,
-    STATE(80), 1,
-      sym__word_common,
-    ACTIONS(19), 2,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-    ACTIONS(204), 2,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-    ACTIONS(5), 4,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-    ACTIONS(17), 6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(9), 7,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-    STATE(17), 11,
-      sym__atom_noli,
-      sym_word_noli,
-      sym__atom_common,
-      sym_keycode,
-      sym__uppercase_words,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [546] = 17,
-    ACTIONS(7), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(33), 1,
-      anon_sym_STAR,
-    ACTIONS(35), 1,
-      sym_url_word,
-    ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
-    ACTIONS(180), 1,
-      aux_sym_uppercase_name_token1,
-    ACTIONS(206), 1,
-      anon_sym_LT,
-    STATE(11), 1,
-      aux_sym_line_li_repeat2,
-    STATE(67), 1,
-      sym__line_noli,
-    STATE(80), 1,
-      sym__word_common,
-    ACTIONS(19), 2,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-    ACTIONS(208), 2,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-    ACTIONS(5), 4,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-    ACTIONS(17), 6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(9), 7,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-    STATE(17), 11,
-      sym__atom_noli,
-      sym_word_noli,
-      sym__atom_common,
-      sym_keycode,
-      sym__uppercase_words,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [624] = 17,
-    ACTIONS(7), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(11), 1,
-      anon_sym_PIPE,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(33), 1,
-      anon_sym_STAR,
-    ACTIONS(35), 1,
-      sym_url_word,
-    ACTIONS(37), 1,
-      anon_sym_BQUOTE2,
-    ACTIONS(180), 1,
-      aux_sym_uppercase_name_token1,
-    ACTIONS(210), 1,
-      anon_sym_LT,
-    STATE(12), 1,
-      aux_sym_line_li_repeat2,
-    STATE(67), 1,
-      sym__line_noli,
-    STATE(80), 1,
-      sym__word_common,
-    ACTIONS(19), 2,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-    ACTIONS(212), 2,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-    ACTIONS(5), 4,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-    ACTIONS(17), 6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-    ACTIONS(9), 7,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-    STATE(17), 11,
-      sym__atom_noli,
-      sym_word_noli,
-      sym__atom_common,
-      sym_keycode,
-      sym__uppercase_words,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [702] = 16,
+  [0] = 16,
     ACTIONS(7), 1,
       anon_sym_SQUOTE,
     ACTIONS(11), 1,
@@ -7481,15 +8846,6 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
-    ACTIONS(216), 8,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -7501,7 +8857,20 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [774] = 17,
+    ACTIONS(216), 12,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_COMMA,
+  [76] = 17,
     ACTIONS(7), 1,
       anon_sym_SQUOTE,
     ACTIONS(11), 1,
@@ -7539,14 +8908,6 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
-    ACTIONS(216), 7,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -7558,7 +8919,19 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [848] = 16,
+    ACTIONS(216), 11,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      aux_sym__word_common_token6,
+      anon_sym_COMMA,
+  [154] = 16,
     ACTIONS(7), 1,
       anon_sym_SQUOTE,
     ACTIONS(11), 1,
@@ -7594,15 +8967,6 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
-    ACTIONS(216), 8,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -7614,7 +8978,20 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [920] = 16,
+    ACTIONS(216), 12,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_COMMA,
+  [230] = 16,
     ACTIONS(7), 1,
       anon_sym_SQUOTE,
     ACTIONS(11), 1,
@@ -7650,15 +9027,6 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
-    ACTIONS(216), 8,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -7670,7 +9038,20 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [992] = 16,
+    ACTIONS(216), 12,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_COMMA,
+  [306] = 16,
     ACTIONS(7), 1,
       anon_sym_SQUOTE,
     ACTIONS(11), 1,
@@ -7706,15 +9087,6 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
-    ACTIONS(216), 8,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -7726,7 +9098,20 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1064] = 17,
+    ACTIONS(216), 12,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_COMMA,
+  [382] = 17,
     ACTIONS(7), 1,
       anon_sym_SQUOTE,
     ACTIONS(11), 1,
@@ -7764,14 +9149,6 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
-    ACTIONS(216), 7,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -7783,7 +9160,19 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1138] = 14,
+    ACTIONS(216), 11,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      aux_sym__word_common_token6,
+      anon_sym_COMMA,
+  [460] = 14,
     ACTIONS(241), 1,
       anon_sym_SQUOTE,
     ACTIONS(247), 1,
@@ -7815,16 +9204,6 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
-    ACTIONS(244), 9,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -7836,7 +9215,21 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1205] = 14,
+    ACTIONS(244), 13,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+  [531] = 14,
     ACTIONS(7), 1,
       anon_sym_SQUOTE,
     ACTIONS(11), 1,
@@ -7868,16 +9261,6 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
-    ACTIONS(216), 9,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -7889,7 +9272,21 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1272] = 14,
+    ACTIONS(216), 13,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+  [602] = 14,
     ACTIONS(7), 1,
       anon_sym_SQUOTE,
     ACTIONS(11), 1,
@@ -7921,16 +9318,6 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
-    ACTIONS(216), 9,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -7942,7 +9329,21 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1339] = 14,
+    ACTIONS(216), 13,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+  [673] = 14,
     ACTIONS(7), 1,
       anon_sym_SQUOTE,
     ACTIONS(11), 1,
@@ -7974,16 +9375,6 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
-    ACTIONS(216), 9,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -7995,7 +9386,21 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1406] = 14,
+    ACTIONS(216), 13,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+  [744] = 14,
     ACTIONS(7), 1,
       anon_sym_SQUOTE,
     ACTIONS(11), 1,
@@ -8027,16 +9432,6 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
-    ACTIONS(216), 9,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -8048,7 +9443,21 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1473] = 13,
+    ACTIONS(216), 13,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+  [815] = 13,
     ACTIONS(7), 1,
       anon_sym_SQUOTE,
     ACTIONS(11), 1,
@@ -8078,16 +9487,6 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
-    ACTIONS(216), 9,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -8099,7 +9498,21 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1537] = 13,
+    ACTIONS(216), 13,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+  [883] = 13,
     ACTIONS(7), 1,
       anon_sym_SQUOTE,
     ACTIONS(11), 1,
@@ -8129,16 +9542,6 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
-    ACTIONS(216), 9,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -8150,7 +9553,21 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1601] = 13,
+    ACTIONS(216), 13,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+  [951] = 13,
     ACTIONS(7), 1,
       anon_sym_SQUOTE,
     ACTIONS(11), 1,
@@ -8180,16 +9597,6 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
-    ACTIONS(216), 9,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -8201,7 +9608,21 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1665] = 13,
+    ACTIONS(216), 13,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+  [1019] = 13,
     ACTIONS(7), 1,
       anon_sym_SQUOTE,
     ACTIONS(11), 1,
@@ -8231,16 +9652,6 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
-    ACTIONS(216), 9,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      anon_sym_TILDE,
-      anon_sym_GT,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -8252,7 +9663,21 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1729] = 6,
+    ACTIONS(216), 13,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      aux_sym__word_common_token6,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+  [1087] = 6,
     ACTIONS(25), 1,
       anon_sym_LF2,
     ACTIONS(282), 1,
@@ -8261,7 +9686,24 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_help_file_repeat1,
     STATE(46), 1,
       sym__blank,
-    ACTIONS(278), 15,
+    ACTIONS(280), 16,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      aux_sym__word_common_token6,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token7,
+      aux_sym_keycode_token8,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+      anon_sym_STAR,
+    ACTIONS(278), 18,
       ts_builtin_sym_end,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -8269,43 +9711,31 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-    ACTIONS(280), 15,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token7,
-      aux_sym_keycode_token8,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      anon_sym_STAR,
-  [1776] = 5,
+  [1138] = 5,
     ACTIONS(25), 1,
       anon_sym_LF2,
     STATE(43), 1,
       aux_sym_help_file_repeat1,
     STATE(46), 1,
       sym__blank,
-    ACTIONS(286), 15,
+    ACTIONS(286), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8316,7 +9746,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(284), 16,
+    ACTIONS(284), 19,
       ts_builtin_sym_end,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -8324,8 +9754,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       aux_sym_line_li_token1,
@@ -8333,7 +9766,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [1821] = 6,
+  [1187] = 6,
     ACTIONS(290), 1,
       anon_sym_LF2,
     ACTIONS(292), 1,
@@ -8345,7 +9778,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(294), 2,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
-    ACTIONS(288), 28,
+    ACTIONS(288), 32,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_SQUOTE,
@@ -8357,9 +9790,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -8374,7 +9811,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [1868] = 6,
+  [1238] = 6,
     ACTIONS(298), 1,
       anon_sym_LF2,
     ACTIONS(301), 1,
@@ -8386,7 +9823,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(304), 2,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
-    ACTIONS(296), 28,
+    ACTIONS(296), 32,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_SQUOTE,
@@ -8398,9 +9835,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -8415,19 +9856,20 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [1915] = 5,
+  [1289] = 5,
     ACTIONS(25), 1,
       anon_sym_LF2,
     STATE(43), 1,
       aux_sym_help_file_repeat1,
     STATE(46), 1,
       sym__blank,
-    ACTIONS(308), 15,
+    ACTIONS(308), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8438,7 +9880,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(306), 16,
+    ACTIONS(306), 19,
       ts_builtin_sym_end,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -8446,8 +9888,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       aux_sym_line_li_token1,
@@ -8455,19 +9900,20 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [1960] = 5,
+  [1338] = 5,
     ACTIONS(25), 1,
       anon_sym_LF2,
     STATE(39), 1,
       aux_sym_help_file_repeat1,
     STATE(46), 1,
       sym__blank,
-    ACTIONS(312), 15,
+    ACTIONS(312), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8478,7 +9924,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(310), 16,
+    ACTIONS(310), 19,
       ts_builtin_sym_end,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -8486,8 +9932,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       aux_sym_line_li_token1,
@@ -8495,19 +9944,20 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2005] = 5,
+  [1387] = 5,
     ACTIONS(25), 1,
       anon_sym_LF2,
     STATE(43), 1,
       aux_sym_help_file_repeat1,
     STATE(46), 1,
       sym__blank,
-    ACTIONS(316), 15,
+    ACTIONS(316), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8518,7 +9968,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(314), 16,
+    ACTIONS(314), 19,
       ts_builtin_sym_end,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -8526,8 +9976,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       aux_sym_line_li_token1,
@@ -8535,19 +9988,20 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2050] = 5,
+  [1436] = 5,
     ACTIONS(25), 1,
       anon_sym_LF2,
     STATE(43), 1,
       aux_sym_help_file_repeat1,
     STATE(46), 1,
       sym__blank,
-    ACTIONS(320), 15,
+    ACTIONS(320), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8558,7 +10012,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(318), 16,
+    ACTIONS(318), 19,
       ts_builtin_sym_end,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -8566,8 +10020,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       aux_sym_line_li_token1,
@@ -8575,19 +10032,20 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2095] = 5,
+  [1485] = 5,
     ACTIONS(25), 1,
       anon_sym_LF2,
     STATE(36), 1,
       aux_sym_help_file_repeat1,
     STATE(46), 1,
       sym__blank,
-    ACTIONS(316), 15,
+    ACTIONS(316), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8598,7 +10056,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(314), 16,
+    ACTIONS(314), 19,
       ts_builtin_sym_end,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -8606,8 +10064,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       aux_sym_line_li_token1,
@@ -8615,19 +10076,20 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2140] = 5,
+  [1534] = 5,
     ACTIONS(25), 1,
       anon_sym_LF2,
     STATE(44), 1,
       aux_sym_help_file_repeat1,
     STATE(46), 1,
       sym__blank,
-    ACTIONS(312), 15,
+    ACTIONS(312), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8638,7 +10100,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(310), 16,
+    ACTIONS(310), 19,
       ts_builtin_sym_end,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -8646,8 +10108,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       aux_sym_line_li_token1,
@@ -8655,7 +10120,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2185] = 6,
+  [1583] = 6,
     ACTIONS(25), 1,
       anon_sym_LF2,
     ACTIONS(282), 1,
@@ -8664,28 +10129,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_help_file_repeat1,
     STATE(46), 1,
       sym__blank,
-    ACTIONS(322), 15,
-      ts_builtin_sym_end,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-    ACTIONS(324), 15,
+    ACTIONS(324), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8696,19 +10146,39 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-  [2232] = 5,
+    ACTIONS(322), 18,
+      ts_builtin_sym_end,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE2,
+  [1634] = 5,
     ACTIONS(330), 1,
       anon_sym_LF2,
     STATE(43), 1,
       aux_sym_help_file_repeat1,
     STATE(46), 1,
       sym__blank,
-    ACTIONS(328), 15,
+    ACTIONS(328), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8719,7 +10189,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(326), 16,
+    ACTIONS(326), 19,
       ts_builtin_sym_end,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -8727,8 +10197,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       aux_sym_line_li_token1,
@@ -8736,19 +10209,20 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2277] = 5,
+  [1683] = 5,
     ACTIONS(25), 1,
       anon_sym_LF2,
     STATE(43), 1,
       aux_sym_help_file_repeat1,
     STATE(46), 1,
       sym__blank,
-    ACTIONS(320), 15,
+    ACTIONS(320), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8759,7 +10233,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(318), 16,
+    ACTIONS(318), 19,
       ts_builtin_sym_end,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -8767,8 +10241,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       aux_sym_line_li_token1,
@@ -8776,7 +10253,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2322] = 5,
+  [1732] = 5,
     ACTIONS(333), 1,
       anon_sym_LF2,
     ACTIONS(335), 1,
@@ -8785,7 +10262,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_codeblock_repeat1,
     STATE(62), 1,
       sym_line_code,
-    ACTIONS(288), 28,
+    ACTIONS(288), 32,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_SQUOTE,
@@ -8797,9 +10274,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -8814,13 +10295,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2365] = 2,
-    ACTIONS(339), 15,
+  [1779] = 2,
+    ACTIONS(339), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8831,7 +10313,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(337), 17,
+    ACTIONS(337), 20,
       ts_builtin_sym_end,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -8839,8 +10321,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       anon_sym_LF2,
@@ -8849,13 +10334,14 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2402] = 2,
-    ACTIONS(343), 15,
+  [1820] = 2,
+    ACTIONS(343), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8866,7 +10352,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(341), 17,
+    ACTIONS(341), 20,
       ts_builtin_sym_end,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -8874,8 +10360,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       anon_sym_LF2,
@@ -8884,12 +10373,12 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2439] = 2,
+  [1861] = 2,
     ACTIONS(347), 3,
       anon_sym_LF2,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
-    ACTIONS(345), 29,
+    ACTIONS(345), 33,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_SQUOTE,
@@ -8901,9 +10390,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -8919,12 +10412,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2476] = 2,
+  [1902] = 2,
     ACTIONS(351), 3,
       anon_sym_LF2,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
-    ACTIONS(349), 29,
+    ACTIONS(349), 33,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_SQUOTE,
@@ -8936,9 +10429,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -8954,7 +10451,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2513] = 5,
+  [1943] = 5,
     ACTIONS(353), 1,
       anon_sym_LF2,
     ACTIONS(356), 1,
@@ -8963,7 +10460,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_codeblock_repeat1,
     STATE(62), 1,
       sym_line_code,
-    ACTIONS(296), 28,
+    ACTIONS(296), 32,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_SQUOTE,
@@ -8975,9 +10472,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -8992,7 +10493,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2556] = 3,
+  [1990] = 3,
     ACTIONS(361), 3,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -9002,9 +10503,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE2,
       anon_sym_RBRACE2,
       anon_sym_LPAREN2,
-      anon_sym_RPAREN,
+      anon_sym_RPAREN2,
       anon_sym_BQUOTE,
-    ACTIONS(359), 23,
+    ACTIONS(359), 27,
       aux_sym_word_token1,
       aux_sym_word_token2,
       anon_sym_SQUOTE,
@@ -9014,9 +10515,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9028,13 +10533,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2595] = 2,
-    ACTIONS(365), 15,
+  [2033] = 2,
+    ACTIONS(365), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -9045,15 +10551,18 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(367), 16,
+    ACTIONS(367), 19,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       anon_sym_LF2,
@@ -9062,13 +10571,14 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2631] = 2,
-    ACTIONS(369), 15,
+  [2073] = 2,
+    ACTIONS(369), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -9079,15 +10589,18 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(371), 16,
+    ACTIONS(371), 19,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       anon_sym_LF2,
@@ -9096,13 +10609,14 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2667] = 2,
-    ACTIONS(373), 15,
+  [2113] = 2,
+    ACTIONS(373), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -9113,15 +10627,18 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(375), 16,
+    ACTIONS(375), 19,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       anon_sym_LF2,
@@ -9130,13 +10647,14 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2703] = 2,
-    ACTIONS(377), 15,
+  [2153] = 2,
+    ACTIONS(377), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -9147,15 +10665,18 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(379), 16,
+    ACTIONS(379), 19,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       anon_sym_LF2,
@@ -9164,13 +10685,14 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2739] = 2,
-    ACTIONS(381), 15,
+  [2193] = 2,
+    ACTIONS(381), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -9181,15 +10703,18 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(383), 16,
+    ACTIONS(383), 19,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       anon_sym_LF2,
@@ -9198,13 +10723,14 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2775] = 2,
-    ACTIONS(385), 15,
+  [2233] = 2,
+    ACTIONS(385), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -9215,15 +10741,18 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(387), 16,
+    ACTIONS(387), 19,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       anon_sym_LF2,
@@ -9232,13 +10761,14 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2811] = 2,
-    ACTIONS(389), 15,
+  [2273] = 2,
+    ACTIONS(389), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -9249,15 +10779,18 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(391), 16,
+    ACTIONS(391), 19,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       anon_sym_LF2,
@@ -9266,13 +10799,14 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2847] = 2,
-    ACTIONS(393), 15,
+  [2313] = 2,
+    ACTIONS(393), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -9283,15 +10817,18 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(395), 16,
+    ACTIONS(395), 19,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       anon_sym_LF2,
@@ -9300,13 +10837,14 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2883] = 2,
-    ACTIONS(397), 15,
+  [2353] = 2,
+    ACTIONS(397), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -9317,15 +10855,18 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(399), 16,
+    ACTIONS(399), 19,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       anon_sym_LF2,
@@ -9334,13 +10875,14 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2919] = 2,
-    ACTIONS(401), 15,
+  [2393] = 2,
+    ACTIONS(401), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -9351,15 +10893,18 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-    ACTIONS(403), 16,
+    ACTIONS(403), 19,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       anon_sym_LF2,
@@ -9368,10 +10913,10 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2955] = 2,
+  [2433] = 2,
     ACTIONS(347), 1,
       anon_sym_LF2,
-    ACTIONS(345), 29,
+    ACTIONS(345), 33,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_SQUOTE,
@@ -9383,9 +10928,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9401,10 +10950,10 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [2990] = 2,
+  [2472] = 2,
     ACTIONS(351), 1,
       anon_sym_LF2,
-    ACTIONS(349), 29,
+    ACTIONS(349), 33,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_SQUOTE,
@@ -9416,9 +10965,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9434,28 +10987,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3025] = 2,
-    ACTIONS(367), 14,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-    ACTIONS(365), 15,
+  [2511] = 2,
+    ACTIONS(365), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -9466,7 +11005,25 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-  [3059] = 4,
+    ACTIONS(367), 17,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
+      anon_sym_LF2,
+      aux_sym_line_li_token1,
+      sym_url_word,
+      anon_sym_BQUOTE2,
+  [2549] = 4,
     ACTIONS(407), 1,
       aux_sym_optionlink_token1,
     ACTIONS(405), 2,
@@ -9484,44 +11041,34 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
       anon_sym_LF2,
-    ACTIONS(359), 15,
+    ACTIONS(359), 19,
       aux_sym_word_token1,
       aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_RBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3097] = 2,
-    ACTIONS(375), 14,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      aux_sym__word_common_token4,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token5,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-      sym_url_word,
-      anon_sym_BQUOTE2,
-    ACTIONS(373), 15,
+  [2591] = 2,
+    ACTIONS(373), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -9532,28 +11079,32 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-  [3131] = 2,
-    ACTIONS(411), 14,
+    ACTIONS(375), 17,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       anon_sym_LF2,
       aux_sym_line_li_token1,
       sym_url_word,
       anon_sym_BQUOTE2,
-    ACTIONS(409), 15,
+  [2629] = 2,
+    ACTIONS(409), 16,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -9564,7 +11115,25 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
       anon_sym_STAR,
-  [3165] = 3,
+    ACTIONS(411), 17,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      aux_sym__word_common_token4,
+      anon_sym_RBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
+      anon_sym_LF2,
+      aux_sym_line_li_token1,
+      sym_url_word,
+      anon_sym_BQUOTE2,
+  [2667] = 3,
     ACTIONS(413), 2,
       aux_sym_codeblock_token1,
       anon_sym_LF,
@@ -9577,7 +11146,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       anon_sym_LF2,
-    ACTIONS(361), 18,
+    ACTIONS(361), 22,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -9585,9 +11154,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
@@ -9596,17 +11169,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3200] = 4,
+  [2706] = 4,
     ACTIONS(419), 1,
       aux_sym_uppercase_name_token2,
     STATE(69), 1,
       aux_sym_uppercase_name_repeat1,
-    ACTIONS(415), 12,
+    ACTIONS(415), 13,
       aux_sym_word_token1,
       aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -9614,22 +11188,25 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token4,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
-    ACTIONS(417), 14,
+    ACTIONS(417), 17,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       anon_sym_LF2,
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3237] = 5,
+  [2747] = 5,
     ACTIONS(426), 1,
       aux_sym_uppercase_name_token2,
     STATE(73), 1,
@@ -9637,12 +11214,13 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(428), 2,
       anon_sym_LF2,
       anon_sym_STAR,
-    ACTIONS(422), 12,
+    ACTIONS(422), 13,
       aux_sym_word_token1,
       aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -9650,30 +11228,34 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token4,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
-    ACTIONS(424), 12,
+    ACTIONS(424), 15,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3276] = 4,
+  [2790] = 4,
     ACTIONS(426), 1,
       aux_sym_uppercase_name_token2,
     STATE(72), 1,
       aux_sym_uppercase_name_repeat1,
-    ACTIONS(422), 12,
+    ACTIONS(422), 13,
       aux_sym_word_token1,
       aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -9681,32 +11263,36 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token4,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
-    ACTIONS(424), 14,
+    ACTIONS(424), 17,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       anon_sym_LF2,
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3313] = 4,
+  [2831] = 4,
     ACTIONS(426), 1,
       aux_sym_uppercase_name_token2,
     STATE(69), 1,
       aux_sym_uppercase_name_repeat1,
-    ACTIONS(430), 12,
+    ACTIONS(430), 13,
       aux_sym_word_token1,
       aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -9714,22 +11300,25 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token4,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
-    ACTIONS(432), 14,
+    ACTIONS(432), 17,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       anon_sym_LF2,
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3350] = 5,
+  [2872] = 5,
     ACTIONS(426), 1,
       aux_sym_uppercase_name_token2,
     STATE(69), 1,
@@ -9737,12 +11326,13 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(434), 2,
       anon_sym_LF2,
       anon_sym_STAR,
-    ACTIONS(430), 12,
+    ACTIONS(430), 13,
       aux_sym_word_token1,
       aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -9750,20 +11340,23 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token4,
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
-    ACTIONS(432), 12,
+    ACTIONS(432), 15,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3389] = 3,
+  [2915] = 3,
     ACTIONS(436), 2,
       aux_sym_codeblock_token1,
       anon_sym_LF,
@@ -9776,7 +11369,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       anon_sym_LF2,
-    ACTIONS(361), 18,
+    ACTIONS(361), 22,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -9784,9 +11377,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
@@ -9795,7 +11392,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3424] = 3,
+  [2954] = 3,
     ACTIONS(438), 1,
       anon_sym_LF,
     ACTIONS(359), 8,
@@ -9807,7 +11404,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       anon_sym_LF2,
-    ACTIONS(361), 18,
+    ACTIONS(361), 22,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -9815,9 +11412,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
@@ -9826,7 +11427,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3458] = 3,
+  [2992] = 3,
     ACTIONS(442), 1,
       anon_sym_SQUOTE2,
     ACTIONS(440), 8,
@@ -9838,16 +11439,20 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(444), 18,
+    ACTIONS(444), 22,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
@@ -9857,7 +11462,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3492] = 3,
+  [3030] = 3,
     ACTIONS(446), 1,
       aux_sym_argument_token1,
     ACTIONS(361), 6,
@@ -9867,7 +11472,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__word_common_token5,
       aux_sym_keycode_token6,
       anon_sym_LF2,
-    ACTIONS(359), 20,
+    ACTIONS(359), 24,
       aux_sym_word_token1,
       aux_sym_word_token2,
       anon_sym_SQUOTE,
@@ -9875,9 +11480,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9888,7 +11497,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3526] = 3,
+  [3068] = 3,
     ACTIONS(448), 1,
       anon_sym_LF,
     ACTIONS(359), 8,
@@ -9900,7 +11509,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       anon_sym_LF2,
-    ACTIONS(361), 18,
+    ACTIONS(361), 22,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -9908,9 +11517,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
@@ -9919,13 +11532,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3560] = 2,
-    ACTIONS(450), 13,
+  [3106] = 2,
+    ACTIONS(450), 14,
       aux_sym_word_token1,
       aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
       aux_sym__word_common_token6,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -9934,22 +11548,25 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_keycode_token8,
       aux_sym_uppercase_name_token2,
-    ACTIONS(452), 14,
+    ACTIONS(452), 17,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
       anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
       anon_sym_LF2,
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3592] = 2,
+  [3142] = 2,
     ACTIONS(454), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -9958,7 +11575,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(456), 19,
+    ACTIONS(456), 23,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -9966,9 +11583,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
@@ -9978,7 +11599,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3623] = 2,
+  [3177] = 2,
     ACTIONS(458), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -9987,7 +11608,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(460), 19,
+    ACTIONS(460), 23,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -9995,9 +11616,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
@@ -10007,7 +11632,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3654] = 2,
+  [3212] = 2,
     ACTIONS(462), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -10016,7 +11641,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(464), 19,
+    ACTIONS(464), 23,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -10024,9 +11649,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
@@ -10036,7 +11665,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3685] = 2,
+  [3247] = 2,
     ACTIONS(466), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -10045,7 +11674,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(468), 19,
+    ACTIONS(468), 23,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -10053,9 +11682,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
@@ -10065,7 +11698,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3716] = 2,
+  [3282] = 2,
     ACTIONS(470), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -10074,7 +11707,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(472), 19,
+    ACTIONS(472), 23,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -10082,9 +11715,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
@@ -10094,7 +11731,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3747] = 2,
+  [3317] = 2,
     ACTIONS(474), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -10103,7 +11740,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(476), 19,
+    ACTIONS(476), 23,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -10111,9 +11748,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
@@ -10123,7 +11764,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3778] = 2,
+  [3352] = 2,
     ACTIONS(478), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -10132,7 +11773,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(480), 19,
+    ACTIONS(480), 23,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -10140,9 +11781,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
@@ -10152,7 +11797,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3809] = 2,
+  [3387] = 2,
     ACTIONS(482), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -10161,7 +11806,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(484), 19,
+    ACTIONS(484), 23,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -10169,9 +11814,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
@@ -10181,7 +11830,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3840] = 2,
+  [3422] = 2,
     ACTIONS(486), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -10190,7 +11839,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(488), 19,
+    ACTIONS(488), 23,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -10198,9 +11847,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
@@ -10210,7 +11863,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3871] = 2,
+  [3457] = 2,
     ACTIONS(490), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -10219,7 +11872,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(492), 19,
+    ACTIONS(492), 23,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -10227,9 +11880,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
@@ -10239,7 +11896,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3902] = 2,
+  [3492] = 2,
     ACTIONS(494), 7,
       aux_sym_word_token1,
       aux_sym_word_token2,
@@ -10248,7 +11905,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(496), 19,
+    ACTIONS(496), 23,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       aux_sym__word_common_token4,
@@ -10256,9 +11913,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token5,
       anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
       aux_sym__word_common_token6,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       aux_sym_keycode_token6,
@@ -10268,7 +11929,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_url_word,
       anon_sym_BQUOTE2,
-  [3933] = 5,
+  [3527] = 5,
     ACTIONS(25), 1,
       anon_sym_LF2,
     ACTIONS(27), 1,
@@ -10280,7 +11941,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(93), 2,
       sym_line_li,
       aux_sym_block_repeat2,
-  [3950] = 5,
+  [3544] = 5,
     ACTIONS(25), 1,
       anon_sym_LF2,
     ACTIONS(27), 1,
@@ -10292,7 +11953,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(93), 2,
       sym_line_li,
       aux_sym_block_repeat2,
-  [3967] = 4,
+  [3561] = 4,
     ACTIONS(502), 1,
       anon_sym_LT,
     ACTIONS(505), 1,
@@ -10302,7 +11963,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(93), 2,
       sym_line_li,
       aux_sym_block_repeat2,
-  [3981] = 4,
+  [3575] = 4,
     ACTIONS(290), 1,
       anon_sym_LF2,
     ACTIONS(292), 1,
@@ -10311,7 +11972,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_codeblock_repeat1,
     STATE(48), 1,
       sym_line_code,
-  [3994] = 4,
+  [3588] = 4,
     ACTIONS(333), 1,
       anon_sym_LF2,
     ACTIONS(335), 1,
@@ -10320,141 +11981,132 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_codeblock_repeat1,
     STATE(62), 1,
       sym_line_code,
-  [4007] = 3,
+  [3601] = 3,
     ACTIONS(222), 1,
       anon_sym_STAR,
     ACTIONS(510), 1,
       anon_sym_LF2,
     STATE(25), 1,
       sym_tag,
-  [4017] = 1,
+  [3611] = 1,
     ACTIONS(512), 1,
       ts_builtin_sym_end,
-  [4021] = 1,
+  [3615] = 1,
     ACTIONS(514), 1,
       anon_sym_SQUOTE2,
-  [4025] = 1,
+  [3619] = 1,
     ACTIONS(282), 1,
       aux_sym_line_li_token1,
-  [4029] = 1,
+  [3623] = 1,
     ACTIONS(516), 1,
       anon_sym_BQUOTE,
-  [4033] = 1,
+  [3627] = 1,
     ACTIONS(518), 1,
       anon_sym_STAR2,
-  [4037] = 1,
+  [3631] = 1,
     ACTIONS(520), 1,
       aux_sym_codespan_token1,
-  [4041] = 1,
+  [3635] = 1,
     ACTIONS(522), 1,
       aux_sym_tag_token1,
-  [4045] = 1,
+  [3639] = 1,
     ACTIONS(524), 1,
       anon_sym_RBRACE2,
-  [4049] = 1,
+  [3643] = 1,
     ACTIONS(526), 1,
       anon_sym_PIPE2,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
-  [SMALL_STATE(8)] = 0,
-  [SMALL_STATE(9)] = 78,
-  [SMALL_STATE(10)] = 156,
-  [SMALL_STATE(11)] = 234,
-  [SMALL_STATE(12)] = 312,
-  [SMALL_STATE(13)] = 390,
-  [SMALL_STATE(14)] = 468,
-  [SMALL_STATE(15)] = 546,
-  [SMALL_STATE(16)] = 624,
-  [SMALL_STATE(17)] = 702,
-  [SMALL_STATE(18)] = 774,
-  [SMALL_STATE(19)] = 848,
-  [SMALL_STATE(20)] = 920,
-  [SMALL_STATE(21)] = 992,
-  [SMALL_STATE(22)] = 1064,
-  [SMALL_STATE(23)] = 1138,
-  [SMALL_STATE(24)] = 1205,
-  [SMALL_STATE(25)] = 1272,
-  [SMALL_STATE(26)] = 1339,
-  [SMALL_STATE(27)] = 1406,
-  [SMALL_STATE(28)] = 1473,
-  [SMALL_STATE(29)] = 1537,
-  [SMALL_STATE(30)] = 1601,
-  [SMALL_STATE(31)] = 1665,
-  [SMALL_STATE(32)] = 1729,
-  [SMALL_STATE(33)] = 1776,
-  [SMALL_STATE(34)] = 1821,
-  [SMALL_STATE(35)] = 1868,
-  [SMALL_STATE(36)] = 1915,
-  [SMALL_STATE(37)] = 1960,
-  [SMALL_STATE(38)] = 2005,
-  [SMALL_STATE(39)] = 2050,
-  [SMALL_STATE(40)] = 2095,
-  [SMALL_STATE(41)] = 2140,
-  [SMALL_STATE(42)] = 2185,
-  [SMALL_STATE(43)] = 2232,
-  [SMALL_STATE(44)] = 2277,
-  [SMALL_STATE(45)] = 2322,
-  [SMALL_STATE(46)] = 2365,
-  [SMALL_STATE(47)] = 2402,
-  [SMALL_STATE(48)] = 2439,
-  [SMALL_STATE(49)] = 2476,
-  [SMALL_STATE(50)] = 2513,
-  [SMALL_STATE(51)] = 2556,
-  [SMALL_STATE(52)] = 2595,
-  [SMALL_STATE(53)] = 2631,
-  [SMALL_STATE(54)] = 2667,
-  [SMALL_STATE(55)] = 2703,
-  [SMALL_STATE(56)] = 2739,
-  [SMALL_STATE(57)] = 2775,
-  [SMALL_STATE(58)] = 2811,
-  [SMALL_STATE(59)] = 2847,
-  [SMALL_STATE(60)] = 2883,
-  [SMALL_STATE(61)] = 2919,
-  [SMALL_STATE(62)] = 2955,
-  [SMALL_STATE(63)] = 2990,
-  [SMALL_STATE(64)] = 3025,
-  [SMALL_STATE(65)] = 3059,
-  [SMALL_STATE(66)] = 3097,
-  [SMALL_STATE(67)] = 3131,
-  [SMALL_STATE(68)] = 3165,
-  [SMALL_STATE(69)] = 3200,
-  [SMALL_STATE(70)] = 3237,
-  [SMALL_STATE(71)] = 3276,
-  [SMALL_STATE(72)] = 3313,
-  [SMALL_STATE(73)] = 3350,
-  [SMALL_STATE(74)] = 3389,
-  [SMALL_STATE(75)] = 3424,
-  [SMALL_STATE(76)] = 3458,
-  [SMALL_STATE(77)] = 3492,
-  [SMALL_STATE(78)] = 3526,
-  [SMALL_STATE(79)] = 3560,
-  [SMALL_STATE(80)] = 3592,
-  [SMALL_STATE(81)] = 3623,
-  [SMALL_STATE(82)] = 3654,
-  [SMALL_STATE(83)] = 3685,
-  [SMALL_STATE(84)] = 3716,
-  [SMALL_STATE(85)] = 3747,
-  [SMALL_STATE(86)] = 3778,
-  [SMALL_STATE(87)] = 3809,
-  [SMALL_STATE(88)] = 3840,
-  [SMALL_STATE(89)] = 3871,
-  [SMALL_STATE(90)] = 3902,
-  [SMALL_STATE(91)] = 3933,
-  [SMALL_STATE(92)] = 3950,
-  [SMALL_STATE(93)] = 3967,
-  [SMALL_STATE(94)] = 3981,
-  [SMALL_STATE(95)] = 3994,
-  [SMALL_STATE(96)] = 4007,
-  [SMALL_STATE(97)] = 4017,
-  [SMALL_STATE(98)] = 4021,
-  [SMALL_STATE(99)] = 4025,
-  [SMALL_STATE(100)] = 4029,
-  [SMALL_STATE(101)] = 4033,
-  [SMALL_STATE(102)] = 4037,
-  [SMALL_STATE(103)] = 4041,
-  [SMALL_STATE(104)] = 4045,
-  [SMALL_STATE(105)] = 4049,
+  [SMALL_STATE(17)] = 0,
+  [SMALL_STATE(18)] = 76,
+  [SMALL_STATE(19)] = 154,
+  [SMALL_STATE(20)] = 230,
+  [SMALL_STATE(21)] = 306,
+  [SMALL_STATE(22)] = 382,
+  [SMALL_STATE(23)] = 460,
+  [SMALL_STATE(24)] = 531,
+  [SMALL_STATE(25)] = 602,
+  [SMALL_STATE(26)] = 673,
+  [SMALL_STATE(27)] = 744,
+  [SMALL_STATE(28)] = 815,
+  [SMALL_STATE(29)] = 883,
+  [SMALL_STATE(30)] = 951,
+  [SMALL_STATE(31)] = 1019,
+  [SMALL_STATE(32)] = 1087,
+  [SMALL_STATE(33)] = 1138,
+  [SMALL_STATE(34)] = 1187,
+  [SMALL_STATE(35)] = 1238,
+  [SMALL_STATE(36)] = 1289,
+  [SMALL_STATE(37)] = 1338,
+  [SMALL_STATE(38)] = 1387,
+  [SMALL_STATE(39)] = 1436,
+  [SMALL_STATE(40)] = 1485,
+  [SMALL_STATE(41)] = 1534,
+  [SMALL_STATE(42)] = 1583,
+  [SMALL_STATE(43)] = 1634,
+  [SMALL_STATE(44)] = 1683,
+  [SMALL_STATE(45)] = 1732,
+  [SMALL_STATE(46)] = 1779,
+  [SMALL_STATE(47)] = 1820,
+  [SMALL_STATE(48)] = 1861,
+  [SMALL_STATE(49)] = 1902,
+  [SMALL_STATE(50)] = 1943,
+  [SMALL_STATE(51)] = 1990,
+  [SMALL_STATE(52)] = 2033,
+  [SMALL_STATE(53)] = 2073,
+  [SMALL_STATE(54)] = 2113,
+  [SMALL_STATE(55)] = 2153,
+  [SMALL_STATE(56)] = 2193,
+  [SMALL_STATE(57)] = 2233,
+  [SMALL_STATE(58)] = 2273,
+  [SMALL_STATE(59)] = 2313,
+  [SMALL_STATE(60)] = 2353,
+  [SMALL_STATE(61)] = 2393,
+  [SMALL_STATE(62)] = 2433,
+  [SMALL_STATE(63)] = 2472,
+  [SMALL_STATE(64)] = 2511,
+  [SMALL_STATE(65)] = 2549,
+  [SMALL_STATE(66)] = 2591,
+  [SMALL_STATE(67)] = 2629,
+  [SMALL_STATE(68)] = 2667,
+  [SMALL_STATE(69)] = 2706,
+  [SMALL_STATE(70)] = 2747,
+  [SMALL_STATE(71)] = 2790,
+  [SMALL_STATE(72)] = 2831,
+  [SMALL_STATE(73)] = 2872,
+  [SMALL_STATE(74)] = 2915,
+  [SMALL_STATE(75)] = 2954,
+  [SMALL_STATE(76)] = 2992,
+  [SMALL_STATE(77)] = 3030,
+  [SMALL_STATE(78)] = 3068,
+  [SMALL_STATE(79)] = 3106,
+  [SMALL_STATE(80)] = 3142,
+  [SMALL_STATE(81)] = 3177,
+  [SMALL_STATE(82)] = 3212,
+  [SMALL_STATE(83)] = 3247,
+  [SMALL_STATE(84)] = 3282,
+  [SMALL_STATE(85)] = 3317,
+  [SMALL_STATE(86)] = 3352,
+  [SMALL_STATE(87)] = 3387,
+  [SMALL_STATE(88)] = 3422,
+  [SMALL_STATE(89)] = 3457,
+  [SMALL_STATE(90)] = 3492,
+  [SMALL_STATE(91)] = 3527,
+  [SMALL_STATE(92)] = 3544,
+  [SMALL_STATE(93)] = 3561,
+  [SMALL_STATE(94)] = 3575,
+  [SMALL_STATE(95)] = 3588,
+  [SMALL_STATE(96)] = 3601,
+  [SMALL_STATE(97)] = 3611,
+  [SMALL_STATE(98)] = 3615,
+  [SMALL_STATE(99)] = 3619,
+  [SMALL_STATE(100)] = 3623,
+  [SMALL_STATE(101)] = 3627,
+  [SMALL_STATE(102)] = 3631,
+  [SMALL_STATE(103)] = 3635,
+  [SMALL_STATE(104)] = 3639,
+  [SMALL_STATE(105)] = 3643,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {


### PR DESCRIPTION
Closes #102 

Didn't test everything imaginable, but the ones linked in the issue parse fine now

```vimdoc
vim.foo({bar})

vim.foo( {bar})

nvim_foo({bar})

nvim_foo({bar},{baz})

nvim_foo({bar}, {baz})

```

![image](https://user-images.githubusercontent.com/29718261/235328360-b4395ee1-02a7-475b-ba79-5aa0dc2b7858.png)
