### PR TITLE
feat(build): add parser build to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,21 @@
+
+.PHONY: build
+
+build: parser/vimdoc.so
+
+parser/vimdoc.so: src/parser.c
+	$(RM) $@
+	mkdir -p parser
+	$(CC) -o $@ -Isrc $^ -shared -fPIC -Os
+
+src/parser.c: grammar.js
+	tree-sitter generate
+
+.PHONY: all
 all:
-	npm run build
 	npm run test
+
+.PHONY: run
+run: all
+	tree-sitter build-wasm
+	tree-sitter web-ui


### PR DESCRIPTION
`make` builds the `parser/vimdoc.so` for Neovim, `make all` runs tests as before.