### PR TITLE
fix: argument in "vim.foo({bar})"

### DIFF
--- a/corpus/arguments.txt
+++ b/corpus/arguments.txt
@@ -93,10 +93,12 @@ nvim_buf_detach_event[{buf}]
       (word))
     (line
       (word)
+      (word)
       (argument
         (word))
       (word))
     (line
+      (word)
       (word)
       (argument
         (word))
@@ -105,6 +107,7 @@ nvim_buf_detach_event[{buf}]
         (word))
       (word))
     (line
+      (word)
       (word)
       (argument
         (word))
@@ -149,8 +152,6 @@ EXTERNAL *netrw-externapp* {{{2
       (word)
       (word)
       (word)
-      (word)
-      (word)
       (word))
     (line
       (word)
@@ -181,7 +182,6 @@ EXTERNAL *netrw-externapp* {{{2
       (word)
       (word))
     (line
-      (word)
       (word)
       (word)
       (word)

--- a/corpus/arguments.txt
+++ b/corpus/arguments.txt
@@ -37,6 +37,7 @@ list of { uri:string, name: string } tables
       (word)
       (word)
       (word)
+      (word)
       (word))))
 
 ================================================================================
@@ -61,6 +62,12 @@ multiple arguments on the same line
 argument in parentheses
 ================================================================================
 ({aaa})
+vim.foo({bar})
+vim.foo( {bar})
+nvim_foo({bar})
+nvim_foo({bar},{baz})
+nvim_foo({bar}, {baz})
+nvim_buf_detach_event[{buf}]
 
 
 --------------------------------------------------------------------------------
@@ -68,6 +75,45 @@ argument in parentheses
 (help_file
   (block
     (line
+      (word)
+      (argument
+        (word))
+      (word))
+    (line
+      (word)
+      (word)
+      (argument
+        (word))
+      (word))
+    (line
+      (word)
+      (word)
+      (argument
+        (word))
+      (word))
+    (line
+      (word)
+      (argument
+        (word))
+      (word))
+    (line
+      (word)
+      (argument
+        (word))
+      (word)
+      (argument
+        (word))
+      (word))
+    (line
+      (word)
+      (argument
+        (word))
+      (word)
+      (argument
+        (word))
+      (word))
+    (line
+      (word)
       (word)
       (argument
         (word))

--- a/corpus/codeblock.txt
+++ b/corpus/codeblock.txt
@@ -90,7 +90,6 @@ text
       (word)
       (taglink
         (word))
-      (word)
       (word))
     (line
       (codeblock
@@ -442,7 +441,7 @@ Not a language annotation: >lua is not at EOL
       (word)
       (word))
     (line
-     (word)))
+      (word)))
   (block
     (line
       (word)
@@ -452,18 +451,18 @@ Not a language annotation: >lua is not at EOL
       (word)
       (word))
     (line
-     (word)))
+      (word)))
   (block
-   (line
-    (word)
-    (word)
-    (word)
-    (word)
-    (word)
-    (word)
-    (word)
-    (word)
-    (word)
-    (word))
-   (line
-    (word))))
+    (line
+      (word)
+      (word)
+      (word)
+      (word)
+      (word)
+      (word)
+      (word)
+      (word)
+      (word)
+      (word))
+    (line
+      (word))))

--- a/corpus/codeblock.txt
+++ b/corpus/codeblock.txt
@@ -90,6 +90,7 @@ text
       (word)
       (taglink
         (word))
+      (word)
       (word))
     (line
       (codeblock
@@ -331,6 +332,7 @@ To test for a non-empty string, use empty(): >
       (word)
       (word)
       (word)
+      (word)
       (word))
     (line
       (word)
@@ -343,6 +345,8 @@ To test for a non-empty string, use empty(): >
           (line)
           (line))))
     (line
+      (word)
+      (word)
       (word)
       (word)
       (word)
@@ -393,6 +397,7 @@ codeblock stop and start on same line
       (tag
         (word)))
     (line
+      (word)
       (word)
       (word)
       (word))

--- a/corpus/heading3-column_heading.txt
+++ b/corpus/heading3-column_heading.txt
@@ -127,6 +127,7 @@ nvim_ui_try_resize({width}, {height})                   *nvim_ui_try_resize()*
   (block
     (line
       (word)
+      (word)
       (argument
         (word))
       (word)

--- a/corpus/line_block.txt
+++ b/corpus/line_block.txt
@@ -113,6 +113,7 @@ li continues
       (line))
     (line_li
       (line
+        (word)
         (word))
       (line)
       (line

--- a/corpus/optionlink.txt
+++ b/corpus/optionlink.txt
@@ -96,14 +96,12 @@ Regular	  /	:help /[
       (word)
       (word)
       (word)
-      (word)
       (ERROR
         (word))
       (word)
       (word)
       (argument
         (word))
-      (word)
       (word))
     (line
       (word)

--- a/corpus/optionlink.txt
+++ b/corpus/optionlink.txt
@@ -80,13 +80,15 @@ Regular	  /	:help /[
     (line
       (word)
       (word)
-      (word))
-    (line
-      (word)
-      (word)
       (word)
       (word))
     (line
+      (word)
+      (word)
+      (word)
+      (word))
+    (line
+      (word)
       (word)
       (word)
       (word)
@@ -117,6 +119,7 @@ Regular	  /	:help /[
       (optionlink
         (word)))
     (line
+      (word)
       (word)
       (word)
       (word)

--- a/corpus/taglink.txt
+++ b/corpus/taglink.txt
@@ -56,6 +56,8 @@ Hello |world| hello
       (taglink
         (word))
       (word)
+      (word)
+      (word)
       (word))
     (line
       (taglink

--- a/corpus/url.txt
+++ b/corpus/url.txt
@@ -51,7 +51,16 @@ markdown: [https://neovim.io/doc/user/#yay](https://neovim.io/doc/user/#yay).
       (word)
       (url
         (word))
+      (word)
       (word))
     (line
+      (word)
+      (word)
+      (url
+        (word))
+      (word)
+      (word)
+      (url
+        (word))
       (word)
       (word))))

--- a/corpus/url.txt
+++ b/corpus/url.txt
@@ -51,7 +51,6 @@ markdown: [https://neovim.io/doc/user/#yay](https://neovim.io/doc/user/#yay).
       (word)
       (url
         (word))
-      (word)
       (word))
     (line
       (word)
@@ -62,5 +61,4 @@ markdown: [https://neovim.io/doc/user/#yay](https://neovim.io/doc/user/#yay).
       (word)
       (url
         (word))
-      (word)
       (word))))

--- a/grammar.js
+++ b/grammar.js
@@ -30,10 +30,7 @@ module.exports = grammar({
       $._atom_common,
     ),
     word: ($) => choice(
-      // Try the more-restrictive pattern at higher relative precedence, so that things like
-      // "foo({a})" parse as "(word) (argument)" instead of "(word)".
-      token(prec(-1, /[^{,(\[\n\t ][^,(\[\n\t ]*/)),
-      token(prec(-2, /[^\n\t ]+/)),
+      token(prec(-1, /[^,(\[\n\t ]+/)),
       $._word_common,
     ),
 
@@ -76,16 +73,11 @@ module.exports = grammar({
       '|',
       // NOT argument:
       '{',
-      '}',
       '{}',
       /\{\{+[0-9]*/,
+
       '(',
-      ')',
       '[',
-      ']',
-      "['",
-      "']",
-      /\w+\(/,
       '~',
       // NOT codeblock: random ">" in middle of the motherflippin text.
       '>',

--- a/grammar.js
+++ b/grammar.js
@@ -32,7 +32,7 @@ module.exports = grammar({
     word: ($) => choice(
       // Try the more-restrictive pattern at higher relative precedence, so that things like
       // "foo({a})" parse as "(word) (argument)" instead of "(word)".
-      token(prec(-1, /[^\n\t{ ][^\n\t ]*/)),
+      token(prec(-1, /[^{,(\[\n\t ][^,(\[\n\t ]*/)),
       token(prec(-2, /[^\n\t ]+/)),
       $._word_common,
     ),
@@ -43,7 +43,7 @@ module.exports = grammar({
     ),
     word_noli: ($) => choice(
       // Lines contained by line_li must not start with a listitem symbol.
-      token(prec(-1, /[^-•\n\t ][^\n\t ]*/)),
+      token(prec(-1, /[^-•\n\t ][^(\[\n\t ]*/)),
       token(prec(-1, /[-•][^\n\t ]+/)),
       $._word_common,
     ),
@@ -80,10 +80,16 @@ module.exports = grammar({
       '{}',
       /\{\{+[0-9]*/,
       '(',
+      ')',
+      '[',
+      ']',
+      "['",
+      "']",
       /\w+\(/,
       '~',
       // NOT codeblock: random ">" in middle of the motherflippin text.
       '>',
+      ',',
     ),
 
     keycode: () => choice(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -43,18 +43,7 @@
             "value": -1,
             "content": {
               "type": "PATTERN",
-              "value": "[^\\n\\t{ ][^\\n\\t ]*"
-            }
-          }
-        },
-        {
-          "type": "TOKEN",
-          "content": {
-            "type": "PREC",
-            "value": -2,
-            "content": {
-              "type": "PATTERN",
-              "value": "[^\\n\\t ]+"
+              "value": "[^,(\\[\\n\\t ]+"
             }
           }
         },
@@ -92,7 +81,7 @@
             "value": -1,
             "content": {
               "type": "PATTERN",
-              "value": "[^-•\\n\\t ][^\\n\\t ]*"
+              "value": "[^-•\\n\\t ][^(\\[\\n\\t ]*"
             }
           }
         },
@@ -241,10 +230,6 @@
         },
         {
           "type": "STRING",
-          "value": "}"
-        },
-        {
-          "type": "STRING",
           "value": "{}"
         },
         {
@@ -256,8 +241,8 @@
           "value": "("
         },
         {
-          "type": "PATTERN",
-          "value": "\\w+\\("
+          "type": "STRING",
+          "value": "["
         },
         {
           "type": "STRING",
@@ -266,6 +251,10 @@
         {
           "type": "STRING",
           "value": ">"
+        },
+        {
+          "type": "STRING",
+          "value": ","
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -483,6 +483,10 @@
     "named": false
   },
   {
+    "type": ",",
+    "named": false
+  },
+  {
     "type": "<",
     "named": false
   },
@@ -492,6 +496,10 @@
   },
   {
     "type": "CTRL-{char}",
+    "named": false
+  },
+  {
+    "type": "[",
     "named": false
   },
   {

--- a/src/parser.c
+++ b/src/parser.c
@@ -15,10 +15,10 @@
 
 #define LANGUAGE_VERSION 14
 #define STATE_COUNT 107
-#define LARGE_STATE_COUNT 8
-#define SYMBOL_COUNT 84
+#define LARGE_STATE_COUNT 17
+#define SYMBOL_COUNT 83
 #define ALIAS_COUNT 1
-#define TOKEN_COUNT 49
+#define TOKEN_COUNT 48
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 3
 #define MAX_ALIAS_SEQUENCE_LENGTH 5
@@ -26,95 +26,93 @@
 
 enum {
   aux_sym_word_token1 = 1,
-  aux_sym_word_token2 = 2,
-  aux_sym_word_noli_token1 = 3,
-  aux_sym_word_noli_token2 = 4,
-  anon_sym_STAR = 5,
-  anon_sym_SQUOTE = 6,
-  aux_sym__word_common_token1 = 7,
-  aux_sym__word_common_token2 = 8,
-  anon_sym_SQUOTE2 = 9,
-  aux_sym__word_common_token3 = 10,
-  anon_sym_PIPE = 11,
-  anon_sym_LBRACE = 12,
-  anon_sym_RBRACE = 13,
-  anon_sym_LBRACE_RBRACE = 14,
-  aux_sym__word_common_token4 = 15,
-  anon_sym_LPAREN = 16,
-  aux_sym__word_common_token5 = 17,
-  anon_sym_TILDE = 18,
-  anon_sym_GT = 19,
-  aux_sym_keycode_token1 = 20,
-  aux_sym_keycode_token2 = 21,
-  aux_sym_keycode_token3 = 22,
-  aux_sym_keycode_token4 = 23,
-  aux_sym_keycode_token5 = 24,
-  anon_sym_CTRL_DASH_LBRACEchar_RBRACE = 25,
-  aux_sym_keycode_token6 = 26,
-  aux_sym_keycode_token7 = 27,
-  aux_sym_uppercase_name_token1 = 28,
-  aux_sym_uppercase_name_token2 = 29,
-  anon_sym_LT = 30,
-  aux_sym_codeblock_token1 = 31,
-  anon_sym_LF = 32,
-  anon_sym_LF2 = 33,
-  aux_sym_line_li_token1 = 34,
-  aux_sym_line_code_token1 = 35,
-  aux_sym_h1_token1 = 36,
-  aux_sym_h2_token1 = 37,
-  aux_sym_tag_token1 = 38,
-  anon_sym_STAR2 = 39,
-  sym_url_word = 40,
-  aux_sym_optionlink_token1 = 41,
-  aux_sym_taglink_token1 = 42,
-  anon_sym_PIPE2 = 43,
-  anon_sym_BQUOTE = 44,
-  aux_sym_codespan_token1 = 45,
-  anon_sym_BQUOTE2 = 46,
-  aux_sym_argument_token1 = 47,
-  anon_sym_RBRACE2 = 48,
-  sym_help_file = 49,
-  sym__atom = 50,
-  sym_word = 51,
-  sym__atom_noli = 52,
-  sym_word_noli = 53,
-  sym__atom_common = 54,
-  sym__word_common = 55,
-  sym_keycode = 56,
-  sym_uppercase_name = 57,
-  sym__uppercase_words = 58,
-  sym_block = 59,
-  sym_codeblock = 60,
-  sym__blank = 61,
-  sym_line = 62,
-  sym_line_li = 63,
-  sym_line_code = 64,
-  sym__line_noli = 65,
-  sym_column_heading = 66,
-  sym_h1 = 67,
-  sym_h2 = 68,
-  sym_h3 = 69,
-  sym_tag = 70,
-  sym_url = 71,
-  sym_optionlink = 72,
-  sym_taglink = 73,
-  sym_codespan = 74,
-  sym_argument = 75,
-  aux_sym_help_file_repeat1 = 76,
-  aux_sym_help_file_repeat2 = 77,
-  aux_sym_uppercase_name_repeat1 = 78,
-  aux_sym_block_repeat1 = 79,
-  aux_sym_block_repeat2 = 80,
-  aux_sym_codeblock_repeat1 = 81,
-  aux_sym_line_li_repeat1 = 82,
-  aux_sym_line_li_repeat2 = 83,
-  alias_sym_code = 84,
+  aux_sym_word_noli_token1 = 2,
+  aux_sym_word_noli_token2 = 3,
+  anon_sym_STAR = 4,
+  anon_sym_SQUOTE = 5,
+  aux_sym__word_common_token1 = 6,
+  aux_sym__word_common_token2 = 7,
+  anon_sym_SQUOTE2 = 8,
+  aux_sym__word_common_token3 = 9,
+  anon_sym_PIPE = 10,
+  anon_sym_LBRACE = 11,
+  anon_sym_LBRACE_RBRACE = 12,
+  aux_sym__word_common_token4 = 13,
+  anon_sym_LPAREN = 14,
+  anon_sym_LBRACK = 15,
+  anon_sym_TILDE = 16,
+  anon_sym_GT = 17,
+  anon_sym_COMMA = 18,
+  aux_sym_keycode_token1 = 19,
+  aux_sym_keycode_token2 = 20,
+  aux_sym_keycode_token3 = 21,
+  aux_sym_keycode_token4 = 22,
+  aux_sym_keycode_token5 = 23,
+  anon_sym_CTRL_DASH_LBRACEchar_RBRACE = 24,
+  aux_sym_keycode_token6 = 25,
+  aux_sym_keycode_token7 = 26,
+  aux_sym_uppercase_name_token1 = 27,
+  aux_sym_uppercase_name_token2 = 28,
+  anon_sym_LT = 29,
+  aux_sym_codeblock_token1 = 30,
+  anon_sym_LF = 31,
+  anon_sym_LF2 = 32,
+  aux_sym_line_li_token1 = 33,
+  aux_sym_line_code_token1 = 34,
+  aux_sym_h1_token1 = 35,
+  aux_sym_h2_token1 = 36,
+  aux_sym_tag_token1 = 37,
+  anon_sym_STAR2 = 38,
+  sym_url_word = 39,
+  aux_sym_optionlink_token1 = 40,
+  aux_sym_taglink_token1 = 41,
+  anon_sym_PIPE2 = 42,
+  anon_sym_BQUOTE = 43,
+  aux_sym_codespan_token1 = 44,
+  anon_sym_BQUOTE2 = 45,
+  aux_sym_argument_token1 = 46,
+  anon_sym_RBRACE = 47,
+  sym_help_file = 48,
+  sym__atom = 49,
+  sym_word = 50,
+  sym__atom_noli = 51,
+  sym_word_noli = 52,
+  sym__atom_common = 53,
+  sym__word_common = 54,
+  sym_keycode = 55,
+  sym_uppercase_name = 56,
+  sym__uppercase_words = 57,
+  sym_block = 58,
+  sym_codeblock = 59,
+  sym__blank = 60,
+  sym_line = 61,
+  sym_line_li = 62,
+  sym_line_code = 63,
+  sym__line_noli = 64,
+  sym_column_heading = 65,
+  sym_h1 = 66,
+  sym_h2 = 67,
+  sym_h3 = 68,
+  sym_tag = 69,
+  sym_url = 70,
+  sym_optionlink = 71,
+  sym_taglink = 72,
+  sym_codespan = 73,
+  sym_argument = 74,
+  aux_sym_help_file_repeat1 = 75,
+  aux_sym_help_file_repeat2 = 76,
+  aux_sym_uppercase_name_repeat1 = 77,
+  aux_sym_block_repeat1 = 78,
+  aux_sym_block_repeat2 = 79,
+  aux_sym_codeblock_repeat1 = 80,
+  aux_sym_line_li_repeat1 = 81,
+  aux_sym_line_li_repeat2 = 82,
+  alias_sym_code = 83,
 };
 
 static const char * const ts_symbol_names[] = {
   [ts_builtin_sym_end] = "end",
   [aux_sym_word_token1] = "word_token1",
-  [aux_sym_word_token2] = "word_token2",
   [aux_sym_word_noli_token1] = "word_noli_token1",
   [aux_sym_word_noli_token2] = "word_noli_token2",
   [anon_sym_STAR] = "*",
@@ -125,13 +123,13 @@ static const char * const ts_symbol_names[] = {
   [aux_sym__word_common_token3] = "_word_common_token3",
   [anon_sym_PIPE] = "|",
   [anon_sym_LBRACE] = "{",
-  [anon_sym_RBRACE] = "}",
   [anon_sym_LBRACE_RBRACE] = "{}",
   [aux_sym__word_common_token4] = "_word_common_token4",
   [anon_sym_LPAREN] = "(",
-  [aux_sym__word_common_token5] = "_word_common_token5",
+  [anon_sym_LBRACK] = "[",
   [anon_sym_TILDE] = "~",
   [anon_sym_GT] = ">",
+  [anon_sym_COMMA] = ",",
   [aux_sym_keycode_token1] = "keycode_token1",
   [aux_sym_keycode_token2] = "keycode_token2",
   [aux_sym_keycode_token3] = "keycode_token3",
@@ -160,7 +158,7 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_codespan_token1] = "word",
   [anon_sym_BQUOTE2] = "`",
   [aux_sym_argument_token1] = "word",
-  [anon_sym_RBRACE2] = "}",
+  [anon_sym_RBRACE] = "}",
   [sym_help_file] = "help_file",
   [sym__atom] = "_atom",
   [sym_word] = "word",
@@ -202,7 +200,6 @@ static const char * const ts_symbol_names[] = {
 static const TSSymbol ts_symbol_map[] = {
   [ts_builtin_sym_end] = ts_builtin_sym_end,
   [aux_sym_word_token1] = aux_sym_word_token1,
-  [aux_sym_word_token2] = aux_sym_word_token2,
   [aux_sym_word_noli_token1] = aux_sym_word_noli_token1,
   [aux_sym_word_noli_token2] = aux_sym_word_noli_token2,
   [anon_sym_STAR] = anon_sym_STAR,
@@ -213,13 +210,13 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym__word_common_token3] = aux_sym__word_common_token3,
   [anon_sym_PIPE] = anon_sym_PIPE,
   [anon_sym_LBRACE] = anon_sym_LBRACE,
-  [anon_sym_RBRACE] = anon_sym_RBRACE,
   [anon_sym_LBRACE_RBRACE] = anon_sym_LBRACE_RBRACE,
   [aux_sym__word_common_token4] = aux_sym__word_common_token4,
   [anon_sym_LPAREN] = anon_sym_LPAREN,
-  [aux_sym__word_common_token5] = aux_sym__word_common_token5,
+  [anon_sym_LBRACK] = anon_sym_LBRACK,
   [anon_sym_TILDE] = anon_sym_TILDE,
   [anon_sym_GT] = anon_sym_GT,
+  [anon_sym_COMMA] = anon_sym_COMMA,
   [aux_sym_keycode_token1] = aux_sym_keycode_token1,
   [aux_sym_keycode_token2] = aux_sym_keycode_token2,
   [aux_sym_keycode_token3] = aux_sym_keycode_token3,
@@ -248,7 +245,7 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_codespan_token1] = sym_word,
   [anon_sym_BQUOTE2] = anon_sym_BQUOTE,
   [aux_sym_argument_token1] = sym_word,
-  [anon_sym_RBRACE2] = anon_sym_RBRACE,
+  [anon_sym_RBRACE] = anon_sym_RBRACE,
   [sym_help_file] = sym_help_file,
   [sym__atom] = sym__atom,
   [sym_word] = sym_word,
@@ -296,10 +293,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
-  [aux_sym_word_token2] = {
-    .visible = false,
-    .named = false,
-  },
   [aux_sym_word_noli_token1] = {
     .visible = false,
     .named = false,
@@ -340,10 +333,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [anon_sym_RBRACE] = {
-    .visible = true,
-    .named = false,
-  },
   [anon_sym_LBRACE_RBRACE] = {
     .visible = true,
     .named = false,
@@ -356,8 +345,8 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [aux_sym__word_common_token5] = {
-    .visible = false,
+  [anon_sym_LBRACK] = {
+    .visible = true,
     .named = false,
   },
   [anon_sym_TILDE] = {
@@ -365,6 +354,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [anon_sym_GT] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_COMMA] = {
     .visible = true,
     .named = false,
   },
@@ -480,7 +473,7 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [anon_sym_RBRACE2] = {
+  [anon_sym_RBRACE] = {
     .visible = true,
     .named = false,
   },
@@ -852,2436 +845,2523 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   switch (state) {
     case 0:
       if (eof) ADVANCE(30);
-      if (lookahead == '\n') ADVANCE(376);
-      if (lookahead == '\'') ADVANCE(445);
-      if (lookahead == '(') ADVANCE(445);
-      if (lookahead == '*') ADVANCE(446);
-      if (lookahead == '<') ADVANCE(443);
-      if (lookahead == '>') ADVANCE(445);
-      if (lookahead == 'A') ADVANCE(391);
-      if (lookahead == 'C') ADVANCE(394);
-      if (lookahead == 'M') ADVANCE(390);
-      if (lookahead == '`') ADVANCE(445);
-      if (lookahead == 'h') ADVANCE(401);
-      if (lookahead == '{') ADVANCE(438);
-      if (lookahead == '|') ADVANCE(445);
-      if (lookahead == '}') ADVANCE(445);
-      if (lookahead == '~') ADVANCE(445);
+      if (lookahead == '\n') ADVANCE(375);
+      if (lookahead == '\'') ADVANCE(443);
+      if (lookahead == '(') ADVANCE(444);
+      if (lookahead == '*') ADVANCE(445);
+      if (lookahead == ',') ADVANCE(444);
+      if (lookahead == '<') ADVANCE(440);
+      if (lookahead == '>') ADVANCE(443);
+      if (lookahead == 'A') ADVANCE(400);
+      if (lookahead == 'C') ADVANCE(403);
+      if (lookahead == 'M') ADVANCE(396);
+      if (lookahead == '[') ADVANCE(444);
+      if (lookahead == '`') ADVANCE(443);
+      if (lookahead == 'h') ADVANCE(430);
+      if (lookahead == '{') ADVANCE(434);
+      if (lookahead == '|') ADVANCE(443);
+      if (lookahead == '}') ADVANCE(443);
+      if (lookahead == '~') ADVANCE(443);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(27)
-      if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(445);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(403);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(404);
-      if (lookahead != 0) ADVANCE(445);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(442);
+      if (lookahead != 0) ADVANCE(443);
       END_STATE();
     case 1:
       if (lookahead == '\t') ADVANCE(21);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == ' ') ADVANCE(378);
-      if (lookahead != 0) ADVANCE(213);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == ' ') ADVANCE(377);
+      if (lookahead != 0) ADVANCE(208);
       END_STATE();
     case 2:
-      if (lookahead == '\n') ADVANCE(376);
-      if (lookahead == '\'') ADVANCE(229);
-      if (lookahead == '(') ADVANCE(265);
-      if (lookahead == '*') ADVANCE(225);
-      if (lookahead == '<') ADVANCE(90);
-      if (lookahead == '>') ADVANCE(278);
-      if (lookahead == 'A') ADVANCE(44);
-      if (lookahead == 'C') ADVANCE(47);
-      if (lookahead == 'M') ADVANCE(43);
-      if (lookahead == '`') ADVANCE(511);
-      if (lookahead == 'h') ADVANCE(52);
-      if (lookahead == '{') ADVANCE(253);
-      if (lookahead == '|') ADVANCE(249);
-      if (lookahead == '}') ADVANCE(256);
-      if (lookahead == '~') ADVANCE(274);
+      if (lookahead == '\n') ADVANCE(375);
+      if (lookahead == '\'') ADVANCE(224);
+      if (lookahead == '(') ADVANCE(255);
+      if (lookahead == '*') ADVANCE(220);
+      if (lookahead == ',') ADVANCE(273);
+      if (lookahead == '<') ADVANCE(89);
+      if (lookahead == '>') ADVANCE(269);
+      if (lookahead == 'A') ADVANCE(57);
+      if (lookahead == 'C') ADVANCE(60);
+      if (lookahead == 'M') ADVANCE(54);
+      if (lookahead == '[') ADVANCE(261);
+      if (lookahead == '`') ADVANCE(513);
+      if (lookahead == 'h') ADVANCE(82);
+      if (lookahead == '{') ADVANCE(246);
+      if (lookahead == '|') ADVANCE(242);
+      if (lookahead == '~') ADVANCE(265);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(5)
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (lookahead != 0) ADVANCE(92);
+      if (lookahead != 0) ADVANCE(90);
       END_STATE();
     case 3:
-      if (lookahead == '\n') ADVANCE(376);
-      if (lookahead == '\'') ADVANCE(229);
-      if (lookahead == '(') ADVANCE(265);
-      if (lookahead == '*') ADVANCE(225);
-      if (lookahead == '<') ADVANCE(90);
-      if (lookahead == '>') ADVANCE(278);
-      if (lookahead == 'A') ADVANCE(44);
-      if (lookahead == 'C') ADVANCE(47);
-      if (lookahead == 'M') ADVANCE(43);
-      if (lookahead == '`') ADVANCE(511);
+      if (lookahead == '\n') ADVANCE(375);
+      if (lookahead == '\'') ADVANCE(224);
+      if (lookahead == '(') ADVANCE(255);
+      if (lookahead == '*') ADVANCE(220);
+      if (lookahead == ',') ADVANCE(273);
+      if (lookahead == '<') ADVANCE(89);
+      if (lookahead == '>') ADVANCE(269);
+      if (lookahead == 'A') ADVANCE(57);
+      if (lookahead == 'C') ADVANCE(60);
+      if (lookahead == 'M') ADVANCE(54);
+      if (lookahead == '[') ADVANCE(261);
+      if (lookahead == '`') ADVANCE(513);
       if (lookahead == 'h') ADVANCE(35);
-      if (lookahead == '{') ADVANCE(253);
-      if (lookahead == '|') ADVANCE(249);
-      if (lookahead == '}') ADVANCE(256);
-      if (lookahead == '~') ADVANCE(274);
+      if (lookahead == '{') ADVANCE(246);
+      if (lookahead == '|') ADVANCE(242);
+      if (lookahead == '~') ADVANCE(265);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(5)
-      if (('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(53);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(36);
-      if (lookahead != 0) ADVANCE(92);
+      if (lookahead != 0) ADVANCE(90);
       END_STATE();
     case 4:
-      if (lookahead == '\n') ADVANCE(377);
-      if (lookahead == '\'') ADVANCE(445);
-      if (lookahead == '(') ADVANCE(445);
-      if (lookahead == '*') ADVANCE(225);
-      if (lookahead == '<') ADVANCE(443);
-      if (lookahead == '>') ADVANCE(445);
-      if (lookahead == 'A') ADVANCE(391);
-      if (lookahead == 'C') ADVANCE(394);
-      if (lookahead == 'M') ADVANCE(390);
-      if (lookahead == '`') ADVANCE(445);
-      if (lookahead == 'h') ADVANCE(402);
-      if (lookahead == '{') ADVANCE(438);
-      if (lookahead == '|') ADVANCE(440);
-      if (lookahead == '}') ADVANCE(445);
-      if (lookahead == '~') ADVANCE(445);
+      if (lookahead == '\n') ADVANCE(376);
+      if (lookahead == '\'') ADVANCE(443);
+      if (lookahead == '(') ADVANCE(444);
+      if (lookahead == '*') ADVANCE(220);
+      if (lookahead == ',') ADVANCE(444);
+      if (lookahead == '<') ADVANCE(440);
+      if (lookahead == '>') ADVANCE(443);
+      if (lookahead == 'A') ADVANCE(400);
+      if (lookahead == 'C') ADVANCE(403);
+      if (lookahead == 'M') ADVANCE(396);
+      if (lookahead == '[') ADVANCE(444);
+      if (lookahead == '`') ADVANCE(443);
+      if (lookahead == 'h') ADVANCE(432);
+      if (lookahead == '{') ADVANCE(434);
+      if (lookahead == '|') ADVANCE(436);
+      if (lookahead == '~') ADVANCE(443);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(5)
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(404);
-      if (lookahead != 0) ADVANCE(445);
+      if (lookahead != 0) ADVANCE(443);
       END_STATE();
     case 5:
-      if (lookahead == '\n') ADVANCE(377);
-      if (lookahead == '\'') ADVANCE(229);
-      if (lookahead == '(') ADVANCE(265);
-      if (lookahead == '*') ADVANCE(225);
-      if (lookahead == '<') ADVANCE(90);
-      if (lookahead == '>') ADVANCE(278);
-      if (lookahead == 'A') ADVANCE(44);
-      if (lookahead == 'C') ADVANCE(47);
-      if (lookahead == 'M') ADVANCE(43);
-      if (lookahead == '`') ADVANCE(511);
-      if (lookahead == 'h') ADVANCE(52);
-      if (lookahead == '{') ADVANCE(253);
-      if (lookahead == '|') ADVANCE(249);
-      if (lookahead == '}') ADVANCE(256);
-      if (lookahead == '~') ADVANCE(274);
+      if (lookahead == '\n') ADVANCE(376);
+      if (lookahead == '\'') ADVANCE(224);
+      if (lookahead == '(') ADVANCE(255);
+      if (lookahead == '*') ADVANCE(220);
+      if (lookahead == ',') ADVANCE(273);
+      if (lookahead == '<') ADVANCE(89);
+      if (lookahead == '>') ADVANCE(269);
+      if (lookahead == 'A') ADVANCE(57);
+      if (lookahead == 'C') ADVANCE(60);
+      if (lookahead == 'M') ADVANCE(54);
+      if (lookahead == '[') ADVANCE(261);
+      if (lookahead == '`') ADVANCE(513);
+      if (lookahead == 'h') ADVANCE(82);
+      if (lookahead == '{') ADVANCE(246);
+      if (lookahead == '|') ADVANCE(242);
+      if (lookahead == '~') ADVANCE(265);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(5)
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (lookahead != 0) ADVANCE(92);
+      if (lookahead != 0) ADVANCE(90);
       END_STATE();
     case 6:
-      if (lookahead == '\n') ADVANCE(377);
-      if (lookahead == '\'') ADVANCE(229);
-      if (lookahead == '(') ADVANCE(265);
-      if (lookahead == '*') ADVANCE(225);
-      if (lookahead == '<') ADVANCE(209);
-      if (lookahead == '>') ADVANCE(278);
-      if (lookahead == 'A') ADVANCE(152);
-      if (lookahead == 'C') ADVANCE(155);
-      if (lookahead == 'M') ADVANCE(151);
-      if (lookahead == '`') ADVANCE(511);
-      if (lookahead == 'h') ADVANCE(160);
-      if (lookahead == '{') ADVANCE(253);
-      if (lookahead == '|') ADVANCE(249);
-      if (lookahead == '}') ADVANCE(256);
-      if (lookahead == '~') ADVANCE(274);
+      if (lookahead == '\n') ADVANCE(376);
+      if (lookahead == '\'') ADVANCE(224);
+      if (lookahead == '(') ADVANCE(255);
+      if (lookahead == '*') ADVANCE(220);
+      if (lookahead == ',') ADVANCE(273);
+      if (lookahead == '<') ADVANCE(205);
+      if (lookahead == '>') ADVANCE(269);
+      if (lookahead == 'A') ADVANCE(173);
+      if (lookahead == 'C') ADVANCE(176);
+      if (lookahead == 'M') ADVANCE(170);
+      if (lookahead == '[') ADVANCE(261);
+      if (lookahead == '`') ADVANCE(513);
+      if (lookahead == 'h') ADVANCE(198);
+      if (lookahead == '{') ADVANCE(246);
+      if (lookahead == '|') ADVANCE(242);
+      if (lookahead == '~') ADVANCE(265);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(6)
       if (lookahead == '-' ||
           lookahead == 8226) ADVANCE(24);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(161);
-      if (lookahead != 0) ADVANCE(211);
+      if (lookahead != 0) ADVANCE(206);
       END_STATE();
     case 7:
-      if (lookahead == '\n') ADVANCE(377);
-      if (lookahead == '\'') ADVANCE(229);
-      if (lookahead == '(') ADVANCE(268);
-      if (lookahead == '*') ADVANCE(225);
+      if (lookahead == '\n') ADVANCE(376);
+      if (lookahead == '\'') ADVANCE(224);
+      if (lookahead == '(') ADVANCE(257);
+      if (lookahead == '*') ADVANCE(220);
+      if (lookahead == ',') ADVANCE(273);
       if (lookahead == '-') ADVANCE(23);
-      if (lookahead == '<') ADVANCE(374);
-      if (lookahead == '=') ADVANCE(178);
-      if (lookahead == '>') ADVANCE(278);
-      if (lookahead == 'A') ADVANCE(163);
-      if (lookahead == 'C') ADVANCE(164);
-      if (lookahead == 'M') ADVANCE(162);
-      if (lookahead == '`') ADVANCE(511);
-      if (lookahead == 'h') ADVANCE(160);
-      if (lookahead == '{') ADVANCE(253);
-      if (lookahead == '|') ADVANCE(249);
-      if (lookahead == '}') ADVANCE(256);
-      if (lookahead == '~') ADVANCE(274);
+      if (lookahead == '<') ADVANCE(373);
+      if (lookahead == '=') ADVANCE(163);
+      if (lookahead == '>') ADVANCE(269);
+      if (lookahead == 'A') ADVANCE(143);
+      if (lookahead == 'C') ADVANCE(144);
+      if (lookahead == 'M') ADVANCE(142);
+      if (lookahead == '[') ADVANCE(261);
+      if (lookahead == '`') ADVANCE(513);
+      if (lookahead == 'h') ADVANCE(198);
+      if (lookahead == '{') ADVANCE(246);
+      if (lookahead == '|') ADVANCE(242);
+      if (lookahead == '~') ADVANCE(265);
       if (lookahead == 8226) ADVANCE(24);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(12);
       if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(210);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(161);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(165);
-      if (lookahead != 0) ADVANCE(211);
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(145);
+      if (lookahead != 0) ADVANCE(206);
       END_STATE();
     case 8:
-      if (lookahead == '\n') ADVANCE(377);
-      if (lookahead == '\'') ADVANCE(229);
-      if (lookahead == '(') ADVANCE(268);
-      if (lookahead == '*') ADVANCE(225);
-      if (lookahead == '<') ADVANCE(374);
-      if (lookahead == '>') ADVANCE(278);
-      if (lookahead == 'A') ADVANCE(163);
-      if (lookahead == 'C') ADVANCE(164);
-      if (lookahead == 'M') ADVANCE(162);
-      if (lookahead == '`') ADVANCE(511);
-      if (lookahead == 'h') ADVANCE(160);
-      if (lookahead == '{') ADVANCE(253);
-      if (lookahead == '|') ADVANCE(249);
-      if (lookahead == '}') ADVANCE(256);
-      if (lookahead == '~') ADVANCE(274);
+      if (lookahead == '\n') ADVANCE(376);
+      if (lookahead == '\'') ADVANCE(224);
+      if (lookahead == '(') ADVANCE(257);
+      if (lookahead == '*') ADVANCE(220);
+      if (lookahead == ',') ADVANCE(273);
+      if (lookahead == '<') ADVANCE(373);
+      if (lookahead == '>') ADVANCE(269);
+      if (lookahead == 'A') ADVANCE(143);
+      if (lookahead == 'C') ADVANCE(144);
+      if (lookahead == 'M') ADVANCE(142);
+      if (lookahead == '[') ADVANCE(261);
+      if (lookahead == '`') ADVANCE(513);
+      if (lookahead == 'h') ADVANCE(198);
+      if (lookahead == '{') ADVANCE(246);
+      if (lookahead == '|') ADVANCE(242);
+      if (lookahead == '~') ADVANCE(265);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(6)
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(210);
       if (lookahead == '-' ||
           lookahead == 8226) ADVANCE(24);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(161);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(165);
-      if (lookahead != 0) ADVANCE(211);
+      if (lookahead == ')' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(145);
+      if (lookahead != 0) ADVANCE(206);
       END_STATE();
     case 9:
-      if (lookahead == '\n') ADVANCE(377);
-      if (lookahead == '\'') ADVANCE(229);
-      if (lookahead == '(') ADVANCE(268);
-      if (lookahead == '*') ADVANCE(225);
-      if (lookahead == '<') ADVANCE(374);
-      if (lookahead == '>') ADVANCE(278);
-      if (lookahead == 'A') ADVANCE(163);
-      if (lookahead == 'C') ADVANCE(164);
-      if (lookahead == 'M') ADVANCE(162);
-      if (lookahead == '`') ADVANCE(511);
-      if (lookahead == 'h') ADVANCE(160);
-      if (lookahead == '{') ADVANCE(253);
-      if (lookahead == '|') ADVANCE(249);
-      if (lookahead == '}') ADVANCE(256);
-      if (lookahead == '~') ADVANCE(274);
+      if (lookahead == '\n') ADVANCE(376);
+      if (lookahead == '\'') ADVANCE(224);
+      if (lookahead == '(') ADVANCE(257);
+      if (lookahead == '*') ADVANCE(220);
+      if (lookahead == ',') ADVANCE(273);
+      if (lookahead == '<') ADVANCE(373);
+      if (lookahead == '>') ADVANCE(269);
+      if (lookahead == 'A') ADVANCE(143);
+      if (lookahead == 'C') ADVANCE(144);
+      if (lookahead == 'M') ADVANCE(142);
+      if (lookahead == '[') ADVANCE(261);
+      if (lookahead == '`') ADVANCE(513);
+      if (lookahead == 'h') ADVANCE(198);
+      if (lookahead == '{') ADVANCE(246);
+      if (lookahead == '|') ADVANCE(242);
+      if (lookahead == '~') ADVANCE(265);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(12);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(210);
       if (lookahead == '-' ||
           lookahead == 8226) ADVANCE(24);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(161);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(165);
-      if (lookahead != 0) ADVANCE(211);
+      if (lookahead == ')' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(145);
+      if (lookahead != 0) ADVANCE(206);
       END_STATE();
     case 10:
-      if (lookahead == '\n') ADVANCE(377);
-      if (lookahead == '\'') ADVANCE(229);
-      if (lookahead == '(') ADVANCE(267);
-      if (lookahead == '*') ADVANCE(227);
-      if (lookahead == '<') ADVANCE(238);
-      if (lookahead == '>') ADVANCE(280);
-      if (lookahead == 'A') ADVANCE(233);
-      if (lookahead == 'C') ADVANCE(234);
-      if (lookahead == 'M') ADVANCE(232);
-      if (lookahead == '`') ADVANCE(513);
-      if (lookahead == 'h') ADVANCE(236);
-      if (lookahead == '{') ADVANCE(254);
-      if (lookahead == '|') ADVANCE(250);
-      if (lookahead == '}') ADVANCE(258);
-      if (lookahead == '~') ADVANCE(276);
+      if (lookahead == '\n') ADVANCE(376);
+      if (lookahead == '\'') ADVANCE(224);
+      if (lookahead == '(') ADVANCE(258);
+      if (lookahead == '*') ADVANCE(223);
+      if (lookahead == ',') ADVANCE(275);
+      if (lookahead == '<') ADVANCE(232);
+      if (lookahead == '>') ADVANCE(272);
+      if (lookahead == 'A') ADVANCE(228);
+      if (lookahead == 'C') ADVANCE(229);
+      if (lookahead == 'M') ADVANCE(227);
+      if (lookahead == '[') ADVANCE(263);
+      if (lookahead == '`') ADVANCE(516);
+      if (lookahead == 'h') ADVANCE(230);
+      if (lookahead == '{') ADVANCE(247);
+      if (lookahead == '|') ADVANCE(243);
+      if (lookahead == '~') ADVANCE(268);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(5)
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(237);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(235);
-      if (lookahead != 0) ADVANCE(239);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(231);
+      if (lookahead != 0) ADVANCE(233);
       END_STATE();
     case 11:
-      if (lookahead == '\n') ADVANCE(377);
-      if (lookahead == '\'') ADVANCE(229);
-      if (lookahead == '(') ADVANCE(269);
-      if (lookahead == '*') ADVANCE(225);
-      if (lookahead == '<') ADVANCE(90);
-      if (lookahead == '>') ADVANCE(278);
-      if (lookahead == 'A') ADVANCE(55);
-      if (lookahead == 'C') ADVANCE(56);
-      if (lookahead == 'M') ADVANCE(54);
-      if (lookahead == '`') ADVANCE(511);
-      if (lookahead == 'h') ADVANCE(52);
-      if (lookahead == '{') ADVANCE(253);
-      if (lookahead == '|') ADVANCE(249);
-      if (lookahead == '}') ADVANCE(256);
-      if (lookahead == '~') ADVANCE(274);
+      if (lookahead == '\n') ADVANCE(376);
+      if (lookahead == '\'') ADVANCE(224);
+      if (lookahead == '(') ADVANCE(259);
+      if (lookahead == '*') ADVANCE(220);
+      if (lookahead == ',') ADVANCE(273);
+      if (lookahead == '<') ADVANCE(89);
+      if (lookahead == '>') ADVANCE(269);
+      if (lookahead == 'A') ADVANCE(38);
+      if (lookahead == 'C') ADVANCE(39);
+      if (lookahead == 'M') ADVANCE(37);
+      if (lookahead == '[') ADVANCE(261);
+      if (lookahead == '`') ADVANCE(513);
+      if (lookahead == 'h') ADVANCE(82);
+      if (lookahead == '{') ADVANCE(246);
+      if (lookahead == '|') ADVANCE(242);
+      if (lookahead == '~') ADVANCE(265);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(11)
       if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(91);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(57);
-      if (lookahead != 0) ADVANCE(92);
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(40);
+      if (lookahead != 0) ADVANCE(90);
       END_STATE();
     case 12:
-      if (lookahead == '\n') ADVANCE(377);
-      if (lookahead == '\'') ADVANCE(230);
-      if (lookahead == '(') ADVANCE(266);
-      if (lookahead == '*') ADVANCE(226);
-      if (lookahead == '<') ADVANCE(140);
-      if (lookahead == '>') ADVANCE(279);
-      if (lookahead == 'A') ADVANCE(101);
-      if (lookahead == 'C') ADVANCE(104);
-      if (lookahead == 'M') ADVANCE(100);
-      if (lookahead == '`') ADVANCE(512);
-      if (lookahead == 'h') ADVANCE(109);
-      if (lookahead == '{') ADVANCE(252);
-      if (lookahead == '|') ADVANCE(248);
-      if (lookahead == '}') ADVANCE(257);
-      if (lookahead == '~') ADVANCE(275);
+      if (lookahead == '\n') ADVANCE(376);
+      if (lookahead == '\'') ADVANCE(225);
+      if (lookahead == '(') ADVANCE(256);
+      if (lookahead == '*') ADVANCE(221);
+      if (lookahead == ',') ADVANCE(274);
+      if (lookahead == '<') ADVANCE(137);
+      if (lookahead == '>') ADVANCE(270);
+      if (lookahead == 'A') ADVANCE(108);
+      if (lookahead == 'C') ADVANCE(111);
+      if (lookahead == 'M') ADVANCE(105);
+      if (lookahead == '[') ADVANCE(262);
+      if (lookahead == '`') ADVANCE(514);
+      if (lookahead == 'h') ADVANCE(133);
+      if (lookahead == '{') ADVANCE(245);
+      if (lookahead == '|') ADVANCE(241);
+      if (lookahead == '~') ADVANCE(266);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(12);
       if (lookahead == '-' ||
           lookahead == 8226) ADVANCE(1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(110);
-      if (lookahead != 0) ADVANCE(141);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 13:
-      if (lookahead == '\n') ADVANCE(377);
-      if (lookahead == '\'') ADVANCE(509);
-      if (lookahead == '(') ADVANCE(509);
-      if (lookahead == '*') ADVANCE(509);
-      if (lookahead == '<') ADVANCE(507);
-      if (lookahead == '>') ADVANCE(509);
-      if (lookahead == 'A') ADVANCE(460);
-      if (lookahead == 'C') ADVANCE(463);
-      if (lookahead == 'M') ADVANCE(459);
-      if (lookahead == '`') ADVANCE(509);
-      if (lookahead == 'h') ADVANCE(468);
+      if (lookahead == '\n') ADVANCE(376);
+      if (lookahead == '\'') ADVANCE(510);
+      if (lookahead == '(') ADVANCE(511);
+      if (lookahead == '*') ADVANCE(510);
+      if (lookahead == ',') ADVANCE(511);
+      if (lookahead == '<') ADVANCE(508);
+      if (lookahead == '>') ADVANCE(510);
+      if (lookahead == 'A') ADVANCE(472);
+      if (lookahead == 'C') ADVANCE(475);
+      if (lookahead == 'M') ADVANCE(468);
+      if (lookahead == '[') ADVANCE(511);
+      if (lookahead == '`') ADVANCE(510);
+      if (lookahead == 'h') ADVANCE(501);
       if (lookahead == '{') ADVANCE(503);
-      if (lookahead == '|') ADVANCE(249);
-      if (lookahead == '}') ADVANCE(509);
-      if (lookahead == '~') ADVANCE(509);
+      if (lookahead == '|') ADVANCE(242);
+      if (lookahead == '~') ADVANCE(510);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(5)
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(469);
-      if (lookahead != 0) ADVANCE(509);
+      if (lookahead != 0) ADVANCE(510);
       END_STATE();
     case 14:
-      if (lookahead == '\n') ADVANCE(377);
-      if (lookahead == '\'') ADVANCE(244);
-      if (lookahead == '(') ADVANCE(265);
-      if (lookahead == '*') ADVANCE(225);
-      if (lookahead == '<') ADVANCE(90);
-      if (lookahead == '>') ADVANCE(278);
-      if (lookahead == 'A') ADVANCE(44);
-      if (lookahead == 'C') ADVANCE(47);
-      if (lookahead == 'M') ADVANCE(43);
-      if (lookahead == '`') ADVANCE(511);
-      if (lookahead == 'h') ADVANCE(52);
-      if (lookahead == '{') ADVANCE(253);
-      if (lookahead == '|') ADVANCE(249);
-      if (lookahead == '}') ADVANCE(256);
-      if (lookahead == '~') ADVANCE(274);
+      if (lookahead == '\n') ADVANCE(376);
+      if (lookahead == '\'') ADVANCE(237);
+      if (lookahead == '(') ADVANCE(255);
+      if (lookahead == '*') ADVANCE(220);
+      if (lookahead == ',') ADVANCE(273);
+      if (lookahead == '<') ADVANCE(89);
+      if (lookahead == '>') ADVANCE(269);
+      if (lookahead == 'A') ADVANCE(57);
+      if (lookahead == 'C') ADVANCE(60);
+      if (lookahead == 'M') ADVANCE(54);
+      if (lookahead == '[') ADVANCE(261);
+      if (lookahead == '`') ADVANCE(513);
+      if (lookahead == 'h') ADVANCE(82);
+      if (lookahead == '{') ADVANCE(246);
+      if (lookahead == '|') ADVANCE(242);
+      if (lookahead == '~') ADVANCE(265);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(5)
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (lookahead != 0) ADVANCE(92);
+      if (lookahead != 0) ADVANCE(90);
       END_STATE();
     case 15:
-      if (lookahead == '\n') ADVANCE(377);
-      if (lookahead == '\'') ADVANCE(231);
-      if (lookahead == '(') ADVANCE(270);
-      if (lookahead == '*') ADVANCE(228);
-      if (lookahead == '<') ADVANCE(574);
-      if (lookahead == '>') ADVANCE(281);
-      if (lookahead == 'A') ADVANCE(524);
-      if (lookahead == 'C') ADVANCE(527);
-      if (lookahead == 'M') ADVANCE(523);
-      if (lookahead == '`') ADVANCE(514);
-      if (lookahead == 'h') ADVANCE(532);
-      if (lookahead == '{') ADVANCE(255);
-      if (lookahead == '|') ADVANCE(251);
-      if (lookahead == '}') ADVANCE(256);
-      if (lookahead == '~') ADVANCE(277);
+      if (lookahead == '\n') ADVANCE(376);
+      if (lookahead == '\'') ADVANCE(226);
+      if (lookahead == '(') ADVANCE(260);
+      if (lookahead == '*') ADVANCE(222);
+      if (lookahead == ',') ADVANCE(276);
+      if (lookahead == '<') ADVANCE(577);
+      if (lookahead == '>') ADVANCE(271);
+      if (lookahead == 'A') ADVANCE(537);
+      if (lookahead == 'C') ADVANCE(540);
+      if (lookahead == 'M') ADVANCE(533);
+      if (lookahead == '[') ADVANCE(264);
+      if (lookahead == '`') ADVANCE(515);
+      if (lookahead == 'h') ADVANCE(567);
+      if (lookahead == '{') ADVANCE(248);
+      if (lookahead == '|') ADVANCE(244);
+      if (lookahead == '}') ADVANCE(90);
+      if (lookahead == '~') ADVANCE(267);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(5)
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(533);
-      if (lookahead != 0) ADVANCE(576);
+      if (lookahead != 0) ADVANCE(579);
       END_STATE();
     case 16:
-      if (lookahead == '\n') ADVANCE(377);
-      if (lookahead == '*') ADVANCE(446);
-      if (lookahead == '<') ADVANCE(373);
-      if (lookahead == '`') ADVANCE(516);
-      if (lookahead == '|') ADVANCE(510);
-      if (lookahead == '}') ADVANCE(577);
+      if (lookahead == '\n') ADVANCE(376);
+      if (lookahead == '*') ADVANCE(445);
+      if (lookahead == '<') ADVANCE(372);
+      if (lookahead == '`') ADVANCE(518);
+      if (lookahead == '|') ADVANCE(512);
+      if (lookahead == '}') ADVANCE(581);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(17)
       if (lookahead == '-' ||
           lookahead == 8226) ADVANCE(22);
       END_STATE();
     case 17:
-      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '\n') ADVANCE(376);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(17)
       if (lookahead == '-' ||
           lookahead == 8226) ADVANCE(22);
       END_STATE();
     case 18:
-      if (lookahead == '\n') ADVANCE(382);
+      if (lookahead == '\n') ADVANCE(381);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(18);
       END_STATE();
     case 19:
-      if (lookahead == '\n') ADVANCE(381);
+      if (lookahead == '\n') ADVANCE(380);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(19);
       END_STATE();
     case 20:
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '>') ADVANCE(288);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '>') ADVANCE(283);
       if (lookahead != 0) ADVANCE(21);
       END_STATE();
     case 21:
-      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '\n') ADVANCE(379);
       if (lookahead != 0) ADVANCE(21);
       END_STATE();
     case 22:
-      if (lookahead == ' ') ADVANCE(379);
+      if (lookahead == ' ') ADVANCE(378);
       END_STATE();
     case 23:
-      if (lookahead == ' ') ADVANCE(379);
-      if (lookahead == '-') ADVANCE(223);
+      if (lookahead == ' ') ADVANCE(378);
+      if (lookahead == '-') ADVANCE(218);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(224);
+          lookahead != '\n') ADVANCE(219);
       END_STATE();
     case 24:
-      if (lookahead == ' ') ADVANCE(379);
+      if (lookahead == ' ') ADVANCE(378);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(224);
+          lookahead != '\n') ADVANCE(219);
       END_STATE();
     case 25:
-      if (lookahead == '>') ADVANCE(286);
+      if (lookahead == '>') ADVANCE(281);
       END_STATE();
     case 26:
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '`') ADVANCE(515);
+          lookahead != '`') ADVANCE(517);
       END_STATE();
     case 27:
       if (eof) ADVANCE(30);
-      if (lookahead == '\n') ADVANCE(377);
-      if (lookahead == '\'') ADVANCE(229);
-      if (lookahead == '(') ADVANCE(265);
-      if (lookahead == '*') ADVANCE(225);
-      if (lookahead == '<') ADVANCE(90);
-      if (lookahead == '>') ADVANCE(278);
-      if (lookahead == 'A') ADVANCE(44);
-      if (lookahead == 'C') ADVANCE(47);
-      if (lookahead == 'M') ADVANCE(43);
-      if (lookahead == '`') ADVANCE(511);
-      if (lookahead == 'h') ADVANCE(52);
-      if (lookahead == '{') ADVANCE(253);
-      if (lookahead == '|') ADVANCE(247);
-      if (lookahead == '}') ADVANCE(256);
-      if (lookahead == '~') ADVANCE(274);
+      if (lookahead == '\n') ADVANCE(376);
+      if (lookahead == '\'') ADVANCE(224);
+      if (lookahead == '(') ADVANCE(255);
+      if (lookahead == '*') ADVANCE(220);
+      if (lookahead == ',') ADVANCE(273);
+      if (lookahead == '<') ADVANCE(89);
+      if (lookahead == '>') ADVANCE(269);
+      if (lookahead == 'A') ADVANCE(57);
+      if (lookahead == 'C') ADVANCE(60);
+      if (lookahead == 'M') ADVANCE(54);
+      if (lookahead == '[') ADVANCE(261);
+      if (lookahead == '`') ADVANCE(513);
+      if (lookahead == 'h') ADVANCE(82);
+      if (lookahead == '{') ADVANCE(246);
+      if (lookahead == '|') ADVANCE(240);
+      if (lookahead == '~') ADVANCE(265);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(27)
-      if (lookahead == '-' ||
-          lookahead == 8226) ADVANCE(92);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (lookahead != 0) ADVANCE(92);
+      if (lookahead != 0) ADVANCE(90);
       END_STATE();
     case 28:
       if (eof) ADVANCE(30);
-      if (lookahead == '\n') ADVANCE(377);
-      if (lookahead == '\'') ADVANCE(229);
-      if (lookahead == '(') ADVANCE(265);
-      if (lookahead == '*') ADVANCE(225);
-      if (lookahead == '<') ADVANCE(209);
-      if (lookahead == '>') ADVANCE(278);
-      if (lookahead == 'A') ADVANCE(152);
-      if (lookahead == 'C') ADVANCE(155);
-      if (lookahead == 'M') ADVANCE(151);
-      if (lookahead == '`') ADVANCE(511);
-      if (lookahead == 'h') ADVANCE(160);
-      if (lookahead == '{') ADVANCE(253);
-      if (lookahead == '|') ADVANCE(249);
-      if (lookahead == '}') ADVANCE(256);
-      if (lookahead == '~') ADVANCE(274);
+      if (lookahead == '\n') ADVANCE(376);
+      if (lookahead == '\'') ADVANCE(224);
+      if (lookahead == '(') ADVANCE(255);
+      if (lookahead == '*') ADVANCE(220);
+      if (lookahead == ',') ADVANCE(273);
+      if (lookahead == '<') ADVANCE(205);
+      if (lookahead == '>') ADVANCE(269);
+      if (lookahead == 'A') ADVANCE(173);
+      if (lookahead == 'C') ADVANCE(176);
+      if (lookahead == 'M') ADVANCE(170);
+      if (lookahead == '[') ADVANCE(261);
+      if (lookahead == '`') ADVANCE(513);
+      if (lookahead == 'h') ADVANCE(198);
+      if (lookahead == '{') ADVANCE(246);
+      if (lookahead == '|') ADVANCE(242);
+      if (lookahead == '~') ADVANCE(265);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(28)
       if (lookahead == '-' ||
           lookahead == 8226) ADVANCE(24);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('_' <= lookahead && lookahead <= 'z')) ADVANCE(161);
-      if (lookahead != 0) ADVANCE(211);
+      if (lookahead != 0) ADVANCE(206);
       END_STATE();
     case 29:
       if (eof) ADVANCE(30);
-      if (lookahead == '\n') ADVANCE(377);
-      if (lookahead == '\'') ADVANCE(229);
-      if (lookahead == '(') ADVANCE(268);
-      if (lookahead == '*') ADVANCE(225);
+      if (lookahead == '\n') ADVANCE(376);
+      if (lookahead == '\'') ADVANCE(224);
+      if (lookahead == '(') ADVANCE(257);
+      if (lookahead == '*') ADVANCE(220);
+      if (lookahead == ',') ADVANCE(273);
       if (lookahead == '-') ADVANCE(23);
-      if (lookahead == '<') ADVANCE(374);
-      if (lookahead == '=') ADVANCE(178);
-      if (lookahead == '>') ADVANCE(278);
-      if (lookahead == 'A') ADVANCE(163);
-      if (lookahead == 'C') ADVANCE(164);
-      if (lookahead == 'M') ADVANCE(162);
-      if (lookahead == '`') ADVANCE(511);
-      if (lookahead == 'h') ADVANCE(160);
-      if (lookahead == '{') ADVANCE(253);
-      if (lookahead == '|') ADVANCE(249);
-      if (lookahead == '}') ADVANCE(256);
-      if (lookahead == '~') ADVANCE(274);
+      if (lookahead == '<') ADVANCE(373);
+      if (lookahead == '=') ADVANCE(163);
+      if (lookahead == '>') ADVANCE(269);
+      if (lookahead == 'A') ADVANCE(143);
+      if (lookahead == 'C') ADVANCE(144);
+      if (lookahead == 'M') ADVANCE(142);
+      if (lookahead == '[') ADVANCE(261);
+      if (lookahead == '`') ADVANCE(513);
+      if (lookahead == 'h') ADVANCE(198);
+      if (lookahead == '{') ADVANCE(246);
+      if (lookahead == '|') ADVANCE(242);
+      if (lookahead == '~') ADVANCE(265);
       if (lookahead == 8226) ADVANCE(24);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(28)
       if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(210);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(161);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(165);
-      if (lookahead != 0) ADVANCE(211);
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(145);
+      if (lookahead != 0) ADVANCE(206);
       END_STATE();
     case 30:
       ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 31:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(375);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == ':') ADVANCE(89);
+      if (lookahead == '\n') ADVANCE(374);
+      if (lookahead == ':') ADVANCE(85);
       if (lookahead == 's') ADVANCE(32);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(53);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(36);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 32:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(375);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == ':') ADVANCE(89);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(374);
+      if (lookahead == ':') ADVANCE(85);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(36);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 33:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(375);
-      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == '\n') ADVANCE(374);
       if (lookahead == 'p') ADVANCE(31);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(53);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(36);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 34:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(375);
-      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == '\n') ADVANCE(374);
       if (lookahead == 't') ADVANCE(33);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(53);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(36);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 35:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(375);
-      if (lookahead == '(') ADVANCE(271);
+      if (lookahead == '\n') ADVANCE(374);
       if (lookahead == 't') ADVANCE(34);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(53);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(36);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 36:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(375);
-      if (lookahead == '(') ADVANCE(271);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(374);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(36);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 37:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == '-') ADVANCE(86);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == 'E') ADVANCE(364);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+          lookahead == '_') ADVANCE(366);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 38:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == '-') ADVANCE(63);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == 'L') ADVANCE(363);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+          lookahead == '_') ADVANCE(366);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 39:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == '-') ADVANCE(87);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == 'T') ADVANCE(362);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+          lookahead == '_') ADVANCE(366);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 40:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == ':') ADVANCE(89);
-      if (lookahead == 's') ADVANCE(41);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+          lookahead == '_') ADVANCE(366);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 41:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == ':') ADVANCE(89);
+      if (lookahead == '-') ADVANCE(49);
+      if (lookahead == '>') ADVANCE(277);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(48);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 42:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 'A') ADVANCE(39);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+      if (lookahead == '-') ADVANCE(86);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 43:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 'E') ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+      if (lookahead == '-') ADVANCE(52);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 44:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 'L') ADVANCE(48);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+      if (lookahead == '-') ADVANCE(87);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 45:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 'L') ADVANCE(38);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
-      END_STATE();
-    case 46:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 'R') ADVANCE(45);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
-      END_STATE();
-    case 47:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 'T') ADVANCE(46);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
-      END_STATE();
-    case 48:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 'T') ADVANCE(37);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
-      END_STATE();
-    case 49:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 'T') ADVANCE(42);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
-      END_STATE();
-    case 50:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 'p') ADVANCE(40);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
-      END_STATE();
-    case 51:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 't') ADVANCE(50);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
-      END_STATE();
-    case 52:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 't') ADVANCE(51);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
-      END_STATE();
-    case 53:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
-      END_STATE();
-    case 54:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(273);
-      if (lookahead == 'E') ADVANCE(362);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(372);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(363);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
-      END_STATE();
-    case 55:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(273);
-      if (lookahead == 'L') ADVANCE(361);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(372);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(363);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
-      END_STATE();
-    case 56:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(273);
-      if (lookahead == 'T') ADVANCE(360);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(372);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(363);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
-      END_STATE();
-    case 57:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(273);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(372);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(363);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
-      END_STATE();
-    case 58:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '-') ADVANCE(61);
-      if (lookahead == '>') ADVANCE(282);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
-      END_STATE();
-    case 59:
       ACCEPT_TOKEN(aux_sym_word_token1);
       if (lookahead == '-') ADVANCE(88);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
+      END_STATE();
+    case 46:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == ':') ADVANCE(85);
+      if (lookahead == 's') ADVANCE(47);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
+      END_STATE();
+    case 47:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == ':') ADVANCE(85);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
+      END_STATE();
+    case 48:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '>') ADVANCE(277);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(48);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
+      END_STATE();
+    case 49:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '>') ADVANCE(280);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(25);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(48);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(50);
+      END_STATE();
+    case 50:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '>') ADVANCE(281);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
+      END_STATE();
+    case 51:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'A') ADVANCE(44);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
+      END_STATE();
+    case 52:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'B') ADVANCE(309);
+      if (lookahead == 'D') ADVANCE(305);
+      if (lookahead == 'I') ADVANCE(307);
+      if (lookahead == 'P') ADVANCE(301);
+      if (lookahead == 'S') ADVANCE(299);
+      if (lookahead == '{') ADVANCE(303);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(284);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(284);
+      END_STATE();
+    case 53:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'D') ADVANCE(74);
+      if (lookahead == 'U') ADVANCE(76);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
+      END_STATE();
+    case 54:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'E') ADVANCE(62);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
+      END_STATE();
+    case 55:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'F') ADVANCE(63);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
+      END_STATE();
+    case 56:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'I') ADVANCE(55);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
+      END_STATE();
+    case 57:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'L') ADVANCE(61);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
+      END_STATE();
+    case 58:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'L') ADVANCE(43);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
+      END_STATE();
+    case 59:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'R') ADVANCE(58);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 60:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '>') ADVANCE(282);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
-      END_STATE();
-    case 61:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '>') ADVANCE(285);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(25);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(62);
-      END_STATE();
-    case 62:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '>') ADVANCE(286);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
-      END_STATE();
-    case 63:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'B') ADVANCE(312);
-      if (lookahead == 'D') ADVANCE(306);
-      if (lookahead == 'I') ADVANCE(309);
-      if (lookahead == 'P') ADVANCE(301);
-      if (lookahead == 'S') ADVANCE(298);
-      if (lookahead == '{') ADVANCE(304);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(289);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(289);
-      END_STATE();
-    case 64:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'D') ADVANCE(78);
-      if (lookahead == 'U') ADVANCE(79);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
-      END_STATE();
-    case 65:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'F') ADVANCE(67);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
-      END_STATE();
-    case 66:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'I') ADVANCE(65);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
-      END_STATE();
-    case 67:
       ACCEPT_TOKEN(aux_sym_word_token1);
       if (lookahead == 'T') ADVANCE(59);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
-    case 68:
+    case 61:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'a') ADVANCE(75);
+      if (lookahead == 'T') ADVANCE(42);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
-    case 69:
+    case 62:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'a') ADVANCE(81);
+      if (lookahead == 'T') ADVANCE(51);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
-    case 70:
+    case 63:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'e') ADVANCE(68);
+      if (lookahead == 'T') ADVANCE(45);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
-    case 71:
+    case 64:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'e') ADVANCE(80);
+      if (lookahead == 'a') ADVANCE(71);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
-    case 72:
+    case 65:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'a') ADVANCE(77);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
+      END_STATE();
+    case 66:
       ACCEPT_TOKEN(aux_sym_word_token1);
       if (lookahead == 'e') ADVANCE(64);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
+      END_STATE();
+    case 67:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'e') ADVANCE(78);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
+      END_STATE();
+    case 68:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'e') ADVANCE(53);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
+      END_STATE();
+    case 69:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'g') ADVANCE(68);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
+      END_STATE();
+    case 70:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'h') ADVANCE(65);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
+      END_STATE();
+    case 71:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'k') ADVANCE(317);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
+      END_STATE();
+    case 72:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'l') ADVANCE(317);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 73:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'g') ADVANCE(72);
+      if (lookahead == 'n') ADVANCE(317);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 74:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'h') ADVANCE(69);
+      if (lookahead == 'o') ADVANCE(83);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 75:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'k') ADVANCE(320);
+      if (lookahead == 'p') ADVANCE(46);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 76:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'l') ADVANCE(320);
+      if (lookahead == 'p') ADVANCE(317);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 77:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'n') ADVANCE(320);
+      if (lookahead == 'r') ADVANCE(84);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 78:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'o') ADVANCE(84);
+      if (lookahead == 'r') ADVANCE(81);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 79:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'p') ADVANCE(320);
+      if (lookahead == 's') ADVANCE(67);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 80:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'r') ADVANCE(83);
+      if (lookahead == 't') ADVANCE(75);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 81:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'r') ADVANCE(85);
+      if (lookahead == 't') ADVANCE(317);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 82:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 's') ADVANCE(71);
+      if (lookahead == 't') ADVANCE(80);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 83:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 't') ADVANCE(320);
+      if (lookahead == 'w') ADVANCE(73);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 84:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'w') ADVANCE(77);
+      if (lookahead == '}') ADVANCE(319);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 85:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '}') ADVANCE(322);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(90);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(450);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ') ADVANCE(449);
       END_STATE();
     case 86:
       ACCEPT_TOKEN(aux_sym_word_token1);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(328);
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(326);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(328);
+          lookahead != '\n') ADVANCE(326);
       END_STATE();
     case 87:
       ACCEPT_TOKEN(aux_sym_word_token1);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(324);
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(321);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(324);
+          lookahead != '\n') ADVANCE(321);
       END_STATE();
     case 88:
       ACCEPT_TOKEN(aux_sym_word_token1);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(316);
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(312);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(316);
+          lookahead != '\n') ADVANCE(312);
       END_STATE();
     case 89:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(92);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(448);
-      END_STATE();
-    case 90:
       ACCEPT_TOKEN(aux_sym_word_token1);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(58);
+          lookahead == 'S') ADVANCE(41);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(48);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
+      END_STATE();
+    case 90:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(90);
       END_STATE();
     case 91:
-      ACCEPT_TOKEN(aux_sym_word_token1);
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '=') ADVANCE(91);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(19);
+      if (lookahead != 0 &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
+      END_STATE();
+    case 92:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '-') ADVANCE(103);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 93:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '-') ADVANCE(139);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 94:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '-') ADVANCE(100);
+      if (lookahead == '>') ADVANCE(279);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(99);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 95:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '-') ADVANCE(140);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 96:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '-') ADVANCE(141);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 97:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == ':') ADVANCE(136);
+      if (lookahead == 's') ADVANCE(98);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 98:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == ':') ADVANCE(136);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 99:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '>') ADVANCE(279);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(99);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 100:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '>') ADVANCE(278);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(20);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(99);
+      if (lookahead != 0) ADVANCE(101);
+      END_STATE();
+    case 101:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '>') ADVANCE(282);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 102:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'A') ADVANCE(95);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 103:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'B') ADVANCE(290);
+      if (lookahead == 'D') ADVANCE(288);
+      if (lookahead == 'I') ADVANCE(289);
+      if (lookahead == 'P') ADVANCE(286);
+      if (lookahead == 'S') ADVANCE(285);
+      if (lookahead == '{') ADVANCE(287);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(292);
+      if (lookahead != 0) ADVANCE(291);
+      END_STATE();
+    case 104:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'D') ADVANCE(125);
+      if (lookahead == 'U') ADVANCE(127);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 105:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'E') ADVANCE(113);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 106:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'F') ADVANCE(114);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 107:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'I') ADVANCE(106);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 108:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'L') ADVANCE(112);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 109:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'L') ADVANCE(92);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 110:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'R') ADVANCE(109);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 111:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'T') ADVANCE(110);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 112:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'T') ADVANCE(93);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 113:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'T') ADVANCE(102);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 114:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'T') ADVANCE(96);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 115:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'a') ADVANCE(122);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 116:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'a') ADVANCE(128);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 117:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'e') ADVANCE(115);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 118:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'e') ADVANCE(129);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 119:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'e') ADVANCE(104);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 120:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'g') ADVANCE(119);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 121:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'h') ADVANCE(116);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 122:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'k') ADVANCE(318);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 123:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'l') ADVANCE(318);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 124:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'n') ADVANCE(318);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 125:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'o') ADVANCE(134);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 126:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'p') ADVANCE(97);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 127:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'p') ADVANCE(318);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 128:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'r') ADVANCE(135);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 129:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'r') ADVANCE(132);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 130:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 's') ADVANCE(118);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 131:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 't') ADVANCE(126);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 132:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 't') ADVANCE(318);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 133:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 't') ADVANCE(131);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 134:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'w') ADVANCE(124);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 135:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '}') ADVANCE(320);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 136:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
       if (lookahead == '(' ||
-          lookahead == ')' ||
+          lookahead == '[') ADVANCE(447);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(138);
+      if (lookahead != 0) ADVANCE(446);
+      END_STATE();
+    case 137:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead == 'A' ||
+          lookahead == 'C' ||
+          lookahead == 'D' ||
+          lookahead == 'M' ||
+          lookahead == 'S') ADVANCE(94);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(99);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 138:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 139:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(328);
+      if (lookahead != 0) ADVANCE(327);
+      END_STATE();
+    case 140:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(323);
+      if (lookahead != 0) ADVANCE(322);
+      END_STATE();
+    case 141:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(314);
+      if (lookahead != 0) ADVANCE(313);
+      END_STATE();
+    case 142:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'E') ADVANCE(343);
+      if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(372);
+          lookahead == '_') ADVANCE(352);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
-      END_STATE();
-    case 92:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(92);
-      END_STATE();
-    case 93:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(381);
-      if (lookahead == '=') ADVANCE(93);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(19);
-      if (lookahead != 0) ADVANCE(211);
-      END_STATE();
-    case 94:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '(') ADVANCE(272);
-      if (lookahead == '-') ADVANCE(116);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 95:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '(') ADVANCE(272);
-      if (lookahead == '-') ADVANCE(142);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 96:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '(') ADVANCE(272);
-      if (lookahead == '-') ADVANCE(143);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 97:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '(') ADVANCE(272);
-      if (lookahead == ':') ADVANCE(139);
-      if (lookahead == 's') ADVANCE(98);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 98:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '(') ADVANCE(272);
-      if (lookahead == ':') ADVANCE(139);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 99:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '(') ADVANCE(272);
-      if (lookahead == 'A') ADVANCE(96);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 100:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '(') ADVANCE(272);
-      if (lookahead == 'E') ADVANCE(106);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 101:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '(') ADVANCE(272);
-      if (lookahead == 'L') ADVANCE(105);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 102:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '(') ADVANCE(272);
-      if (lookahead == 'L') ADVANCE(94);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 103:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '(') ADVANCE(272);
-      if (lookahead == 'R') ADVANCE(102);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 104:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '(') ADVANCE(272);
-      if (lookahead == 'T') ADVANCE(103);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 105:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '(') ADVANCE(272);
-      if (lookahead == 'T') ADVANCE(95);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 106:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '(') ADVANCE(272);
-      if (lookahead == 'T') ADVANCE(99);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 107:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '(') ADVANCE(272);
-      if (lookahead == 'p') ADVANCE(97);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 108:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '(') ADVANCE(272);
-      if (lookahead == 't') ADVANCE(107);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 109:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '(') ADVANCE(272);
-      if (lookahead == 't') ADVANCE(108);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 110:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '(') ADVANCE(272);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(110);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 111:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '-') ADVANCE(114);
-      if (lookahead == '>') ADVANCE(284);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 112:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '-') ADVANCE(144);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 113:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '>') ADVANCE(284);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 114:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '>') ADVANCE(283);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(20);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(115);
-      END_STATE();
-    case 115:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '>') ADVANCE(287);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 116:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'B') ADVANCE(295);
-      if (lookahead == 'D') ADVANCE(293);
-      if (lookahead == 'I') ADVANCE(294);
-      if (lookahead == 'P') ADVANCE(291);
-      if (lookahead == 'S') ADVANCE(290);
-      if (lookahead == '{') ADVANCE(292);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(297);
-      if (lookahead != 0) ADVANCE(296);
-      END_STATE();
-    case 117:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'D') ADVANCE(131);
-      if (lookahead == 'U') ADVANCE(132);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 118:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'F') ADVANCE(120);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 119:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'I') ADVANCE(118);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 120:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'T') ADVANCE(112);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 121:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'a') ADVANCE(128);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 122:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'a') ADVANCE(134);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 123:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'e') ADVANCE(121);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 124:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'e') ADVANCE(133);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 125:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'e') ADVANCE(117);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 126:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'g') ADVANCE(125);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 127:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'h') ADVANCE(122);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 128:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'k') ADVANCE(321);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 129:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'l') ADVANCE(321);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 130:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'n') ADVANCE(321);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 131:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'o') ADVANCE(137);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 132:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'p') ADVANCE(321);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 133:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'r') ADVANCE(136);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 134:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'r') ADVANCE(138);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 135:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 's') ADVANCE(124);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 136:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 't') ADVANCE(321);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 137:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'w') ADVANCE(130);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 138:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '}') ADVANCE(323);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 139:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(141);
-      if (lookahead != 0) ADVANCE(447);
-      END_STATE();
-    case 140:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead == 'A' ||
-          lookahead == 'C' ||
-          lookahead == 'D' ||
-          lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(111);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 141:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 142:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(330);
-      if (lookahead != 0) ADVANCE(329);
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 143:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(326);
-      if (lookahead != 0) ADVANCE(325);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'L') ADVANCE(342);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(352);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 144:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(318);
-      if (lookahead != 0) ADVANCE(317);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'T') ADVANCE(341);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(352);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 145:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == '-') ADVANCE(205);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+          lookahead == '_') ADVANCE(352);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 146:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == '-') ADVANCE(182);
+      if (lookahead == '-') ADVANCE(165);
+      if (lookahead == '>') ADVANCE(277);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 147:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == '-') ADVANCE(206);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead == '-') ADVANCE(202);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 148:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == ':') ADVANCE(208);
-      if (lookahead == 's') ADVANCE(149);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead == '-') ADVANCE(168);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 149:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == ':') ADVANCE(208);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead == '-') ADVANCE(203);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 150:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 'A') ADVANCE(147);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead == '-') ADVANCE(204);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 151:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 'E') ADVANCE(157);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead == ':') ADVANCE(201);
+      if (lookahead == 's') ADVANCE(152);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 152:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 'L') ADVANCE(156);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead == ':') ADVANCE(201);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 153:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 'L') ADVANCE(146);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead == '=') ADVANCE(91);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 154:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 'R') ADVANCE(153);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead == '=') ADVANCE(153);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 155:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 'T') ADVANCE(154);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead == '=') ADVANCE(154);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 156:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 'T') ADVANCE(145);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead == '=') ADVANCE(155);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 157:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 'T') ADVANCE(150);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead == '=') ADVANCE(156);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 158:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 'p') ADVANCE(148);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead == '=') ADVANCE(157);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 159:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 't') ADVANCE(158);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead == '=') ADVANCE(158);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 160:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 't') ADVANCE(159);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead == '=') ADVANCE(159);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 161:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
+      if (lookahead == '=') ADVANCE(160);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 162:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(354);
-      if (lookahead == 'E') ADVANCE(339);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(354);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(340);
+      if (lookahead == '=') ADVANCE(161);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 163:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(354);
-      if (lookahead == 'L') ADVANCE(338);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(354);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(340);
+      if (lookahead == '=') ADVANCE(162);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 164:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(354);
-      if (lookahead == 'T') ADVANCE(337);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(354);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '>') ADVANCE(277);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(340);
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 165:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(354);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(354);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '>') ADVANCE(280);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(25);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(340);
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != '\n') ADVANCE(166);
       END_STATE();
     case 166:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '-') ADVANCE(180);
-      if (lookahead == '>') ADVANCE(282);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(179);
+      if (lookahead == '>') ADVANCE(281);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 167:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '-') ADVANCE(207);
+      if (lookahead == 'A') ADVANCE(149);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 168:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(93);
+      if (lookahead == 'B') ADVANCE(310);
+      if (lookahead == 'D') ADVANCE(306);
+      if (lookahead == 'I') ADVANCE(308);
+      if (lookahead == 'P') ADVANCE(302);
+      if (lookahead == 'S') ADVANCE(300);
+      if (lookahead == '{') ADVANCE(304);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(284);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != '\n') ADVANCE(284);
       END_STATE();
     case 169:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(168);
+      if (lookahead == 'D') ADVANCE(190);
+      if (lookahead == 'U') ADVANCE(191);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 170:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(169);
+      if (lookahead == 'E') ADVANCE(178);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 171:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(170);
+      if (lookahead == 'F') ADVANCE(179);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 172:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(171);
+      if (lookahead == 'I') ADVANCE(171);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 173:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(172);
+      if (lookahead == 'L') ADVANCE(177);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 174:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(173);
+      if (lookahead == 'L') ADVANCE(148);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 175:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(174);
+      if (lookahead == 'R') ADVANCE(174);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 176:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(175);
+      if (lookahead == 'T') ADVANCE(175);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 177:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(176);
+      if (lookahead == 'T') ADVANCE(147);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 178:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(177);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
-      END_STATE();
-    case 179:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '>') ADVANCE(282);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(179);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
-      END_STATE();
-    case 180:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '>') ADVANCE(285);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(25);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(179);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(181);
-      END_STATE();
-    case 181:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '>') ADVANCE(286);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
-      END_STATE();
-    case 182:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'B') ADVANCE(314);
-      if (lookahead == 'D') ADVANCE(308);
-      if (lookahead == 'I') ADVANCE(311);
-      if (lookahead == 'P') ADVANCE(303);
-      if (lookahead == 'S') ADVANCE(299);
-      if (lookahead == '{') ADVANCE(305);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(289);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(289);
-      END_STATE();
-    case 183:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'D') ADVANCE(197);
-      if (lookahead == 'U') ADVANCE(198);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
-      END_STATE();
-    case 184:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'F') ADVANCE(186);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
-      END_STATE();
-    case 185:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'I') ADVANCE(184);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
-      END_STATE();
-    case 186:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
       if (lookahead == 'T') ADVANCE(167);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
+      END_STATE();
+    case 179:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'T') ADVANCE(150);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
+      END_STATE();
+    case 180:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'a') ADVANCE(187);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
+      END_STATE();
+    case 181:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'a') ADVANCE(193);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
+      END_STATE();
+    case 182:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'e') ADVANCE(180);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
+      END_STATE();
+    case 183:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'e') ADVANCE(194);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
+      END_STATE();
+    case 184:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'e') ADVANCE(169);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
+      END_STATE();
+    case 185:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'g') ADVANCE(184);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
+      END_STATE();
+    case 186:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'h') ADVANCE(181);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 187:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'a') ADVANCE(194);
+      if (lookahead == 'k') ADVANCE(317);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 188:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'a') ADVANCE(200);
+      if (lookahead == 'l') ADVANCE(317);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 189:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'e') ADVANCE(187);
+      if (lookahead == 'n') ADVANCE(317);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 190:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'e') ADVANCE(199);
+      if (lookahead == 'o') ADVANCE(199);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 191:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'e') ADVANCE(183);
+      if (lookahead == 'p') ADVANCE(317);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 192:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'g') ADVANCE(191);
+      if (lookahead == 'p') ADVANCE(151);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 193:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'h') ADVANCE(188);
+      if (lookahead == 'r') ADVANCE(200);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 194:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'k') ADVANCE(320);
+      if (lookahead == 'r') ADVANCE(196);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 195:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'l') ADVANCE(320);
+      if (lookahead == 's') ADVANCE(183);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 196:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'n') ADVANCE(320);
+      if (lookahead == 't') ADVANCE(317);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 197:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'o') ADVANCE(203);
+      if (lookahead == 't') ADVANCE(192);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 198:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'p') ADVANCE(320);
+      if (lookahead == 't') ADVANCE(197);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 199:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'r') ADVANCE(202);
+      if (lookahead == 'w') ADVANCE(189);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 200:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'r') ADVANCE(204);
+      if (lookahead == '}') ADVANCE(319);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
       END_STATE();
     case 201:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 's') ADVANCE(190);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
-      END_STATE();
-    case 202:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 't') ADVANCE(320);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
-      END_STATE();
-    case 203:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'w') ADVANCE(196);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
-      END_STATE();
-    case 204:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '}') ADVANCE(322);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
-      END_STATE();
-    case 205:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(328);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(328);
-      END_STATE();
-    case 206:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(324);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(324);
-      END_STATE();
-    case 207:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(316);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(316);
-      END_STATE();
-    case 208:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(' ||
+          lookahead == '[') ADVANCE(450);
       if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(211);
+          lookahead == ']') ADVANCE(206);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ') ADVANCE(448);
       END_STATE();
-    case 209:
+    case 202:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(326);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(326);
+      END_STATE();
+    case 203:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(321);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(321);
+      END_STATE();
+    case 204:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(312);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(312);
+      END_STATE();
+    case 205:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(166);
+          lookahead == 'S') ADVANCE(146);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(179);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
+      END_STATE();
+    case 206:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(206);
+      END_STATE();
+    case 207:
+      ACCEPT_TOKEN(aux_sym_word_noli_token2);
+      if (lookahead == '\n') ADVANCE(381);
+      if (lookahead == '-') ADVANCE(207);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(18);
+      if (lookahead != 0) ADVANCE(219);
+      END_STATE();
+    case 208:
+      ACCEPT_TOKEN(aux_sym_word_noli_token2);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(208);
+      END_STATE();
+    case 209:
+      ACCEPT_TOKEN(aux_sym_word_noli_token2);
+      if (lookahead == '-') ADVANCE(207);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(219);
       END_STATE();
     case 210:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(354);
+      ACCEPT_TOKEN(aux_sym_word_noli_token2);
+      if (lookahead == '-') ADVANCE(209);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ') ADVANCE(219);
       END_STATE();
     case 211:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      ACCEPT_TOKEN(aux_sym_word_noli_token2);
+      if (lookahead == '-') ADVANCE(210);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(211);
+          lookahead != ' ') ADVANCE(219);
       END_STATE();
     case 212:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '\n') ADVANCE(382);
-      if (lookahead == '-') ADVANCE(212);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(18);
-      if (lookahead != 0) ADVANCE(224);
+      if (lookahead == '-') ADVANCE(211);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(219);
       END_STATE();
     case 213:
-      ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(213);
-      END_STATE();
-    case 214:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
       if (lookahead == '-') ADVANCE(212);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(224);
+          lookahead != ' ') ADVANCE(219);
+      END_STATE();
+    case 214:
+      ACCEPT_TOKEN(aux_sym_word_noli_token2);
+      if (lookahead == '-') ADVANCE(213);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(219);
       END_STATE();
     case 215:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
@@ -3289,7 +3369,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(224);
+          lookahead != ' ') ADVANCE(219);
       END_STATE();
     case 216:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
@@ -3297,7 +3377,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(224);
+          lookahead != ' ') ADVANCE(219);
       END_STATE();
     case 217:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
@@ -3305,7 +3385,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(224);
+          lookahead != ' ') ADVANCE(219);
       END_STATE();
     case 218:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
@@ -3313,2002 +3393,2143 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(224);
+          lookahead != ' ') ADVANCE(219);
       END_STATE();
     case 219:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(218);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(224);
+          lookahead != ' ') ADVANCE(219);
       END_STATE();
     case 220:
-      ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(219);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(224);
+      ACCEPT_TOKEN(anon_sym_STAR);
       END_STATE();
     case 221:
-      ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(220);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(224);
+      ACCEPT_TOKEN(anon_sym_STAR);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 222:
-      ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(221);
+      ACCEPT_TOKEN(anon_sym_STAR);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(224);
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 223:
-      ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(222);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(224);
+      ACCEPT_TOKEN(anon_sym_STAR);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(236);
       END_STATE();
     case 224:
-      ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(224);
+      ACCEPT_TOKEN(anon_sym_SQUOTE);
       END_STATE();
     case 225:
-      ACCEPT_TOKEN(anon_sym_STAR);
+      ACCEPT_TOKEN(anon_sym_SQUOTE);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 226:
-      ACCEPT_TOKEN(anon_sym_STAR);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+      ACCEPT_TOKEN(anon_sym_SQUOTE);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 227:
-      ACCEPT_TOKEN(anon_sym_STAR);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
+      ACCEPT_TOKEN(aux_sym__word_common_token1);
+      if (lookahead == 'E') ADVANCE(62);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(236);
       END_STATE();
     case 228:
-      ACCEPT_TOKEN(anon_sym_STAR);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+      ACCEPT_TOKEN(aux_sym__word_common_token1);
+      if (lookahead == 'L') ADVANCE(61);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(236);
       END_STATE();
     case 229:
-      ACCEPT_TOKEN(anon_sym_SQUOTE);
+      ACCEPT_TOKEN(aux_sym__word_common_token1);
+      if (lookahead == 'T') ADVANCE(59);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(236);
       END_STATE();
     case 230:
-      ACCEPT_TOKEN(anon_sym_SQUOTE);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+      ACCEPT_TOKEN(aux_sym__word_common_token1);
+      if (lookahead == 't') ADVANCE(454);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(236);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(455);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '\'') ADVANCE(236);
       END_STATE();
     case 231:
-      ACCEPT_TOKEN(anon_sym_SQUOTE);
+      ACCEPT_TOKEN(aux_sym__word_common_token1);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(236);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(455);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '\'') ADVANCE(236);
       END_STATE();
     case 232:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 'E') ADVANCE(49);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(240);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(53);
-      END_STATE();
-    case 233:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 'L') ADVANCE(48);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(240);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(53);
-      END_STATE();
-    case 234:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (lookahead == 'T') ADVANCE(46);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(240);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(53);
-      END_STATE();
-    case 235:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(271);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(240);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(53);
-      END_STATE();
-    case 236:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(242);
-      if (lookahead == 't') ADVANCE(452);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(453);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(240);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(242);
-      END_STATE();
-    case 237:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(') ADVANCE(242);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(453);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(240);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(242);
-      END_STATE();
-    case 238:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(58);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(241);
+          lookahead == 'S') ADVANCE(41);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(234);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(60);
+          lookahead == '_') ADVANCE(48);
       END_STATE();
-    case 239:
+    case 233:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(236);
       END_STATE();
-    case 240:
+    case 234:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == '(') ADVANCE(271);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(240);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(53);
-      END_STATE();
-    case 241:
-      ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == '>') ADVANCE(282);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(241);
+      if (lookahead == '>') ADVANCE(277);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(234);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(60);
+          lookahead == '_') ADVANCE(48);
       END_STATE();
-    case 242:
+    case 235:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
-      END_STATE();
-    case 243:
-      ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(243);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(450);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(235);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != ')' &&
-          lookahead != ']') ADVANCE(448);
+          lookahead != ']') ADVANCE(449);
       END_STATE();
-    case 244:
+    case 236:
+      ACCEPT_TOKEN(aux_sym__word_common_token2);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(236);
+      END_STATE();
+    case 237:
       ACCEPT_TOKEN(anon_sym_SQUOTE2);
       END_STATE();
-    case 245:
+    case 238:
       ACCEPT_TOKEN(aux_sym__word_common_token3);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '|') ADVANCE(245);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '|') ADVANCE(238);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 239:
+      ACCEPT_TOKEN(aux_sym__word_common_token3);
+      if (lookahead == '|') ADVANCE(239);
+      END_STATE();
+    case 240:
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      END_STATE();
+    case 241:
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '|') ADVANCE(238);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 242:
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == '|') ADVANCE(239);
+      END_STATE();
+    case 243:
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == '|') ADVANCE(239);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(236);
+      END_STATE();
+    case 244:
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == '|') ADVANCE(570);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(579);
+      END_STATE();
+    case 245:
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '{') ADVANCE(251);
+      if (lookahead == '}') ADVANCE(250);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 246:
-      ACCEPT_TOKEN(aux_sym__word_common_token3);
-      if (lookahead == '|') ADVANCE(246);
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      if (lookahead == '{') ADVANCE(253);
+      if (lookahead == '}') ADVANCE(249);
       END_STATE();
     case 247:
-      ACCEPT_TOKEN(anon_sym_PIPE);
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      if (lookahead == '{') ADVANCE(253);
+      if (lookahead == '}') ADVANCE(249);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(236);
       END_STATE();
     case 248:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '|') ADVANCE(245);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      if (lookahead == '{') ADVANCE(569);
+      if (lookahead == '}') ADVANCE(249);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(579);
       END_STATE();
     case 249:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '|') ADVANCE(246);
+      ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
       END_STATE();
     case 250:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '|') ADVANCE(246);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
+      ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 251:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '|') ADVANCE(568);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+      ACCEPT_TOKEN(aux_sym__word_common_token4);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '{') ADVANCE(251);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(252);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 252:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '{') ADVANCE(261);
-      if (lookahead == '}') ADVANCE(260);
+      ACCEPT_TOKEN(aux_sym__word_common_token4);
+      if (lookahead == '\n') ADVANCE(379);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(252);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 253:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
-      if (lookahead == '{') ADVANCE(263);
-      if (lookahead == '}') ADVANCE(259);
+      ACCEPT_TOKEN(aux_sym__word_common_token4);
+      if (lookahead == '{') ADVANCE(253);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(254);
       END_STATE();
     case 254:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
-      if (lookahead == '{') ADVANCE(263);
-      if (lookahead == '}') ADVANCE(259);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
+      ACCEPT_TOKEN(aux_sym__word_common_token4);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(254);
       END_STATE();
     case 255:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
-      if (lookahead == '{') ADVANCE(567);
-      if (lookahead == '}') ADVANCE(259);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(576);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
       END_STATE();
     case 256:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 257:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(352);
       END_STATE();
     case 258:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(236);
       END_STATE();
     case 259:
-      ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(371);
       END_STATE();
     case 260:
-      ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(580);
       END_STATE();
     case 261:
-      ACCEPT_TOKEN(aux_sym__word_common_token4);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '{') ADVANCE(261);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(262);
-      if (lookahead != 0) ADVANCE(141);
+      ACCEPT_TOKEN(anon_sym_LBRACK);
       END_STATE();
     case 262:
-      ACCEPT_TOKEN(aux_sym__word_common_token4);
-      if (lookahead == '\n') ADVANCE(380);
+      ACCEPT_TOKEN(anon_sym_LBRACK);
+      if (lookahead == '\n') ADVANCE(379);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(262);
-      if (lookahead != 0) ADVANCE(141);
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 263:
-      ACCEPT_TOKEN(aux_sym__word_common_token4);
-      if (lookahead == '{') ADVANCE(263);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(264);
+      ACCEPT_TOKEN(anon_sym_LBRACK);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(236);
       END_STATE();
     case 264:
-      ACCEPT_TOKEN(aux_sym__word_common_token4);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(264);
+      ACCEPT_TOKEN(anon_sym_LBRACK);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(580);
       END_STATE();
     case 265:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
+      ACCEPT_TOKEN(anon_sym_TILDE);
       END_STATE();
     case 266:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (lookahead == '\n') ADVANCE(380);
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      if (lookahead == '\n') ADVANCE(379);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 267:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 268:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(354);
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(236);
       END_STATE();
     case 269:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(372);
+      ACCEPT_TOKEN(anon_sym_GT);
       END_STATE();
     case 270:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+      ACCEPT_TOKEN(anon_sym_GT);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 271:
-      ACCEPT_TOKEN(aux_sym__word_common_token5);
+      ACCEPT_TOKEN(anon_sym_GT);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 272:
-      ACCEPT_TOKEN(aux_sym__word_common_token5);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+      ACCEPT_TOKEN(anon_sym_GT);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(236);
       END_STATE();
     case 273:
-      ACCEPT_TOKEN(aux_sym__word_common_token5);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(372);
+      ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
     case 274:
-      ACCEPT_TOKEN(anon_sym_TILDE);
+      ACCEPT_TOKEN(anon_sym_COMMA);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 275:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+      ACCEPT_TOKEN(anon_sym_COMMA);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(236);
       END_STATE();
     case 276:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
+      ACCEPT_TOKEN(anon_sym_COMMA);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(580);
       END_STATE();
     case 277:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+      ACCEPT_TOKEN(aux_sym_keycode_token1);
       END_STATE();
     case 278:
-      ACCEPT_TOKEN(anon_sym_GT);
+      ACCEPT_TOKEN(aux_sym_keycode_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '>') ADVANCE(282);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 279:
-      ACCEPT_TOKEN(anon_sym_GT);
-      if (lookahead == '\n') ADVANCE(380);
+      ACCEPT_TOKEN(aux_sym_keycode_token1);
+      if (lookahead == '\n') ADVANCE(379);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 280:
-      ACCEPT_TOKEN(anon_sym_GT);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
+      ACCEPT_TOKEN(aux_sym_keycode_token1);
+      if (lookahead == '>') ADVANCE(281);
       END_STATE();
     case 281:
-      ACCEPT_TOKEN(anon_sym_GT);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+      ACCEPT_TOKEN(aux_sym_keycode_token2);
       END_STATE();
     case 282:
-      ACCEPT_TOKEN(aux_sym_keycode_token1);
+      ACCEPT_TOKEN(aux_sym_keycode_token2);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 283:
-      ACCEPT_TOKEN(aux_sym_keycode_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '>') ADVANCE(287);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+      ACCEPT_TOKEN(aux_sym_keycode_token2);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead != 0) ADVANCE(21);
       END_STATE();
     case 284:
-      ACCEPT_TOKEN(aux_sym_keycode_token1);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
       END_STATE();
     case 285:
-      ACCEPT_TOKEN(aux_sym_keycode_token1);
-      if (lookahead == '>') ADVANCE(286);
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'H') ADVANCE(107);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 286:
-      ACCEPT_TOKEN(aux_sym_keycode_token2);
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'a') ADVANCE(120);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 287:
-      ACCEPT_TOKEN(aux_sym_keycode_token2);
-      if (lookahead == '\n') ADVANCE(380);
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'c') ADVANCE(121);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 288:
-      ACCEPT_TOKEN(aux_sym_keycode_token2);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead != 0) ADVANCE(21);
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'e') ADVANCE(123);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 289:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'n') ADVANCE(130);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 290:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'H') ADVANCE(119);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == 'r') ADVANCE(117);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 291:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'a') ADVANCE(126);
+      if (lookahead == '\n') ADVANCE(379);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 292:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'c') ADVANCE(127);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead != 0) ADVANCE(21);
       END_STATE();
     case 293:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'e') ADVANCE(129);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == 'H') ADVANCE(360);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(366);
       END_STATE();
     case 294:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'n') ADVANCE(135);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == 'a') ADVANCE(69);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(366);
       END_STATE();
     case 295:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == 'r') ADVANCE(123);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == 'e') ADVANCE(72);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(366);
       END_STATE();
     case 296:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == 'n') ADVANCE(79);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(366);
       END_STATE();
     case 297:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead != 0) ADVANCE(21);
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == 'r') ADVANCE(66);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(366);
       END_STATE();
     case 298:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'H') ADVANCE(66);
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(366);
       END_STATE();
     case 299:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'H') ADVANCE(185);
+      if (lookahead == 'H') ADVANCE(56);
       END_STATE();
     case 300:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'H') ADVANCE(367);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(372);
+      if (lookahead == 'H') ADVANCE(172);
       END_STATE();
     case 301:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'a') ADVANCE(73);
+      if (lookahead == 'a') ADVANCE(69);
       END_STATE();
     case 302:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'a') ADVANCE(73);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(372);
+      if (lookahead == 'a') ADVANCE(185);
       END_STATE();
     case 303:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'a') ADVANCE(192);
+      if (lookahead == 'c') ADVANCE(70);
       END_STATE();
     case 304:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'c') ADVANCE(74);
+      if (lookahead == 'c') ADVANCE(186);
       END_STATE();
     case 305:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'c') ADVANCE(193);
+      if (lookahead == 'e') ADVANCE(72);
       END_STATE();
     case 306:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'e') ADVANCE(76);
+      if (lookahead == 'e') ADVANCE(188);
       END_STATE();
     case 307:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'e') ADVANCE(76);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(372);
+      if (lookahead == 'n') ADVANCE(79);
       END_STATE();
     case 308:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'e') ADVANCE(195);
+      if (lookahead == 'n') ADVANCE(195);
       END_STATE();
     case 309:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'n') ADVANCE(82);
+      if (lookahead == 'r') ADVANCE(66);
       END_STATE();
     case 310:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'n') ADVANCE(82);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(372);
+      if (lookahead == 'r') ADVANCE(182);
       END_STATE();
     case 311:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'n') ADVANCE(201);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(371);
       END_STATE();
     case 312:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'r') ADVANCE(70);
+      ACCEPT_TOKEN(aux_sym_keycode_token4);
       END_STATE();
     case 313:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'r') ADVANCE(70);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(372);
+      ACCEPT_TOKEN(aux_sym_keycode_token4);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 314:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'r') ADVANCE(189);
+      ACCEPT_TOKEN(aux_sym_keycode_token4);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead != 0) ADVANCE(21);
       END_STATE();
     case 315:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      ACCEPT_TOKEN(aux_sym_keycode_token4);
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(372);
+          lookahead == '_') ADVANCE(366);
       END_STATE();
     case 316:
       ACCEPT_TOKEN(aux_sym_keycode_token4);
-      END_STATE();
-    case 317:
-      ACCEPT_TOKEN(aux_sym_keycode_token4);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 318:
-      ACCEPT_TOKEN(aux_sym_keycode_token4);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead != 0) ADVANCE(21);
-      END_STATE();
-    case 319:
-      ACCEPT_TOKEN(aux_sym_keycode_token4);
       if (lookahead == '(' ||
           lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(372);
+          lookahead == '_') ADVANCE(371);
+      END_STATE();
+    case 317:
+      ACCEPT_TOKEN(aux_sym_keycode_token5);
+      END_STATE();
+    case 318:
+      ACCEPT_TOKEN(aux_sym_keycode_token5);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 319:
+      ACCEPT_TOKEN(anon_sym_CTRL_DASH_LBRACEchar_RBRACE);
       END_STATE();
     case 320:
-      ACCEPT_TOKEN(aux_sym_keycode_token5);
+      ACCEPT_TOKEN(anon_sym_CTRL_DASH_LBRACEchar_RBRACE);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 321:
-      ACCEPT_TOKEN(aux_sym_keycode_token5);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+      ACCEPT_TOKEN(aux_sym_keycode_token6);
       END_STATE();
     case 322:
-      ACCEPT_TOKEN(anon_sym_CTRL_DASH_LBRACEchar_RBRACE);
+      ACCEPT_TOKEN(aux_sym_keycode_token6);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 323:
-      ACCEPT_TOKEN(anon_sym_CTRL_DASH_LBRACEchar_RBRACE);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+      ACCEPT_TOKEN(aux_sym_keycode_token6);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead != 0) ADVANCE(21);
       END_STATE();
     case 324:
       ACCEPT_TOKEN(aux_sym_keycode_token6);
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(366);
       END_STATE();
     case 325:
       ACCEPT_TOKEN(aux_sym_keycode_token6);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
-      END_STATE();
-    case 326:
-      ACCEPT_TOKEN(aux_sym_keycode_token6);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead != 0) ADVANCE(21);
-      END_STATE();
-    case 327:
-      ACCEPT_TOKEN(aux_sym_keycode_token6);
       if (lookahead == '(' ||
           lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(372);
+          lookahead == '_') ADVANCE(371);
+      END_STATE();
+    case 326:
+      ACCEPT_TOKEN(aux_sym_keycode_token7);
+      END_STATE();
+    case 327:
+      ACCEPT_TOKEN(aux_sym_keycode_token7);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 328:
       ACCEPT_TOKEN(aux_sym_keycode_token7);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead != 0) ADVANCE(21);
       END_STATE();
     case 329:
       ACCEPT_TOKEN(aux_sym_keycode_token7);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(366);
       END_STATE();
     case 330:
       ACCEPT_TOKEN(aux_sym_keycode_token7);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead != 0) ADVANCE(21);
-      END_STATE();
-    case 331:
-      ACCEPT_TOKEN(aux_sym_keycode_token7);
       if (lookahead == '(' ||
           lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(372);
+          lookahead == '_') ADVANCE(371);
+      END_STATE();
+    case 331:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == '-') ADVANCE(349);
+      if (lookahead == ')' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(352);
       END_STATE();
     case 332:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(354);
-      if (lookahead == '-') ADVANCE(351);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == '-') ADVANCE(336);
       if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(354);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
-      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(340);
+          lookahead == '_') ADVANCE(352);
       END_STATE();
     case 333:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(354);
-      if (lookahead == '-') ADVANCE(342);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == '-') ADVANCE(350);
       if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(354);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
-      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(340);
+          lookahead == '_') ADVANCE(352);
       END_STATE();
     case 334:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(354);
-      if (lookahead == '-') ADVANCE(352);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == '-') ADVANCE(351);
       if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(354);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
-      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(340);
+          lookahead == '_') ADVANCE(352);
       END_STATE();
     case 335:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(354);
-      if (lookahead == 'A') ADVANCE(334);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'A') ADVANCE(333);
       if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.') ADVANCE(354);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
-      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(340);
+          lookahead == '_') ADVANCE(352);
       END_STATE();
     case 336:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(354);
-      if (lookahead == 'L') ADVANCE(333);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'B') ADVANCE(348);
+      if (lookahead == 'D') ADVANCE(346);
+      if (lookahead == 'I') ADVANCE(347);
+      if (lookahead == 'P') ADVANCE(345);
+      if (lookahead == 'S') ADVANCE(338);
+      if (lookahead == '{') ADVANCE(304);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(284);
       if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.') ADVANCE(354);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
-      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(340);
+          lookahead == '_') ADVANCE(352);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(284);
       END_STATE();
     case 337:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(354);
-      if (lookahead == 'R') ADVANCE(336);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'F') ADVANCE(344);
       if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.') ADVANCE(354);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
-      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(340);
+          lookahead == '_') ADVANCE(352);
       END_STATE();
     case 338:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(354);
-      if (lookahead == 'T') ADVANCE(332);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'H') ADVANCE(339);
       if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.') ADVANCE(354);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
-      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(340);
+          lookahead == '_') ADVANCE(352);
       END_STATE();
     case 339:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(354);
-      if (lookahead == 'T') ADVANCE(335);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'I') ADVANCE(337);
       if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.') ADVANCE(354);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
-      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(340);
+          lookahead == '_') ADVANCE(352);
       END_STATE();
     case 340:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(354);
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'L') ADVANCE(332);
       if (lookahead == ')' ||
           lookahead == '-' ||
-          lookahead == '.') ADVANCE(354);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(161);
-      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(340);
+          lookahead == '_') ADVANCE(352);
       END_STATE();
     case 341:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '-') ADVANCE(353);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'R') ADVANCE(340);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(354);
+          lookahead == '_') ADVANCE(352);
       END_STATE();
     case 342:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'B') ADVANCE(350);
-      if (lookahead == 'D') ADVANCE(348);
-      if (lookahead == 'I') ADVANCE(349);
-      if (lookahead == 'P') ADVANCE(347);
-      if (lookahead == 'S') ADVANCE(344);
-      if (lookahead == '{') ADVANCE(305);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(289);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'T') ADVANCE(331);
+      if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(354);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(289);
+          lookahead == '_') ADVANCE(352);
       END_STATE();
     case 343:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'F') ADVANCE(346);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'T') ADVANCE(335);
+      if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(354);
+          lookahead == '_') ADVANCE(352);
       END_STATE();
     case 344:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'H') ADVANCE(345);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'T') ADVANCE(334);
+      if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(354);
+          lookahead == '_') ADVANCE(352);
       END_STATE();
     case 345:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'I') ADVANCE(343);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'a') ADVANCE(185);
+      if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(354);
+          lookahead == '_') ADVANCE(352);
       END_STATE();
     case 346:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'T') ADVANCE(341);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'e') ADVANCE(188);
+      if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(354);
+          lookahead == '_') ADVANCE(352);
       END_STATE();
     case 347:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'a') ADVANCE(192);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'n') ADVANCE(195);
+      if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(354);
+          lookahead == '_') ADVANCE(352);
       END_STATE();
     case 348:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'e') ADVANCE(195);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == 'r') ADVANCE(182);
+      if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(354);
+          lookahead == '_') ADVANCE(352);
       END_STATE();
     case 349:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'n') ADVANCE(201);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(326);
+      if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(354);
+          lookahead == '_') ADVANCE(352);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(326);
       END_STATE();
     case 350:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == 'r') ADVANCE(189);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(321);
+      if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(354);
+          lookahead == '_') ADVANCE(352);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(321);
       END_STATE();
     case 351:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(353);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(328);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(312);
+      if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(354);
+          lookahead == '_') ADVANCE(352);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(328);
+          lookahead != '\n') ADVANCE(312);
       END_STATE();
     case 352:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(324);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+      if (lookahead == '(') ADVANCE(353);
+      if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(354);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(324);
+          lookahead == '_') ADVANCE(352);
       END_STATE();
     case 353:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(316);
       if (lookahead == '(' ||
           lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(354);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(316);
+          lookahead == '_') ADVANCE(353);
       END_STATE();
     case 354:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == '-') ADVANCE(367);
+      if (lookahead == ')' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(354);
+          lookahead == '_') ADVANCE(366);
       END_STATE();
     case 355:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(273);
-      if (lookahead == '-') ADVANCE(369);
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == '-') ADVANCE(368);
       if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(372);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(363);
-      END_STATE();
-    case 356:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(273);
-      if (lookahead == '-') ADVANCE(365);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(372);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(363);
-      END_STATE();
-    case 357:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(273);
-      if (lookahead == '-') ADVANCE(370);
-      if (lookahead == ')' ||
-          lookahead == '.') ADVANCE(372);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(363);
-      END_STATE();
-    case 358:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(273);
-      if (lookahead == 'A') ADVANCE(357);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(372);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(363);
-      END_STATE();
-    case 359:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(273);
-      if (lookahead == 'L') ADVANCE(356);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(372);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(363);
-      END_STATE();
-    case 360:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(273);
-      if (lookahead == 'R') ADVANCE(359);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(372);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(363);
-      END_STATE();
-    case 361:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(273);
-      if (lookahead == 'T') ADVANCE(355);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(372);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(363);
-      END_STATE();
-    case 362:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(273);
-      if (lookahead == 'T') ADVANCE(358);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(372);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(363);
-      END_STATE();
-    case 363:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(273);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.') ADVANCE(372);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(363);
-      END_STATE();
-    case 364:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '-') ADVANCE(371);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(372);
+          lookahead == '_') ADVANCE(366);
+      END_STATE();
+    case 356:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == '-') ADVANCE(369);
+      if (lookahead == ')' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(366);
+      END_STATE();
+    case 357:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == '-') ADVANCE(370);
+      if (lookahead == ')' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(366);
+      END_STATE();
+    case 358:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == 'A') ADVANCE(356);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(366);
+      END_STATE();
+    case 359:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == 'F') ADVANCE(365);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(366);
+      END_STATE();
+    case 360:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == 'I') ADVANCE(359);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(366);
+      END_STATE();
+    case 361:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == 'L') ADVANCE(355);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(366);
+      END_STATE();
+    case 362:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == 'R') ADVANCE(361);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(366);
+      END_STATE();
+    case 363:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == 'T') ADVANCE(354);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(366);
+      END_STATE();
+    case 364:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == 'T') ADVANCE(358);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(366);
       END_STATE();
     case 365:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == 'B') ADVANCE(313);
-      if (lookahead == 'D') ADVANCE(307);
-      if (lookahead == 'I') ADVANCE(310);
-      if (lookahead == 'P') ADVANCE(302);
-      if (lookahead == 'S') ADVANCE(300);
-      if (lookahead == '{') ADVANCE(304);
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == 'T') ADVANCE(357);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(366);
+      END_STATE();
+    case 366:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(371);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(366);
+      END_STATE();
+    case 367:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(330);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(289);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
+          lookahead == ' ' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(326);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(329);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(326);
+      END_STATE();
+    case 368:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(311);
+      if (lookahead == 'B') ADVANCE(297);
+      if (lookahead == 'D') ADVANCE(295);
+      if (lookahead == 'I') ADVANCE(296);
+      if (lookahead == 'P') ADVANCE(294);
+      if (lookahead == 'S') ADVANCE(293);
+      if (lookahead == '{') ADVANCE(303);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(284);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(298);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(284);
+      END_STATE();
+    case 369:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(325);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(321);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(324);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(321);
+      END_STATE();
+    case 370:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(316);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(312);
+      if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_') ADVANCE(315);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(289);
-      END_STATE();
-    case 366:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == 'F') ADVANCE(368);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(372);
-      END_STATE();
-    case 367:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == 'I') ADVANCE(366);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(372);
-      END_STATE();
-    case 368:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == 'T') ADVANCE(364);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(372);
-      END_STATE();
-    case 369:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(328);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(331);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(328);
-      END_STATE();
-    case 370:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(324);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(327);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(324);
+          lookahead != '\n') ADVANCE(312);
       END_STATE();
     case 371:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(316);
       if (lookahead == '(' ||
           lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(316);
+          lookahead == '_') ADVANCE(371);
       END_STATE();
     case 372:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(372);
+      ACCEPT_TOKEN(anon_sym_LT);
       END_STATE();
     case 373:
       ACCEPT_TOKEN(anon_sym_LT);
-      END_STATE();
-    case 374:
-      ACCEPT_TOKEN(anon_sym_LT);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(166);
+          lookahead == 'S') ADVANCE(146);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(179);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(164);
       END_STATE();
-    case 375:
+    case 374:
       ACCEPT_TOKEN(aux_sym_codeblock_token1);
       END_STATE();
-    case 376:
+    case 375:
       ACCEPT_TOKEN(anon_sym_LF);
       END_STATE();
-    case 377:
+    case 376:
       ACCEPT_TOKEN(anon_sym_LF2);
+      END_STATE();
+    case 377:
+      ACCEPT_TOKEN(aux_sym_line_li_token1);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == ' ') ADVANCE(377);
+      if (lookahead != 0) ADVANCE(21);
       END_STATE();
     case 378:
       ACCEPT_TOKEN(aux_sym_line_li_token1);
-      if (lookahead == '\n') ADVANCE(380);
       if (lookahead == ' ') ADVANCE(378);
-      if (lookahead != 0) ADVANCE(21);
       END_STATE();
     case 379:
-      ACCEPT_TOKEN(aux_sym_line_li_token1);
-      if (lookahead == ' ') ADVANCE(379);
-      END_STATE();
-    case 380:
       ACCEPT_TOKEN(aux_sym_line_code_token1);
       END_STATE();
-    case 381:
+    case 380:
       ACCEPT_TOKEN(aux_sym_h1_token1);
       END_STATE();
-    case 382:
+    case 381:
       ACCEPT_TOKEN(aux_sym_h2_token1);
+      END_STATE();
+    case 382:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '-') ADVANCE(443);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 383:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(') ADVANCE(445);
-      if (lookahead == '-') ADVANCE(445);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead == '-') ADVANCE(394);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 384:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(') ADVANCE(445);
-      if (lookahead == '-') ADVANCE(410);
+      if (lookahead == '-') ADVANCE(392);
+      if (lookahead == '>') ADVANCE(443);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(389);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 385:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(') ADVANCE(445);
-      if (lookahead == ':') ADVANCE(442);
+      if (lookahead == ':') ADVANCE(438);
       if (lookahead == 's') ADVANCE(387);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(403);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(404);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(442);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 386:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(') ADVANCE(445);
-      if (lookahead == ':') ADVANCE(442);
+      if (lookahead == ':') ADVANCE(438);
       if (lookahead == 's') ADVANCE(388);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 387:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(') ADVANCE(445);
-      if (lookahead == ':') ADVANCE(442);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(403);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(404);
+      if (lookahead == ':') ADVANCE(438);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(442);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 388:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(') ADVANCE(445);
-      if (lookahead == ':') ADVANCE(442);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead == ':') ADVANCE(438);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 389:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(') ADVANCE(445);
-      if (lookahead == 'A') ADVANCE(383);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
+      if (lookahead == '>') ADVANCE(443);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(389);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 390:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(') ADVANCE(445);
-      if (lookahead == 'E') ADVANCE(396);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead == '>') ADVANCE(443);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 391:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(') ADVANCE(445);
-      if (lookahead == 'L') ADVANCE(395);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead == '>') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(444);
       END_STATE();
     case 392:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(') ADVANCE(445);
-      if (lookahead == 'L') ADVANCE(384);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '>') ADVANCE(390);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(391);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(389);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(390);
       END_STATE();
     case 393:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(') ADVANCE(445);
-      if (lookahead == 'R') ADVANCE(392);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead == 'A') ADVANCE(382);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 394:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(') ADVANCE(445);
-      if (lookahead == 'T') ADVANCE(393);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead == 'B') ADVANCE(426);
+      if (lookahead == 'D') ADVANCE(410);
+      if (lookahead == 'I') ADVANCE(419);
+      if (lookahead == 'P') ADVANCE(406);
+      if (lookahead == 'S') ADVANCE(398);
+      if (lookahead == '{') ADVANCE(409);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 395:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(') ADVANCE(445);
-      if (lookahead == 'T') ADVANCE(383);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead == 'D') ADVANCE(420);
+      if (lookahead == 'U') ADVANCE(421);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 396:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(') ADVANCE(445);
-      if (lookahead == 'T') ADVANCE(389);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead == 'E') ADVANCE(405);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 397:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(') ADVANCE(445);
-      if (lookahead == 'p') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(403);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(404);
+      if (lookahead == 'F') ADVANCE(404);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 398:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(') ADVANCE(445);
-      if (lookahead == 'p') ADVANCE(386);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead == 'H') ADVANCE(399);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 399:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(') ADVANCE(445);
-      if (lookahead == 't') ADVANCE(397);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(403);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(404);
+      if (lookahead == 'I') ADVANCE(397);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 400:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(') ADVANCE(445);
-      if (lookahead == 't') ADVANCE(398);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead == 'L') ADVANCE(404);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 401:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(') ADVANCE(445);
-      if (lookahead == 't') ADVANCE(399);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(403);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(404);
+      if (lookahead == 'L') ADVANCE(383);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 402:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(') ADVANCE(445);
-      if (lookahead == 't') ADVANCE(400);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead == 'R') ADVANCE(401);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 403:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(') ADVANCE(445);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(403);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(404);
+      if (lookahead == 'T') ADVANCE(402);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 404:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(') ADVANCE(445);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (lookahead == 'T') ADVANCE(382);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 405:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '-') ADVANCE(445);
+      if (lookahead == 'T') ADVANCE(393);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 406:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '-') ADVANCE(409);
-      if (lookahead == '>') ADVANCE(445);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(407);
+      if (lookahead == 'a') ADVANCE(414);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 407:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '>') ADVANCE(445);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(407);
+      if (lookahead == 'a') ADVANCE(416);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 408:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '>') ADVANCE(445);
+      if (lookahead == 'a') ADVANCE(425);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 409:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '>') ADVANCE(408);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(407);
+      if (lookahead == 'c') ADVANCE(415);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(408);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 410:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'B') ADVANCE(434);
-      if (lookahead == 'D') ADVANCE(420);
-      if (lookahead == 'I') ADVANCE(429);
-      if (lookahead == 'P') ADVANCE(416);
-      if (lookahead == 'S') ADVANCE(413);
-      if (lookahead == '{') ADVANCE(419);
+      if (lookahead == 'e') ADVANCE(417);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 411:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'D') ADVANCE(430);
-      if (lookahead == 'U') ADVANCE(431);
+      if (lookahead == 'e') ADVANCE(395);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 412:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'F') ADVANCE(415);
+      if (lookahead == 'e') ADVANCE(424);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 413:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'H') ADVANCE(414);
+      if (lookahead == 'e') ADVANCE(407);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 414:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'I') ADVANCE(412);
+      if (lookahead == 'g') ADVANCE(411);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 415:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'T') ADVANCE(405);
+      if (lookahead == 'h') ADVANCE(408);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 416:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'a') ADVANCE(424);
+      if (lookahead == 'k') ADVANCE(443);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 417:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'a') ADVANCE(426);
+      if (lookahead == 'l') ADVANCE(443);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 418:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'a') ADVANCE(433);
+      if (lookahead == 'n') ADVANCE(443);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 419:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'c') ADVANCE(425);
+      if (lookahead == 'n') ADVANCE(427);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 420:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'e') ADVANCE(427);
+      if (lookahead == 'o') ADVANCE(433);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 421:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'e') ADVANCE(411);
+      if (lookahead == 'p') ADVANCE(443);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 422:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'e') ADVANCE(432);
+      if (lookahead == 'p') ADVANCE(385);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(442);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 423:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'e') ADVANCE(417);
+      if (lookahead == 'p') ADVANCE(386);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 424:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'g') ADVANCE(421);
+      if (lookahead == 'r') ADVANCE(428);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 425:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'h') ADVANCE(418);
+      if (lookahead == 'r') ADVANCE(437);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 426:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'k') ADVANCE(445);
+      if (lookahead == 'r') ADVANCE(413);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 427:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'l') ADVANCE(445);
+      if (lookahead == 's') ADVANCE(412);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 428:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'n') ADVANCE(445);
+      if (lookahead == 't') ADVANCE(443);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 429:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'n') ADVANCE(435);
+      if (lookahead == 't') ADVANCE(422);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(442);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 430:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'o') ADVANCE(437);
+      if (lookahead == 't') ADVANCE(429);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(442);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 431:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'p') ADVANCE(445);
+      if (lookahead == 't') ADVANCE(423);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 432:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'r') ADVANCE(436);
+      if (lookahead == 't') ADVANCE(431);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 433:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'r') ADVANCE(441);
+      if (lookahead == 'w') ADVANCE(418);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 434:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'r') ADVANCE(423);
+      if (lookahead == '{') ADVANCE(435);
+      if (lookahead == '}') ADVANCE(443);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 435:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 's') ADVANCE(422);
+      if (lookahead == '{') ADVANCE(435);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(441);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 436:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 't') ADVANCE(445);
+      if (lookahead == '|') ADVANCE(436);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 437:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'w') ADVANCE(428);
+      if (lookahead == '}') ADVANCE(443);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 438:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '{') ADVANCE(439);
-      if (lookahead == '}') ADVANCE(445);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(443);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(439);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(438);
       END_STATE();
     case 439:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '{') ADVANCE(439);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(444);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(439);
       END_STATE();
     case 440:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '|') ADVANCE(440);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
-      END_STATE();
-    case 441:
-      ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '}') ADVANCE(445);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
-      END_STATE();
-    case 442:
-      ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(445);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '*') ADVANCE(442);
-      END_STATE();
-    case 443:
-      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(406);
+          lookahead == 'S') ADVANCE(384);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(407);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(389);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(443);
+      END_STATE();
+    case 441:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(441);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(443);
+      END_STATE();
+    case 442:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(442);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(443);
+      END_STATE();
+    case 443:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(444);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(443);
       END_STATE();
     case 444:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(444);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+          lookahead != '*') ADVANCE(444);
       END_STATE();
     case 445:
-      ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '*') ADVANCE(445);
+      ACCEPT_TOKEN(anon_sym_STAR2);
       END_STATE();
     case 446:
-      ACCEPT_TOKEN(anon_sym_STAR2);
+      ACCEPT_TOKEN(sym_url_word);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead == '(' ||
+          lookahead == '[') ADVANCE(447);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(138);
+      if (lookahead != 0) ADVANCE(446);
       END_STATE();
     case 447:
       ACCEPT_TOKEN(sym_url_word);
-      if (lookahead == '\n') ADVANCE(380);
+      if (lookahead == '\n') ADVANCE(379);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(141);
+          lookahead == ' ' ||
+          lookahead == ')' ||
+          lookahead == ']') ADVANCE(21);
       if (lookahead != 0) ADVANCE(447);
       END_STATE();
     case 448:
       ACCEPT_TOKEN(sym_url_word);
+      if (lookahead == '(' ||
+          lookahead == '[') ADVANCE(450);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
@@ -5317,650 +5538,719 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != ']') ADVANCE(448);
       END_STATE();
     case 449:
-      ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(242);
-      if (lookahead == ':') ADVANCE(243);
-      if (lookahead == 's') ADVANCE(450);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(453);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(240);
+      ACCEPT_TOKEN(sym_url_word);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(450);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(242);
+          lookahead != ')' &&
+          lookahead != ']') ADVANCE(449);
       END_STATE();
     case 450:
-      ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(242);
-      if (lookahead == ':') ADVANCE(243);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(453);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(240);
+      ACCEPT_TOKEN(sym_url_word);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(242);
+          lookahead != ')' &&
+          lookahead != ']') ADVANCE(450);
       END_STATE();
     case 451:
       ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(242);
-      if (lookahead == 'p') ADVANCE(449);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(453);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(240);
+      if (lookahead == ':') ADVANCE(235);
+      if (lookahead == 's') ADVANCE(452);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(236);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(455);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(242);
+          lookahead != '\'') ADVANCE(236);
       END_STATE();
     case 452:
       ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(242);
-      if (lookahead == 't') ADVANCE(451);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(453);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(240);
+      if (lookahead == ':') ADVANCE(235);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(236);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(455);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(242);
+          lookahead != '\'') ADVANCE(236);
       END_STATE();
     case 453:
       ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == '(') ADVANCE(242);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(453);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(240);
+      if (lookahead == 'p') ADVANCE(451);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(236);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(455);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '\'') ADVANCE(242);
+          lookahead != '\'') ADVANCE(236);
       END_STATE();
     case 454:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(509);
-      if (lookahead == '-') ADVANCE(509);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      ACCEPT_TOKEN(aux_sym_optionlink_token1);
+      if (lookahead == 't') ADVANCE(453);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(236);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(455);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '\'') ADVANCE(236);
       END_STATE();
     case 455:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(509);
-      if (lookahead == '-') ADVANCE(475);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      ACCEPT_TOKEN(aux_sym_optionlink_token1);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(236);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(455);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '\'') ADVANCE(236);
       END_STATE();
     case 456:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(509);
-      if (lookahead == ':') ADVANCE(506);
-      if (lookahead == 's') ADVANCE(457);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      if (lookahead == '-') ADVANCE(510);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 457:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(509);
-      if (lookahead == ':') ADVANCE(506);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      if (lookahead == '-') ADVANCE(466);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 458:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(509);
-      if (lookahead == 'A') ADVANCE(454);
+      if (lookahead == '-') ADVANCE(464);
+      if (lookahead == '>') ADVANCE(510);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(461);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 459:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(509);
-      if (lookahead == 'E') ADVANCE(465);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      if (lookahead == ':') ADVANCE(506);
+      if (lookahead == 's') ADVANCE(460);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 460:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(509);
-      if (lookahead == 'L') ADVANCE(464);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      if (lookahead == ':') ADVANCE(506);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 461:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(509);
-      if (lookahead == 'L') ADVANCE(455);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '>') ADVANCE(510);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(461);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 462:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(509);
-      if (lookahead == 'R') ADVANCE(461);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      if (lookahead == '>') ADVANCE(510);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 463:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(509);
-      if (lookahead == 'T') ADVANCE(462);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      if (lookahead == '>') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(511);
       END_STATE();
     case 464:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(509);
-      if (lookahead == 'T') ADVANCE(454);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '>') ADVANCE(462);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(463);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(461);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(462);
       END_STATE();
     case 465:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(509);
-      if (lookahead == 'T') ADVANCE(458);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      if (lookahead == 'A') ADVANCE(456);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 466:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(509);
-      if (lookahead == 'p') ADVANCE(456);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      if (lookahead == 'B') ADVANCE(496);
+      if (lookahead == 'D') ADVANCE(482);
+      if (lookahead == 'I') ADVANCE(491);
+      if (lookahead == 'P') ADVANCE(478);
+      if (lookahead == 'S') ADVANCE(470);
+      if (lookahead == '{') ADVANCE(481);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 467:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(509);
-      if (lookahead == 't') ADVANCE(466);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      if (lookahead == 'D') ADVANCE(492);
+      if (lookahead == 'U') ADVANCE(493);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 468:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(509);
-      if (lookahead == 't') ADVANCE(467);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      if (lookahead == 'E') ADVANCE(477);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 469:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(') ADVANCE(509);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      if (lookahead == 'F') ADVANCE(476);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 470:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '-') ADVANCE(509);
+      if (lookahead == 'H') ADVANCE(471);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 471:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '-') ADVANCE(474);
-      if (lookahead == '>') ADVANCE(509);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(472);
+      if (lookahead == 'I') ADVANCE(469);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 472:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '>') ADVANCE(509);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(472);
+      if (lookahead == 'L') ADVANCE(476);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 473:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '>') ADVANCE(509);
+      if (lookahead == 'L') ADVANCE(457);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 474:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '>') ADVANCE(473);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(472);
+      if (lookahead == 'R') ADVANCE(473);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(473);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 475:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'B') ADVANCE(499);
-      if (lookahead == 'D') ADVANCE(485);
-      if (lookahead == 'I') ADVANCE(494);
-      if (lookahead == 'P') ADVANCE(481);
-      if (lookahead == 'S') ADVANCE(478);
-      if (lookahead == '{') ADVANCE(484);
+      if (lookahead == 'T') ADVANCE(474);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 476:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'D') ADVANCE(495);
-      if (lookahead == 'U') ADVANCE(496);
+      if (lookahead == 'T') ADVANCE(456);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 477:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'F') ADVANCE(480);
+      if (lookahead == 'T') ADVANCE(465);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 478:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'H') ADVANCE(479);
+      if (lookahead == 'a') ADVANCE(486);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 479:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'I') ADVANCE(477);
+      if (lookahead == 'a') ADVANCE(488);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 480:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'T') ADVANCE(470);
+      if (lookahead == 'a') ADVANCE(495);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 481:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'a') ADVANCE(489);
+      if (lookahead == 'c') ADVANCE(487);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 482:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'a') ADVANCE(491);
+      if (lookahead == 'e') ADVANCE(489);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 483:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'a') ADVANCE(498);
+      if (lookahead == 'e') ADVANCE(467);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 484:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'c') ADVANCE(490);
+      if (lookahead == 'e') ADVANCE(497);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 485:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'e') ADVANCE(492);
+      if (lookahead == 'e') ADVANCE(479);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 486:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'e') ADVANCE(476);
+      if (lookahead == 'g') ADVANCE(483);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 487:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'e') ADVANCE(497);
+      if (lookahead == 'h') ADVANCE(480);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 488:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'e') ADVANCE(482);
+      if (lookahead == 'k') ADVANCE(510);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 489:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'g') ADVANCE(486);
+      if (lookahead == 'l') ADVANCE(510);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 490:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'h') ADVANCE(483);
+      if (lookahead == 'n') ADVANCE(510);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 491:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'k') ADVANCE(509);
+      if (lookahead == 'n') ADVANCE(498);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 492:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'l') ADVANCE(509);
+      if (lookahead == 'o') ADVANCE(502);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 493:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'n') ADVANCE(509);
+      if (lookahead == 'p') ADVANCE(510);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 494:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'n') ADVANCE(500);
+      if (lookahead == 'p') ADVANCE(459);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 495:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'o') ADVANCE(502);
+      if (lookahead == 'r') ADVANCE(505);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 496:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'p') ADVANCE(509);
+      if (lookahead == 'r') ADVANCE(485);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 497:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'r') ADVANCE(501);
+      if (lookahead == 'r') ADVANCE(499);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 498:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'r') ADVANCE(505);
+      if (lookahead == 's') ADVANCE(484);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 499:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'r') ADVANCE(488);
+      if (lookahead == 't') ADVANCE(510);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 500:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 's') ADVANCE(487);
+      if (lookahead == 't') ADVANCE(494);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 501:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 't') ADVANCE(509);
+      if (lookahead == 't') ADVANCE(500);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 502:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'w') ADVANCE(493);
+      if (lookahead == 'w') ADVANCE(490);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 503:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
       if (lookahead == '{') ADVANCE(504);
-      if (lookahead == '}') ADVANCE(509);
+      if (lookahead == '}') ADVANCE(510);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 504:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
       if (lookahead == '{') ADVANCE(504);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(508);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(509);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 505:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '}') ADVANCE(509);
+      if (lookahead == '}') ADVANCE(510);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 506:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
       if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(509);
+          lookahead == ']') ADVANCE(510);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(507);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
@@ -5969,727 +6259,870 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 507:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'A' ||
-          lookahead == 'C' ||
-          lookahead == 'D' ||
-          lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(471);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(472);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(511);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(507);
       END_STATE();
     case 508:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(508);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
+      if (lookahead == 'A' ||
+          lookahead == 'C' ||
+          lookahead == 'D' ||
+          lookahead == 'M' ||
+          lookahead == 'S') ADVANCE(458);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(461);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
+          lookahead != '|') ADVANCE(510);
       END_STATE();
     case 509:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(509);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(510);
+      END_STATE();
+    case 510:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(511);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(510);
+      END_STATE();
+    case 511:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(509);
-      END_STATE();
-    case 510:
-      ACCEPT_TOKEN(anon_sym_PIPE2);
-      END_STATE();
-    case 511:
-      ACCEPT_TOKEN(anon_sym_BQUOTE);
+          lookahead != '|') ADVANCE(511);
       END_STATE();
     case 512:
-      ACCEPT_TOKEN(anon_sym_BQUOTE);
-      if (lookahead == '\n') ADVANCE(380);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(141);
+      ACCEPT_TOKEN(anon_sym_PIPE2);
       END_STATE();
     case 513:
       ACCEPT_TOKEN(anon_sym_BQUOTE);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(242);
       END_STATE();
     case 514:
       ACCEPT_TOKEN(anon_sym_BQUOTE);
+      if (lookahead == '\n') ADVANCE(379);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(21);
+      if (lookahead != 0) ADVANCE(138);
+      END_STATE();
+    case 515:
+      ACCEPT_TOKEN(anon_sym_BQUOTE);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
-    case 515:
+    case 516:
+      ACCEPT_TOKEN(anon_sym_BQUOTE);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(236);
+      END_STATE();
+    case 517:
       ACCEPT_TOKEN(aux_sym_codespan_token1);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '`') ADVANCE(515);
-      END_STATE();
-    case 516:
-      ACCEPT_TOKEN(anon_sym_BQUOTE2);
-      END_STATE();
-    case 517:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '(') ADVANCE(576);
-      if (lookahead == '-') ADVANCE(569);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '`') ADVANCE(517);
       END_STATE();
     case 518:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '(') ADVANCE(576);
-      if (lookahead == '-') ADVANCE(539);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+      ACCEPT_TOKEN(anon_sym_BQUOTE2);
       END_STATE();
     case 519:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '(') ADVANCE(576);
-      if (lookahead == '-') ADVANCE(570);
+      if (lookahead == '-') ADVANCE(529);
+      if (lookahead == '>') ADVANCE(579);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(526);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 520:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '(') ADVANCE(576);
-      if (lookahead == ':') ADVANCE(571);
-      if (lookahead == 's') ADVANCE(521);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead == '-') ADVANCE(571);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 521:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '(') ADVANCE(576);
-      if (lookahead == ':') ADVANCE(571);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead == '-') ADVANCE(531);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 522:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '(') ADVANCE(576);
-      if (lookahead == 'A') ADVANCE(519);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead == '-') ADVANCE(572);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 523:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '(') ADVANCE(576);
-      if (lookahead == 'E') ADVANCE(529);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead == '-') ADVANCE(576);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 524:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '(') ADVANCE(576);
-      if (lookahead == 'L') ADVANCE(528);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead == ':') ADVANCE(574);
+      if (lookahead == 's') ADVANCE(525);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 525:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '(') ADVANCE(576);
-      if (lookahead == 'L') ADVANCE(518);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead == ':') ADVANCE(574);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 526:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '(') ADVANCE(576);
-      if (lookahead == 'R') ADVANCE(525);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '>') ADVANCE(579);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(526);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 527:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '(') ADVANCE(576);
-      if (lookahead == 'T') ADVANCE(526);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead == '>') ADVANCE(579);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 528:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '(') ADVANCE(576);
-      if (lookahead == 'T') ADVANCE(517);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead == '>') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(580);
       END_STATE();
     case 529:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '(') ADVANCE(576);
-      if (lookahead == 'T') ADVANCE(522);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '>') ADVANCE(527);
+      if (lookahead == '}') ADVANCE(50);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(25);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(528);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(526);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '\n') ADVANCE(527);
       END_STATE();
     case 530:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '(') ADVANCE(576);
-      if (lookahead == 'p') ADVANCE(520);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead == 'A') ADVANCE(522);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 531:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '(') ADVANCE(576);
-      if (lookahead == 't') ADVANCE(530);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead == 'B') ADVANCE(562);
+      if (lookahead == 'D') ADVANCE(548);
+      if (lookahead == 'I') ADVANCE(557);
+      if (lookahead == 'P') ADVANCE(544);
+      if (lookahead == 'S') ADVANCE(535);
+      if (lookahead == '{') ADVANCE(547);
+      if (lookahead == '}') ADVANCE(284);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(284);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '\n') ADVANCE(579);
       END_STATE();
     case 532:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '(') ADVANCE(576);
-      if (lookahead == 't') ADVANCE(531);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead == 'D') ADVANCE(558);
+      if (lookahead == 'U') ADVANCE(559);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 533:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '(') ADVANCE(576);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(533);
+      if (lookahead == 'E') ADVANCE(542);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 534:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '-') ADVANCE(538);
-      if (lookahead == '>') ADVANCE(576);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(536);
+      if (lookahead == 'F') ADVANCE(543);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 535:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '-') ADVANCE(573);
+      if (lookahead == 'H') ADVANCE(536);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 536:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '>') ADVANCE(576);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(536);
+      if (lookahead == 'I') ADVANCE(534);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 537:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '>') ADVANCE(576);
+      if (lookahead == 'L') ADVANCE(541);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 538:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '>') ADVANCE(537);
-      if (lookahead == '}') ADVANCE(62);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(25);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(536);
+      if (lookahead == 'L') ADVANCE(521);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(537);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 539:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'B') ADVANCE(563);
-      if (lookahead == 'D') ADVANCE(549);
-      if (lookahead == 'I') ADVANCE(558);
-      if (lookahead == 'P') ADVANCE(545);
-      if (lookahead == 'S') ADVANCE(542);
-      if (lookahead == '{') ADVANCE(548);
-      if (lookahead == '}') ADVANCE(289);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(289);
+      if (lookahead == 'R') ADVANCE(538);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(576);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 540:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'D') ADVANCE(559);
-      if (lookahead == 'U') ADVANCE(560);
+      if (lookahead == 'T') ADVANCE(539);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 541:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'F') ADVANCE(544);
+      if (lookahead == 'T') ADVANCE(520);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 542:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'H') ADVANCE(543);
+      if (lookahead == 'T') ADVANCE(530);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 543:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'I') ADVANCE(541);
+      if (lookahead == 'T') ADVANCE(523);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 544:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'T') ADVANCE(535);
+      if (lookahead == 'a') ADVANCE(552);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 545:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'a') ADVANCE(553);
+      if (lookahead == 'a') ADVANCE(554);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 546:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'a') ADVANCE(555);
+      if (lookahead == 'a') ADVANCE(561);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 547:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'a') ADVANCE(562);
+      if (lookahead == 'c') ADVANCE(553);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 548:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'c') ADVANCE(554);
+      if (lookahead == 'e') ADVANCE(555);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 549:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'e') ADVANCE(556);
+      if (lookahead == 'e') ADVANCE(532);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 550:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'e') ADVANCE(540);
+      if (lookahead == 'e') ADVANCE(563);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 551:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'e') ADVANCE(561);
+      if (lookahead == 'e') ADVANCE(545);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 552:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'e') ADVANCE(546);
+      if (lookahead == 'g') ADVANCE(549);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 553:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'g') ADVANCE(550);
+      if (lookahead == 'h') ADVANCE(546);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 554:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'h') ADVANCE(547);
+      if (lookahead == 'k') ADVANCE(579);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 555:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'k') ADVANCE(576);
+      if (lookahead == 'l') ADVANCE(579);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 556:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'l') ADVANCE(576);
+      if (lookahead == 'n') ADVANCE(579);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 557:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'n') ADVANCE(576);
+      if (lookahead == 'n') ADVANCE(564);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 558:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'n') ADVANCE(564);
+      if (lookahead == 'o') ADVANCE(568);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 559:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'o') ADVANCE(566);
+      if (lookahead == 'p') ADVANCE(579);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 560:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'p') ADVANCE(576);
+      if (lookahead == 'p') ADVANCE(524);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 561:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'r') ADVANCE(565);
+      if (lookahead == 'r') ADVANCE(575);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 562:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'r') ADVANCE(572);
+      if (lookahead == 'r') ADVANCE(551);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 563:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'r') ADVANCE(552);
+      if (lookahead == 'r') ADVANCE(565);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 564:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 's') ADVANCE(551);
+      if (lookahead == 's') ADVANCE(550);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 565:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 't') ADVANCE(576);
+      if (lookahead == 't') ADVANCE(579);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 566:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'w') ADVANCE(557);
+      if (lookahead == 't') ADVANCE(560);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 567:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '{') ADVANCE(567);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(575);
+      if (lookahead == 't') ADVANCE(566);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 568:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '|') ADVANCE(568);
+      if (lookahead == 'w') ADVANCE(556);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 569:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '}') ADVANCE(328);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(328);
+      if (lookahead == '{') ADVANCE(569);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(578);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(576);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 570:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '}') ADVANCE(324);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(324);
+      if (lookahead == '|') ADVANCE(570);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(576);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(579);
       END_STATE();
     case 571:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '}') ADVANCE(448);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(576);
+      if (lookahead == '}') ADVANCE(326);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(326);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(571);
+          lookahead != '\n') ADVANCE(579);
       END_STATE();
     case 572:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '}') ADVANCE(322);
+      if (lookahead == '}') ADVANCE(321);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(321);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(576);
+          lookahead != '\n') ADVANCE(579);
       END_STATE();
     case 573:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '}') ADVANCE(316);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(316);
+      if (lookahead == '}') ADVANCE(450);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(580);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(576);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(573);
       END_STATE();
     case 574:
       ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '}') ADVANCE(449);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(579);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(573);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(574);
+      END_STATE();
+    case 575:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '}') ADVANCE(319);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(579);
+      END_STATE();
+    case 576:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '}') ADVANCE(312);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(312);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(579);
+      END_STATE();
+    case 577:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(534);
+          lookahead == 'S') ADVANCE(519);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(536);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(526);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
-    case 575:
+    case 578:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(575);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(578);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(579);
       END_STATE();
-    case 576:
+    case 579:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(580);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(579);
+      END_STATE();
+    case 580:
       ACCEPT_TOKEN(aux_sym_argument_token1);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(576);
+          lookahead != '}') ADVANCE(580);
       END_STATE();
-    case 577:
-      ACCEPT_TOKEN(anon_sym_RBRACE2);
+    case 581:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
       END_STATE();
     default:
       return false;
@@ -6762,8 +7195,8 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [62] = {.lex_state = 9},
   [63] = {.lex_state = 8},
   [64] = {.lex_state = 8},
-  [65] = {.lex_state = 10},
-  [66] = {.lex_state = 8},
+  [65] = {.lex_state = 8},
+  [66] = {.lex_state = 10},
   [67] = {.lex_state = 11},
   [68] = {.lex_state = 11},
   [69] = {.lex_state = 3},
@@ -6810,22 +7243,19 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   [0] = {
     [ts_builtin_sym_end] = ACTIONS(1),
     [aux_sym_word_token1] = ACTIONS(1),
-    [aux_sym_word_token2] = ACTIONS(1),
-    [aux_sym_word_noli_token1] = ACTIONS(1),
-    [aux_sym_word_noli_token2] = ACTIONS(1),
     [anon_sym_STAR] = ACTIONS(1),
     [anon_sym_SQUOTE] = ACTIONS(1),
     [aux_sym__word_common_token1] = ACTIONS(1),
     [anon_sym_SQUOTE2] = ACTIONS(1),
     [anon_sym_PIPE] = ACTIONS(1),
     [anon_sym_LBRACE] = ACTIONS(1),
-    [anon_sym_RBRACE] = ACTIONS(1),
     [anon_sym_LBRACE_RBRACE] = ACTIONS(1),
     [aux_sym__word_common_token4] = ACTIONS(1),
     [anon_sym_LPAREN] = ACTIONS(1),
-    [aux_sym__word_common_token5] = ACTIONS(1),
+    [anon_sym_LBRACK] = ACTIONS(1),
     [anon_sym_TILDE] = ACTIONS(1),
     [anon_sym_GT] = ACTIONS(1),
+    [anon_sym_COMMA] = ACTIONS(1),
     [aux_sym_keycode_token1] = ACTIONS(1),
     [aux_sym_keycode_token2] = ACTIONS(1),
     [aux_sym_keycode_token3] = ACTIONS(1),
@@ -6844,7 +7274,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_PIPE2] = ACTIONS(1),
     [anon_sym_BQUOTE] = ACTIONS(1),
     [anon_sym_BQUOTE2] = ACTIONS(1),
-    [anon_sym_RBRACE2] = ACTIONS(1),
+    [anon_sym_RBRACE] = ACTIONS(1),
   },
   [1] = {
     [sym_help_file] = STATE(102),
@@ -6883,13 +7313,13 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym__word_common_token3] = ACTIONS(11),
     [anon_sym_PIPE] = ACTIONS(13),
     [anon_sym_LBRACE] = ACTIONS(15),
-    [anon_sym_RBRACE] = ACTIONS(11),
     [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
     [aux_sym__word_common_token4] = ACTIONS(11),
     [anon_sym_LPAREN] = ACTIONS(5),
-    [aux_sym__word_common_token5] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(11),
     [anon_sym_TILDE] = ACTIONS(11),
     [anon_sym_GT] = ACTIONS(17),
+    [anon_sym_COMMA] = ACTIONS(11),
     [aux_sym_keycode_token1] = ACTIONS(19),
     [aux_sym_keycode_token2] = ACTIONS(19),
     [aux_sym_keycode_token3] = ACTIONS(19),
@@ -6943,13 +7373,13 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym__word_common_token3] = ACTIONS(11),
     [anon_sym_PIPE] = ACTIONS(13),
     [anon_sym_LBRACE] = ACTIONS(15),
-    [anon_sym_RBRACE] = ACTIONS(11),
     [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
     [aux_sym__word_common_token4] = ACTIONS(11),
     [anon_sym_LPAREN] = ACTIONS(5),
-    [aux_sym__word_common_token5] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(11),
     [anon_sym_TILDE] = ACTIONS(11),
     [anon_sym_GT] = ACTIONS(17),
+    [anon_sym_COMMA] = ACTIONS(11),
     [aux_sym_keycode_token1] = ACTIONS(19),
     [aux_sym_keycode_token2] = ACTIONS(19),
     [aux_sym_keycode_token3] = ACTIONS(19),
@@ -7001,13 +7431,13 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym__word_common_token3] = ACTIONS(11),
     [anon_sym_PIPE] = ACTIONS(13),
     [anon_sym_LBRACE] = ACTIONS(15),
-    [anon_sym_RBRACE] = ACTIONS(11),
     [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
     [aux_sym__word_common_token4] = ACTIONS(11),
     [anon_sym_LPAREN] = ACTIONS(5),
-    [aux_sym__word_common_token5] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(11),
     [anon_sym_TILDE] = ACTIONS(11),
     [anon_sym_GT] = ACTIONS(17),
+    [anon_sym_COMMA] = ACTIONS(11),
     [aux_sym_keycode_token1] = ACTIONS(19),
     [aux_sym_keycode_token2] = ACTIONS(19),
     [aux_sym_keycode_token3] = ACTIONS(19),
@@ -7058,13 +7488,13 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym__word_common_token3] = ACTIONS(54),
     [anon_sym_PIPE] = ACTIONS(57),
     [anon_sym_LBRACE] = ACTIONS(60),
-    [anon_sym_RBRACE] = ACTIONS(54),
     [anon_sym_LBRACE_RBRACE] = ACTIONS(54),
     [aux_sym__word_common_token4] = ACTIONS(54),
     [anon_sym_LPAREN] = ACTIONS(45),
-    [aux_sym__word_common_token5] = ACTIONS(45),
+    [anon_sym_LBRACK] = ACTIONS(54),
     [anon_sym_TILDE] = ACTIONS(54),
     [anon_sym_GT] = ACTIONS(63),
+    [anon_sym_COMMA] = ACTIONS(54),
     [aux_sym_keycode_token1] = ACTIONS(66),
     [aux_sym_keycode_token2] = ACTIONS(66),
     [aux_sym_keycode_token3] = ACTIONS(66),
@@ -7115,13 +7545,13 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym__word_common_token3] = ACTIONS(11),
     [anon_sym_PIPE] = ACTIONS(13),
     [anon_sym_LBRACE] = ACTIONS(15),
-    [anon_sym_RBRACE] = ACTIONS(11),
     [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
     [aux_sym__word_common_token4] = ACTIONS(11),
     [anon_sym_LPAREN] = ACTIONS(5),
-    [aux_sym__word_common_token5] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(11),
     [anon_sym_TILDE] = ACTIONS(11),
     [anon_sym_GT] = ACTIONS(17),
+    [anon_sym_COMMA] = ACTIONS(11),
     [aux_sym_keycode_token1] = ACTIONS(19),
     [aux_sym_keycode_token2] = ACTIONS(19),
     [aux_sym_keycode_token3] = ACTIONS(19),
@@ -7170,13 +7600,13 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym__word_common_token3] = ACTIONS(11),
     [anon_sym_PIPE] = ACTIONS(13),
     [anon_sym_LBRACE] = ACTIONS(15),
-    [anon_sym_RBRACE] = ACTIONS(11),
     [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
     [aux_sym__word_common_token4] = ACTIONS(11),
     [anon_sym_LPAREN] = ACTIONS(5),
-    [aux_sym__word_common_token5] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(11),
     [anon_sym_TILDE] = ACTIONS(11),
     [anon_sym_GT] = ACTIONS(17),
+    [anon_sym_COMMA] = ACTIONS(11),
     [aux_sym_keycode_token1] = ACTIONS(19),
     [aux_sym_keycode_token2] = ACTIONS(19),
     [aux_sym_keycode_token3] = ACTIONS(19),
@@ -7223,13 +7653,13 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym__word_common_token3] = ACTIONS(106),
     [anon_sym_PIPE] = ACTIONS(109),
     [anon_sym_LBRACE] = ACTIONS(112),
-    [anon_sym_RBRACE] = ACTIONS(106),
     [anon_sym_LBRACE_RBRACE] = ACTIONS(106),
     [aux_sym__word_common_token4] = ACTIONS(106),
     [anon_sym_LPAREN] = ACTIONS(97),
-    [aux_sym__word_common_token5] = ACTIONS(97),
+    [anon_sym_LBRACK] = ACTIONS(106),
     [anon_sym_TILDE] = ACTIONS(106),
     [anon_sym_GT] = ACTIONS(115),
+    [anon_sym_COMMA] = ACTIONS(106),
     [aux_sym_keycode_token1] = ACTIONS(118),
     [aux_sym_keycode_token2] = ACTIONS(118),
     [aux_sym_keycode_token3] = ACTIONS(118),
@@ -7247,70 +7677,406 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_url_word] = ACTIONS(137),
     [anon_sym_BQUOTE] = ACTIONS(140),
   },
+  [8] = {
+    [sym__atom_noli] = STATE(17),
+    [sym_word_noli] = STATE(17),
+    [sym__atom_common] = STATE(17),
+    [sym__word_common] = STATE(87),
+    [sym_keycode] = STATE(17),
+    [sym__uppercase_words] = STATE(17),
+    [sym__line_noli] = STATE(65),
+    [sym_tag] = STATE(17),
+    [sym_url] = STATE(17),
+    [sym_optionlink] = STATE(17),
+    [sym_taglink] = STATE(17),
+    [sym_codespan] = STATE(17),
+    [sym_argument] = STATE(17),
+    [aux_sym_line_li_repeat2] = STATE(8),
+    [aux_sym_word_noli_token1] = ACTIONS(143),
+    [aux_sym_word_noli_token2] = ACTIONS(146),
+    [anon_sym_STAR] = ACTIONS(149),
+    [anon_sym_SQUOTE] = ACTIONS(152),
+    [aux_sym__word_common_token3] = ACTIONS(146),
+    [anon_sym_PIPE] = ACTIONS(155),
+    [anon_sym_LBRACE] = ACTIONS(158),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(146),
+    [aux_sym__word_common_token4] = ACTIONS(146),
+    [anon_sym_LPAREN] = ACTIONS(143),
+    [anon_sym_LBRACK] = ACTIONS(146),
+    [anon_sym_TILDE] = ACTIONS(146),
+    [anon_sym_GT] = ACTIONS(146),
+    [anon_sym_COMMA] = ACTIONS(146),
+    [aux_sym_keycode_token1] = ACTIONS(161),
+    [aux_sym_keycode_token2] = ACTIONS(161),
+    [aux_sym_keycode_token3] = ACTIONS(161),
+    [aux_sym_keycode_token4] = ACTIONS(161),
+    [aux_sym_keycode_token5] = ACTIONS(164),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(164),
+    [aux_sym_keycode_token6] = ACTIONS(161),
+    [aux_sym_keycode_token7] = ACTIONS(161),
+    [aux_sym_uppercase_name_token1] = ACTIONS(167),
+    [anon_sym_LT] = ACTIONS(170),
+    [anon_sym_LF2] = ACTIONS(172),
+    [aux_sym_line_li_token1] = ACTIONS(172),
+    [sym_url_word] = ACTIONS(174),
+    [anon_sym_BQUOTE] = ACTIONS(177),
+  },
+  [9] = {
+    [sym__atom_noli] = STATE(17),
+    [sym_word_noli] = STATE(17),
+    [sym__atom_common] = STATE(17),
+    [sym__word_common] = STATE(87),
+    [sym_keycode] = STATE(17),
+    [sym__uppercase_words] = STATE(17),
+    [sym__line_noli] = STATE(65),
+    [sym_tag] = STATE(17),
+    [sym_url] = STATE(17),
+    [sym_optionlink] = STATE(17),
+    [sym_taglink] = STATE(17),
+    [sym_codespan] = STATE(17),
+    [sym_argument] = STATE(17),
+    [aux_sym_line_li_repeat2] = STATE(8),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(7),
+    [anon_sym_SQUOTE] = ACTIONS(9),
+    [aux_sym__word_common_token3] = ACTIONS(11),
+    [anon_sym_PIPE] = ACTIONS(13),
+    [anon_sym_LBRACE] = ACTIONS(15),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(11),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(11),
+    [anon_sym_TILDE] = ACTIONS(11),
+    [anon_sym_GT] = ACTIONS(11),
+    [anon_sym_COMMA] = ACTIONS(11),
+    [aux_sym_keycode_token1] = ACTIONS(19),
+    [aux_sym_keycode_token2] = ACTIONS(19),
+    [aux_sym_keycode_token3] = ACTIONS(19),
+    [aux_sym_keycode_token4] = ACTIONS(19),
+    [aux_sym_keycode_token5] = ACTIONS(21),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(21),
+    [aux_sym_keycode_token6] = ACTIONS(19),
+    [aux_sym_keycode_token7] = ACTIONS(19),
+    [aux_sym_uppercase_name_token1] = ACTIONS(180),
+    [anon_sym_LT] = ACTIONS(182),
+    [anon_sym_LF2] = ACTIONS(184),
+    [aux_sym_line_li_token1] = ACTIONS(184),
+    [sym_url_word] = ACTIONS(35),
+    [anon_sym_BQUOTE] = ACTIONS(37),
+  },
+  [10] = {
+    [sym__atom_noli] = STATE(17),
+    [sym_word_noli] = STATE(17),
+    [sym__atom_common] = STATE(17),
+    [sym__word_common] = STATE(87),
+    [sym_keycode] = STATE(17),
+    [sym__uppercase_words] = STATE(17),
+    [sym__line_noli] = STATE(65),
+    [sym_tag] = STATE(17),
+    [sym_url] = STATE(17),
+    [sym_optionlink] = STATE(17),
+    [sym_taglink] = STATE(17),
+    [sym_codespan] = STATE(17),
+    [sym_argument] = STATE(17),
+    [aux_sym_line_li_repeat2] = STATE(8),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(7),
+    [anon_sym_SQUOTE] = ACTIONS(9),
+    [aux_sym__word_common_token3] = ACTIONS(11),
+    [anon_sym_PIPE] = ACTIONS(13),
+    [anon_sym_LBRACE] = ACTIONS(15),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(11),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(11),
+    [anon_sym_TILDE] = ACTIONS(11),
+    [anon_sym_GT] = ACTIONS(11),
+    [anon_sym_COMMA] = ACTIONS(11),
+    [aux_sym_keycode_token1] = ACTIONS(19),
+    [aux_sym_keycode_token2] = ACTIONS(19),
+    [aux_sym_keycode_token3] = ACTIONS(19),
+    [aux_sym_keycode_token4] = ACTIONS(19),
+    [aux_sym_keycode_token5] = ACTIONS(21),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(21),
+    [aux_sym_keycode_token6] = ACTIONS(19),
+    [aux_sym_keycode_token7] = ACTIONS(19),
+    [aux_sym_uppercase_name_token1] = ACTIONS(180),
+    [anon_sym_LT] = ACTIONS(186),
+    [anon_sym_LF2] = ACTIONS(188),
+    [aux_sym_line_li_token1] = ACTIONS(188),
+    [sym_url_word] = ACTIONS(35),
+    [anon_sym_BQUOTE] = ACTIONS(37),
+  },
+  [11] = {
+    [sym__atom_noli] = STATE(17),
+    [sym_word_noli] = STATE(17),
+    [sym__atom_common] = STATE(17),
+    [sym__word_common] = STATE(87),
+    [sym_keycode] = STATE(17),
+    [sym__uppercase_words] = STATE(17),
+    [sym__line_noli] = STATE(65),
+    [sym_tag] = STATE(17),
+    [sym_url] = STATE(17),
+    [sym_optionlink] = STATE(17),
+    [sym_taglink] = STATE(17),
+    [sym_codespan] = STATE(17),
+    [sym_argument] = STATE(17),
+    [aux_sym_line_li_repeat2] = STATE(8),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(7),
+    [anon_sym_SQUOTE] = ACTIONS(9),
+    [aux_sym__word_common_token3] = ACTIONS(11),
+    [anon_sym_PIPE] = ACTIONS(13),
+    [anon_sym_LBRACE] = ACTIONS(15),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(11),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(11),
+    [anon_sym_TILDE] = ACTIONS(11),
+    [anon_sym_GT] = ACTIONS(11),
+    [anon_sym_COMMA] = ACTIONS(11),
+    [aux_sym_keycode_token1] = ACTIONS(19),
+    [aux_sym_keycode_token2] = ACTIONS(19),
+    [aux_sym_keycode_token3] = ACTIONS(19),
+    [aux_sym_keycode_token4] = ACTIONS(19),
+    [aux_sym_keycode_token5] = ACTIONS(21),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(21),
+    [aux_sym_keycode_token6] = ACTIONS(19),
+    [aux_sym_keycode_token7] = ACTIONS(19),
+    [aux_sym_uppercase_name_token1] = ACTIONS(180),
+    [anon_sym_LT] = ACTIONS(190),
+    [anon_sym_LF2] = ACTIONS(192),
+    [aux_sym_line_li_token1] = ACTIONS(192),
+    [sym_url_word] = ACTIONS(35),
+    [anon_sym_BQUOTE] = ACTIONS(37),
+  },
+  [12] = {
+    [sym__atom_noli] = STATE(17),
+    [sym_word_noli] = STATE(17),
+    [sym__atom_common] = STATE(17),
+    [sym__word_common] = STATE(87),
+    [sym_keycode] = STATE(17),
+    [sym__uppercase_words] = STATE(17),
+    [sym__line_noli] = STATE(65),
+    [sym_tag] = STATE(17),
+    [sym_url] = STATE(17),
+    [sym_optionlink] = STATE(17),
+    [sym_taglink] = STATE(17),
+    [sym_codespan] = STATE(17),
+    [sym_argument] = STATE(17),
+    [aux_sym_line_li_repeat2] = STATE(8),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(7),
+    [anon_sym_SQUOTE] = ACTIONS(9),
+    [aux_sym__word_common_token3] = ACTIONS(11),
+    [anon_sym_PIPE] = ACTIONS(13),
+    [anon_sym_LBRACE] = ACTIONS(15),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(11),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(11),
+    [anon_sym_TILDE] = ACTIONS(11),
+    [anon_sym_GT] = ACTIONS(11),
+    [anon_sym_COMMA] = ACTIONS(11),
+    [aux_sym_keycode_token1] = ACTIONS(19),
+    [aux_sym_keycode_token2] = ACTIONS(19),
+    [aux_sym_keycode_token3] = ACTIONS(19),
+    [aux_sym_keycode_token4] = ACTIONS(19),
+    [aux_sym_keycode_token5] = ACTIONS(21),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(21),
+    [aux_sym_keycode_token6] = ACTIONS(19),
+    [aux_sym_keycode_token7] = ACTIONS(19),
+    [aux_sym_uppercase_name_token1] = ACTIONS(180),
+    [anon_sym_LT] = ACTIONS(194),
+    [anon_sym_LF2] = ACTIONS(196),
+    [aux_sym_line_li_token1] = ACTIONS(196),
+    [sym_url_word] = ACTIONS(35),
+    [anon_sym_BQUOTE] = ACTIONS(37),
+  },
+  [13] = {
+    [sym__atom_noli] = STATE(17),
+    [sym_word_noli] = STATE(17),
+    [sym__atom_common] = STATE(17),
+    [sym__word_common] = STATE(87),
+    [sym_keycode] = STATE(17),
+    [sym__uppercase_words] = STATE(17),
+    [sym__line_noli] = STATE(65),
+    [sym_tag] = STATE(17),
+    [sym_url] = STATE(17),
+    [sym_optionlink] = STATE(17),
+    [sym_taglink] = STATE(17),
+    [sym_codespan] = STATE(17),
+    [sym_argument] = STATE(17),
+    [aux_sym_line_li_repeat2] = STATE(9),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(7),
+    [anon_sym_SQUOTE] = ACTIONS(9),
+    [aux_sym__word_common_token3] = ACTIONS(11),
+    [anon_sym_PIPE] = ACTIONS(13),
+    [anon_sym_LBRACE] = ACTIONS(15),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(11),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(11),
+    [anon_sym_TILDE] = ACTIONS(11),
+    [anon_sym_GT] = ACTIONS(11),
+    [anon_sym_COMMA] = ACTIONS(11),
+    [aux_sym_keycode_token1] = ACTIONS(19),
+    [aux_sym_keycode_token2] = ACTIONS(19),
+    [aux_sym_keycode_token3] = ACTIONS(19),
+    [aux_sym_keycode_token4] = ACTIONS(19),
+    [aux_sym_keycode_token5] = ACTIONS(21),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(21),
+    [aux_sym_keycode_token6] = ACTIONS(19),
+    [aux_sym_keycode_token7] = ACTIONS(19),
+    [aux_sym_uppercase_name_token1] = ACTIONS(180),
+    [anon_sym_LT] = ACTIONS(198),
+    [anon_sym_LF2] = ACTIONS(200),
+    [aux_sym_line_li_token1] = ACTIONS(200),
+    [sym_url_word] = ACTIONS(35),
+    [anon_sym_BQUOTE] = ACTIONS(37),
+  },
+  [14] = {
+    [sym__atom_noli] = STATE(17),
+    [sym_word_noli] = STATE(17),
+    [sym__atom_common] = STATE(17),
+    [sym__word_common] = STATE(87),
+    [sym_keycode] = STATE(17),
+    [sym__uppercase_words] = STATE(17),
+    [sym__line_noli] = STATE(65),
+    [sym_tag] = STATE(17),
+    [sym_url] = STATE(17),
+    [sym_optionlink] = STATE(17),
+    [sym_taglink] = STATE(17),
+    [sym_codespan] = STATE(17),
+    [sym_argument] = STATE(17),
+    [aux_sym_line_li_repeat2] = STATE(10),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(7),
+    [anon_sym_SQUOTE] = ACTIONS(9),
+    [aux_sym__word_common_token3] = ACTIONS(11),
+    [anon_sym_PIPE] = ACTIONS(13),
+    [anon_sym_LBRACE] = ACTIONS(15),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(11),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(11),
+    [anon_sym_TILDE] = ACTIONS(11),
+    [anon_sym_GT] = ACTIONS(11),
+    [anon_sym_COMMA] = ACTIONS(11),
+    [aux_sym_keycode_token1] = ACTIONS(19),
+    [aux_sym_keycode_token2] = ACTIONS(19),
+    [aux_sym_keycode_token3] = ACTIONS(19),
+    [aux_sym_keycode_token4] = ACTIONS(19),
+    [aux_sym_keycode_token5] = ACTIONS(21),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(21),
+    [aux_sym_keycode_token6] = ACTIONS(19),
+    [aux_sym_keycode_token7] = ACTIONS(19),
+    [aux_sym_uppercase_name_token1] = ACTIONS(180),
+    [anon_sym_LT] = ACTIONS(202),
+    [anon_sym_LF2] = ACTIONS(204),
+    [aux_sym_line_li_token1] = ACTIONS(204),
+    [sym_url_word] = ACTIONS(35),
+    [anon_sym_BQUOTE] = ACTIONS(37),
+  },
+  [15] = {
+    [sym__atom_noli] = STATE(17),
+    [sym_word_noli] = STATE(17),
+    [sym__atom_common] = STATE(17),
+    [sym__word_common] = STATE(87),
+    [sym_keycode] = STATE(17),
+    [sym__uppercase_words] = STATE(17),
+    [sym__line_noli] = STATE(65),
+    [sym_tag] = STATE(17),
+    [sym_url] = STATE(17),
+    [sym_optionlink] = STATE(17),
+    [sym_taglink] = STATE(17),
+    [sym_codespan] = STATE(17),
+    [sym_argument] = STATE(17),
+    [aux_sym_line_li_repeat2] = STATE(11),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(7),
+    [anon_sym_SQUOTE] = ACTIONS(9),
+    [aux_sym__word_common_token3] = ACTIONS(11),
+    [anon_sym_PIPE] = ACTIONS(13),
+    [anon_sym_LBRACE] = ACTIONS(15),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(11),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(11),
+    [anon_sym_TILDE] = ACTIONS(11),
+    [anon_sym_GT] = ACTIONS(11),
+    [anon_sym_COMMA] = ACTIONS(11),
+    [aux_sym_keycode_token1] = ACTIONS(19),
+    [aux_sym_keycode_token2] = ACTIONS(19),
+    [aux_sym_keycode_token3] = ACTIONS(19),
+    [aux_sym_keycode_token4] = ACTIONS(19),
+    [aux_sym_keycode_token5] = ACTIONS(21),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(21),
+    [aux_sym_keycode_token6] = ACTIONS(19),
+    [aux_sym_keycode_token7] = ACTIONS(19),
+    [aux_sym_uppercase_name_token1] = ACTIONS(180),
+    [anon_sym_LT] = ACTIONS(206),
+    [anon_sym_LF2] = ACTIONS(208),
+    [aux_sym_line_li_token1] = ACTIONS(208),
+    [sym_url_word] = ACTIONS(35),
+    [anon_sym_BQUOTE] = ACTIONS(37),
+  },
+  [16] = {
+    [sym__atom_noli] = STATE(17),
+    [sym_word_noli] = STATE(17),
+    [sym__atom_common] = STATE(17),
+    [sym__word_common] = STATE(87),
+    [sym_keycode] = STATE(17),
+    [sym__uppercase_words] = STATE(17),
+    [sym__line_noli] = STATE(65),
+    [sym_tag] = STATE(17),
+    [sym_url] = STATE(17),
+    [sym_optionlink] = STATE(17),
+    [sym_taglink] = STATE(17),
+    [sym_codespan] = STATE(17),
+    [sym_argument] = STATE(17),
+    [aux_sym_line_li_repeat2] = STATE(12),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(7),
+    [anon_sym_SQUOTE] = ACTIONS(9),
+    [aux_sym__word_common_token3] = ACTIONS(11),
+    [anon_sym_PIPE] = ACTIONS(13),
+    [anon_sym_LBRACE] = ACTIONS(15),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(11),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(11),
+    [anon_sym_TILDE] = ACTIONS(11),
+    [anon_sym_GT] = ACTIONS(11),
+    [anon_sym_COMMA] = ACTIONS(11),
+    [aux_sym_keycode_token1] = ACTIONS(19),
+    [aux_sym_keycode_token2] = ACTIONS(19),
+    [aux_sym_keycode_token3] = ACTIONS(19),
+    [aux_sym_keycode_token4] = ACTIONS(19),
+    [aux_sym_keycode_token5] = ACTIONS(21),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(21),
+    [aux_sym_keycode_token6] = ACTIONS(19),
+    [aux_sym_keycode_token7] = ACTIONS(19),
+    [aux_sym_uppercase_name_token1] = ACTIONS(180),
+    [anon_sym_LT] = ACTIONS(210),
+    [anon_sym_LF2] = ACTIONS(212),
+    [aux_sym_line_li_token1] = ACTIONS(212),
+    [sym_url_word] = ACTIONS(35),
+    [anon_sym_BQUOTE] = ACTIONS(37),
+  },
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 17,
-    ACTIONS(149), 1,
-      anon_sym_STAR,
-    ACTIONS(152), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(155), 1,
-      anon_sym_PIPE,
-    ACTIONS(158), 1,
-      anon_sym_LBRACE,
-    ACTIONS(167), 1,
-      aux_sym_uppercase_name_token1,
-    ACTIONS(170), 1,
-      anon_sym_LT,
-    ACTIONS(174), 1,
-      sym_url_word,
-    ACTIONS(177), 1,
-      anon_sym_BQUOTE,
-    STATE(8), 1,
-      aux_sym_line_li_repeat2,
-    STATE(66), 1,
-      sym__line_noli,
-    STATE(87), 1,
-      sym__word_common,
-    ACTIONS(164), 2,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-    ACTIONS(172), 2,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-    ACTIONS(143), 3,
-      aux_sym_word_noli_token1,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token5,
-    ACTIONS(161), 6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-    ACTIONS(146), 7,
-      aux_sym_word_noli_token2,
-      aux_sym__word_common_token3,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_TILDE,
-      anon_sym_GT,
-    STATE(17), 11,
-      sym__atom_noli,
-      sym_word_noli,
-      sym__atom_common,
-      sym_keycode,
-      sym__uppercase_words,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [77] = 17,
+  [0] = 16,
     ACTIONS(7), 1,
       anon_sym_STAR,
     ACTIONS(9), 1,
@@ -7323,486 +8089,8 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(37), 1,
       anon_sym_BQUOTE,
-    ACTIONS(180), 1,
-      aux_sym_uppercase_name_token1,
-    ACTIONS(182), 1,
-      anon_sym_LT,
-    STATE(8), 1,
-      aux_sym_line_li_repeat2,
-    STATE(66), 1,
-      sym__line_noli,
-    STATE(87), 1,
-      sym__word_common,
-    ACTIONS(21), 2,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-    ACTIONS(184), 2,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-    ACTIONS(5), 3,
-      aux_sym_word_noli_token1,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token5,
-    ACTIONS(19), 6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-    ACTIONS(11), 7,
-      aux_sym_word_noli_token2,
-      aux_sym__word_common_token3,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_TILDE,
-      anon_sym_GT,
-    STATE(17), 11,
-      sym__atom_noli,
-      sym_word_noli,
-      sym__atom_common,
-      sym_keycode,
-      sym__uppercase_words,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [154] = 17,
-    ACTIONS(7), 1,
-      anon_sym_STAR,
-    ACTIONS(9), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(13), 1,
-      anon_sym_PIPE,
-    ACTIONS(15), 1,
-      anon_sym_LBRACE,
-    ACTIONS(35), 1,
-      sym_url_word,
-    ACTIONS(37), 1,
-      anon_sym_BQUOTE,
-    ACTIONS(180), 1,
-      aux_sym_uppercase_name_token1,
-    ACTIONS(186), 1,
-      anon_sym_LT,
-    STATE(8), 1,
-      aux_sym_line_li_repeat2,
-    STATE(66), 1,
-      sym__line_noli,
-    STATE(87), 1,
-      sym__word_common,
-    ACTIONS(21), 2,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-    ACTIONS(188), 2,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-    ACTIONS(5), 3,
-      aux_sym_word_noli_token1,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token5,
-    ACTIONS(19), 6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-    ACTIONS(11), 7,
-      aux_sym_word_noli_token2,
-      aux_sym__word_common_token3,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_TILDE,
-      anon_sym_GT,
-    STATE(17), 11,
-      sym__atom_noli,
-      sym_word_noli,
-      sym__atom_common,
-      sym_keycode,
-      sym__uppercase_words,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [231] = 17,
-    ACTIONS(7), 1,
-      anon_sym_STAR,
-    ACTIONS(9), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(13), 1,
-      anon_sym_PIPE,
-    ACTIONS(15), 1,
-      anon_sym_LBRACE,
-    ACTIONS(35), 1,
-      sym_url_word,
-    ACTIONS(37), 1,
-      anon_sym_BQUOTE,
-    ACTIONS(180), 1,
-      aux_sym_uppercase_name_token1,
-    ACTIONS(190), 1,
-      anon_sym_LT,
-    STATE(8), 1,
-      aux_sym_line_li_repeat2,
-    STATE(66), 1,
-      sym__line_noli,
-    STATE(87), 1,
-      sym__word_common,
-    ACTIONS(21), 2,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-    ACTIONS(192), 2,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-    ACTIONS(5), 3,
-      aux_sym_word_noli_token1,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token5,
-    ACTIONS(19), 6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-    ACTIONS(11), 7,
-      aux_sym_word_noli_token2,
-      aux_sym__word_common_token3,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_TILDE,
-      anon_sym_GT,
-    STATE(17), 11,
-      sym__atom_noli,
-      sym_word_noli,
-      sym__atom_common,
-      sym_keycode,
-      sym__uppercase_words,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [308] = 17,
-    ACTIONS(7), 1,
-      anon_sym_STAR,
-    ACTIONS(9), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(13), 1,
-      anon_sym_PIPE,
-    ACTIONS(15), 1,
-      anon_sym_LBRACE,
-    ACTIONS(35), 1,
-      sym_url_word,
-    ACTIONS(37), 1,
-      anon_sym_BQUOTE,
-    ACTIONS(180), 1,
-      aux_sym_uppercase_name_token1,
-    ACTIONS(194), 1,
-      anon_sym_LT,
-    STATE(8), 1,
-      aux_sym_line_li_repeat2,
-    STATE(66), 1,
-      sym__line_noli,
-    STATE(87), 1,
-      sym__word_common,
-    ACTIONS(21), 2,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-    ACTIONS(196), 2,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-    ACTIONS(5), 3,
-      aux_sym_word_noli_token1,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token5,
-    ACTIONS(19), 6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-    ACTIONS(11), 7,
-      aux_sym_word_noli_token2,
-      aux_sym__word_common_token3,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_TILDE,
-      anon_sym_GT,
-    STATE(17), 11,
-      sym__atom_noli,
-      sym_word_noli,
-      sym__atom_common,
-      sym_keycode,
-      sym__uppercase_words,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [385] = 17,
-    ACTIONS(7), 1,
-      anon_sym_STAR,
-    ACTIONS(9), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(13), 1,
-      anon_sym_PIPE,
-    ACTIONS(15), 1,
-      anon_sym_LBRACE,
-    ACTIONS(35), 1,
-      sym_url_word,
-    ACTIONS(37), 1,
-      anon_sym_BQUOTE,
-    ACTIONS(180), 1,
-      aux_sym_uppercase_name_token1,
-    ACTIONS(198), 1,
-      anon_sym_LT,
-    STATE(9), 1,
-      aux_sym_line_li_repeat2,
-    STATE(66), 1,
-      sym__line_noli,
-    STATE(87), 1,
-      sym__word_common,
-    ACTIONS(21), 2,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-    ACTIONS(200), 2,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-    ACTIONS(5), 3,
-      aux_sym_word_noli_token1,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token5,
-    ACTIONS(19), 6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-    ACTIONS(11), 7,
-      aux_sym_word_noli_token2,
-      aux_sym__word_common_token3,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_TILDE,
-      anon_sym_GT,
-    STATE(17), 11,
-      sym__atom_noli,
-      sym_word_noli,
-      sym__atom_common,
-      sym_keycode,
-      sym__uppercase_words,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [462] = 17,
-    ACTIONS(7), 1,
-      anon_sym_STAR,
-    ACTIONS(9), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(13), 1,
-      anon_sym_PIPE,
-    ACTIONS(15), 1,
-      anon_sym_LBRACE,
-    ACTIONS(35), 1,
-      sym_url_word,
-    ACTIONS(37), 1,
-      anon_sym_BQUOTE,
-    ACTIONS(180), 1,
-      aux_sym_uppercase_name_token1,
-    ACTIONS(202), 1,
-      anon_sym_LT,
-    STATE(10), 1,
-      aux_sym_line_li_repeat2,
-    STATE(66), 1,
-      sym__line_noli,
-    STATE(87), 1,
-      sym__word_common,
-    ACTIONS(21), 2,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-    ACTIONS(204), 2,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-    ACTIONS(5), 3,
-      aux_sym_word_noli_token1,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token5,
-    ACTIONS(19), 6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-    ACTIONS(11), 7,
-      aux_sym_word_noli_token2,
-      aux_sym__word_common_token3,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_TILDE,
-      anon_sym_GT,
-    STATE(17), 11,
-      sym__atom_noli,
-      sym_word_noli,
-      sym__atom_common,
-      sym_keycode,
-      sym__uppercase_words,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [539] = 17,
-    ACTIONS(7), 1,
-      anon_sym_STAR,
-    ACTIONS(9), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(13), 1,
-      anon_sym_PIPE,
-    ACTIONS(15), 1,
-      anon_sym_LBRACE,
-    ACTIONS(35), 1,
-      sym_url_word,
-    ACTIONS(37), 1,
-      anon_sym_BQUOTE,
-    ACTIONS(180), 1,
-      aux_sym_uppercase_name_token1,
-    ACTIONS(206), 1,
-      anon_sym_LT,
-    STATE(11), 1,
-      aux_sym_line_li_repeat2,
-    STATE(66), 1,
-      sym__line_noli,
-    STATE(87), 1,
-      sym__word_common,
-    ACTIONS(21), 2,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-    ACTIONS(208), 2,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-    ACTIONS(5), 3,
-      aux_sym_word_noli_token1,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token5,
-    ACTIONS(19), 6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-    ACTIONS(11), 7,
-      aux_sym_word_noli_token2,
-      aux_sym__word_common_token3,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_TILDE,
-      anon_sym_GT,
-    STATE(17), 11,
-      sym__atom_noli,
-      sym_word_noli,
-      sym__atom_common,
-      sym_keycode,
-      sym__uppercase_words,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [616] = 17,
-    ACTIONS(7), 1,
-      anon_sym_STAR,
-    ACTIONS(9), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(13), 1,
-      anon_sym_PIPE,
-    ACTIONS(15), 1,
-      anon_sym_LBRACE,
-    ACTIONS(35), 1,
-      sym_url_word,
-    ACTIONS(37), 1,
-      anon_sym_BQUOTE,
-    ACTIONS(180), 1,
-      aux_sym_uppercase_name_token1,
-    ACTIONS(210), 1,
-      anon_sym_LT,
-    STATE(12), 1,
-      aux_sym_line_li_repeat2,
-    STATE(66), 1,
-      sym__line_noli,
-    STATE(87), 1,
-      sym__word_common,
-    ACTIONS(21), 2,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-    ACTIONS(212), 2,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-    ACTIONS(5), 3,
-      aux_sym_word_noli_token1,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token5,
-    ACTIONS(19), 6,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-    ACTIONS(11), 7,
-      aux_sym_word_noli_token2,
-      aux_sym__word_common_token3,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_TILDE,
-      anon_sym_GT,
-    STATE(17), 11,
-      sym__atom_noli,
-      sym_word_noli,
-      sym__atom_common,
-      sym_keycode,
-      sym__uppercase_words,
-      sym_tag,
-      sym_url,
-      sym_optionlink,
-      sym_taglink,
-      sym_codespan,
-      sym_argument,
-  [693] = 16,
-    ACTIONS(7), 1,
-      anon_sym_STAR,
-    ACTIONS(9), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(13), 1,
-      anon_sym_PIPE,
-    ACTIONS(15), 1,
-      anon_sym_LBRACE,
-    ACTIONS(35), 1,
-      sym_url_word,
-    ACTIONS(37), 1,
-      anon_sym_BQUOTE,
+    ACTIONS(214), 1,
+      aux_sym_word_token1,
     ACTIONS(218), 1,
       anon_sym_GT,
     ACTIONS(220), 1,
@@ -7813,9 +8101,6 @@ static const uint16_t ts_small_parse_table[] = {
       sym_codeblock,
     STATE(85), 1,
       sym__word_common,
-    ACTIONS(214), 2,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
     ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -7828,12 +8113,12 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
     ACTIONS(216), 7,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
+      anon_sym_COMMA,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -7845,7 +8130,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [764] = 17,
+  [70] = 17,
     ACTIONS(7), 1,
       anon_sym_STAR,
     ACTIONS(9), 1,
@@ -7860,6 +8145,8 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(37), 1,
       anon_sym_BQUOTE,
+    ACTIONS(214), 1,
+      aux_sym_word_token1,
     ACTIONS(222), 1,
       anon_sym_TILDE,
     ACTIONS(224), 1,
@@ -7870,9 +8157,6 @@ static const uint16_t ts_small_parse_table[] = {
       sym_codeblock,
     STATE(85), 1,
       sym__word_common,
-    ACTIONS(214), 2,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
     ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -7885,11 +8169,11 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
     ACTIONS(216), 6,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_COMMA,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -7901,7 +8185,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [837] = 16,
+  [142] = 16,
     ACTIONS(7), 1,
       anon_sym_STAR,
     ACTIONS(9), 1,
@@ -7914,6 +8198,8 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(37), 1,
       anon_sym_BQUOTE,
+    ACTIONS(214), 1,
+      aux_sym_word_token1,
     ACTIONS(218), 1,
       anon_sym_GT,
     ACTIONS(226), 1,
@@ -7924,9 +8210,6 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_li_repeat1,
     STATE(85), 1,
       sym__word_common,
-    ACTIONS(214), 2,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
     ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -7939,12 +8222,12 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
     ACTIONS(216), 7,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
+      anon_sym_COMMA,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -7956,7 +8239,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [908] = 16,
+  [212] = 16,
     ACTIONS(7), 1,
       anon_sym_STAR,
     ACTIONS(9), 1,
@@ -7969,6 +8252,8 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(37), 1,
       anon_sym_BQUOTE,
+    ACTIONS(214), 1,
+      aux_sym_word_token1,
     ACTIONS(218), 1,
       anon_sym_GT,
     ACTIONS(228), 1,
@@ -7979,9 +8264,6 @@ static const uint16_t ts_small_parse_table[] = {
       sym_codeblock,
     STATE(85), 1,
       sym__word_common,
-    ACTIONS(214), 2,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
     ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -7994,12 +8276,12 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
     ACTIONS(216), 7,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
+      anon_sym_COMMA,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -8011,7 +8293,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [979] = 17,
+  [282] = 17,
     ACTIONS(7), 1,
       anon_sym_STAR,
     ACTIONS(9), 1,
@@ -8026,6 +8308,8 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(37), 1,
       anon_sym_BQUOTE,
+    ACTIONS(214), 1,
+      aux_sym_word_token1,
     ACTIONS(230), 1,
       anon_sym_TILDE,
     ACTIONS(232), 1,
@@ -8036,9 +8320,6 @@ static const uint16_t ts_small_parse_table[] = {
       sym_codeblock,
     STATE(85), 1,
       sym__word_common,
-    ACTIONS(214), 2,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
     ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8051,11 +8332,11 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
     ACTIONS(216), 6,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
+      anon_sym_COMMA,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -8067,7 +8348,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1052] = 16,
+  [354] = 16,
     ACTIONS(7), 1,
       anon_sym_STAR,
     ACTIONS(9), 1,
@@ -8080,6 +8361,8 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(37), 1,
       anon_sym_BQUOTE,
+    ACTIONS(214), 1,
+      aux_sym_word_token1,
     ACTIONS(218), 1,
       anon_sym_GT,
     ACTIONS(234), 1,
@@ -8090,9 +8373,6 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_li_repeat1,
     STATE(85), 1,
       sym__word_common,
-    ACTIONS(214), 2,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
     ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8105,12 +8385,12 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
     ACTIONS(216), 7,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
+      anon_sym_COMMA,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -8122,7 +8402,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1123] = 14,
+  [424] = 14,
     ACTIONS(7), 1,
       anon_sym_STAR,
     ACTIONS(9), 1,
@@ -8135,15 +8415,14 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(37), 1,
       anon_sym_BQUOTE,
+    ACTIONS(214), 1,
+      aux_sym_word_token1,
     ACTIONS(236), 1,
       anon_sym_LF2,
     STATE(24), 1,
       aux_sym_line_li_repeat1,
     STATE(85), 1,
       sym__word_common,
-    ACTIONS(214), 2,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
     ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8156,13 +8435,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
     ACTIONS(216), 8,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -8174,7 +8453,9 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1189] = 14,
+  [489] = 14,
+    ACTIONS(238), 1,
+      aux_sym_word_token1,
     ACTIONS(241), 1,
       anon_sym_STAR,
     ACTIONS(244), 1,
@@ -8193,9 +8474,6 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_li_repeat1,
     STATE(85), 1,
       sym__word_common,
-    ACTIONS(238), 2,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
     ACTIONS(256), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8208,13 +8486,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
     ACTIONS(247), 8,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -8226,7 +8504,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1255] = 14,
+  [554] = 14,
     ACTIONS(7), 1,
       anon_sym_STAR,
     ACTIONS(9), 1,
@@ -8239,15 +8517,14 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(37), 1,
       anon_sym_BQUOTE,
+    ACTIONS(214), 1,
+      aux_sym_word_token1,
     ACTIONS(270), 1,
       anon_sym_LF2,
     STATE(23), 1,
       aux_sym_line_li_repeat1,
     STATE(85), 1,
       sym__word_common,
-    ACTIONS(214), 2,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
     ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8260,13 +8537,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
     ACTIONS(216), 8,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -8278,7 +8555,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1321] = 14,
+  [619] = 14,
     ACTIONS(7), 1,
       anon_sym_STAR,
     ACTIONS(9), 1,
@@ -8291,15 +8568,14 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(37), 1,
       anon_sym_BQUOTE,
+    ACTIONS(214), 1,
+      aux_sym_word_token1,
     ACTIONS(272), 1,
       anon_sym_LF2,
     STATE(24), 1,
       aux_sym_line_li_repeat1,
     STATE(85), 1,
       sym__word_common,
-    ACTIONS(214), 2,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
     ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8312,13 +8588,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
     ACTIONS(216), 8,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -8330,7 +8606,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1387] = 14,
+  [684] = 14,
     ACTIONS(7), 1,
       anon_sym_STAR,
     ACTIONS(9), 1,
@@ -8343,15 +8619,14 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(37), 1,
       anon_sym_BQUOTE,
+    ACTIONS(214), 1,
+      aux_sym_word_token1,
     ACTIONS(274), 1,
       anon_sym_LF2,
     STATE(24), 1,
       aux_sym_line_li_repeat1,
     STATE(85), 1,
       sym__word_common,
-    ACTIONS(214), 2,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
     ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8364,13 +8639,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
     ACTIONS(216), 8,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -8382,7 +8657,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1453] = 13,
+  [749] = 13,
     ACTIONS(7), 1,
       anon_sym_STAR,
     ACTIONS(9), 1,
@@ -8395,13 +8670,12 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(37), 1,
       anon_sym_BQUOTE,
+    ACTIONS(214), 1,
+      aux_sym_word_token1,
     STATE(27), 1,
       aux_sym_line_li_repeat1,
     STATE(85), 1,
       sym__word_common,
-    ACTIONS(214), 2,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
     ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8414,13 +8688,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
     ACTIONS(216), 8,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -8432,7 +8706,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1516] = 13,
+  [811] = 13,
     ACTIONS(7), 1,
       anon_sym_STAR,
     ACTIONS(9), 1,
@@ -8445,13 +8719,12 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(37), 1,
       anon_sym_BQUOTE,
+    ACTIONS(214), 1,
+      aux_sym_word_token1,
     STATE(26), 1,
       aux_sym_line_li_repeat1,
     STATE(85), 1,
       sym__word_common,
-    ACTIONS(214), 2,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
     ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8464,13 +8737,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
     ACTIONS(216), 8,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -8482,7 +8755,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1579] = 13,
+  [873] = 13,
     ACTIONS(7), 1,
       anon_sym_STAR,
     ACTIONS(9), 1,
@@ -8495,13 +8768,12 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(37), 1,
       anon_sym_BQUOTE,
+    ACTIONS(214), 1,
+      aux_sym_word_token1,
     STATE(22), 1,
       aux_sym_line_li_repeat1,
     STATE(85), 1,
       sym__word_common,
-    ACTIONS(214), 2,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
     ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8514,13 +8786,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
     ACTIONS(216), 8,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -8532,7 +8804,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1642] = 13,
+  [935] = 13,
     ACTIONS(7), 1,
       anon_sym_STAR,
     ACTIONS(9), 1,
@@ -8545,13 +8817,12 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(37), 1,
       anon_sym_BQUOTE,
+    ACTIONS(214), 1,
+      aux_sym_word_token1,
     STATE(19), 1,
       aux_sym_line_li_repeat1,
     STATE(85), 1,
       sym__word_common,
-    ACTIONS(214), 2,
-      aux_sym_word_token1,
-      aux_sym_word_token2,
     ACTIONS(19), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
@@ -8564,13 +8835,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
     ACTIONS(216), 8,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
     STATE(84), 10,
       sym__atom,
       sym_word,
@@ -8582,20 +8853,19 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1705] = 5,
+  [997] = 5,
     ACTIONS(27), 1,
       anon_sym_LF2,
     STATE(43), 1,
       aux_sym_help_file_repeat1,
     STATE(50), 1,
       sym__blank,
-    ACTIONS(278), 14,
+    ACTIONS(278), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -8604,16 +8874,17 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(276), 16,
+    ACTIONS(276), 17,
       ts_builtin_sym_end,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_line_li_token1,
@@ -8621,20 +8892,19 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [1749] = 5,
+  [1041] = 5,
     ACTIONS(27), 1,
       anon_sym_LF2,
     STATE(32), 1,
       aux_sym_help_file_repeat1,
     STATE(50), 1,
       sym__blank,
-    ACTIONS(282), 14,
+    ACTIONS(282), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -8643,16 +8913,17 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(280), 16,
+    ACTIONS(280), 17,
       ts_builtin_sym_end,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_line_li_token1,
@@ -8660,20 +8931,19 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [1793] = 5,
+  [1085] = 5,
     ACTIONS(27), 1,
       anon_sym_LF2,
     STATE(43), 1,
       aux_sym_help_file_repeat1,
     STATE(50), 1,
       sym__blank,
-    ACTIONS(286), 14,
+    ACTIONS(286), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -8682,16 +8952,17 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(284), 16,
+    ACTIONS(284), 17,
       ts_builtin_sym_end,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_line_li_token1,
@@ -8699,20 +8970,19 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [1837] = 5,
+  [1129] = 5,
     ACTIONS(27), 1,
       anon_sym_LF2,
     STATE(43), 1,
       aux_sym_help_file_repeat1,
     STATE(50), 1,
       sym__blank,
-    ACTIONS(290), 14,
+    ACTIONS(290), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -8721,16 +8991,17 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(288), 16,
+    ACTIONS(288), 17,
       ts_builtin_sym_end,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_line_li_token1,
@@ -8738,7 +9009,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [1881] = 6,
+  [1173] = 6,
     ACTIONS(294), 1,
       anon_sym_LF2,
     ACTIONS(297), 1,
@@ -8758,13 +9029,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__word_common_token3,
       anon_sym_PIPE,
       anon_sym_LBRACE,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -8778,20 +9049,19 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_li_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [1927] = 5,
+  [1219] = 5,
     ACTIONS(27), 1,
       anon_sym_LF2,
     STATE(43), 1,
       aux_sym_help_file_repeat1,
     STATE(50), 1,
       sym__blank,
-    ACTIONS(278), 14,
+    ACTIONS(278), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -8800,16 +9070,17 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(276), 16,
+    ACTIONS(276), 17,
       ts_builtin_sym_end,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_line_li_token1,
@@ -8817,20 +9088,19 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [1971] = 5,
+  [1263] = 5,
     ACTIONS(27), 1,
       anon_sym_LF2,
     STATE(34), 1,
       aux_sym_help_file_repeat1,
     STATE(50), 1,
       sym__blank,
-    ACTIONS(304), 14,
+    ACTIONS(304), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -8839,16 +9109,17 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(302), 16,
+    ACTIONS(302), 17,
       ts_builtin_sym_end,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_line_li_token1,
@@ -8856,7 +9127,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2015] = 6,
+  [1307] = 6,
     ACTIONS(27), 1,
       anon_sym_LF2,
     ACTIONS(310), 1,
@@ -8865,13 +9136,12 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_help_file_repeat1,
     STATE(50), 1,
       sym__blank,
-    ACTIONS(308), 14,
+    ACTIONS(308), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -8880,36 +9150,36 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(306), 15,
+    ACTIONS(306), 16,
       ts_builtin_sym_end,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2061] = 5,
+  [1353] = 5,
     ACTIONS(27), 1,
       anon_sym_LF2,
     STATE(43), 1,
       aux_sym_help_file_repeat1,
     STATE(50), 1,
       sym__blank,
-    ACTIONS(304), 14,
+    ACTIONS(304), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -8918,16 +9188,17 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(302), 16,
+    ACTIONS(302), 17,
       ts_builtin_sym_end,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_line_li_token1,
@@ -8935,20 +9206,19 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2105] = 5,
+  [1397] = 5,
     ACTIONS(27), 1,
       anon_sym_LF2,
     STATE(37), 1,
       aux_sym_help_file_repeat1,
     STATE(50), 1,
       sym__blank,
-    ACTIONS(282), 14,
+    ACTIONS(282), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -8957,16 +9227,17 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(280), 16,
+    ACTIONS(280), 17,
       ts_builtin_sym_end,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_line_li_token1,
@@ -8974,7 +9245,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2149] = 6,
+  [1441] = 6,
     ACTIONS(314), 1,
       anon_sym_LF2,
     ACTIONS(316), 1,
@@ -8994,13 +9265,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__word_common_token3,
       anon_sym_PIPE,
       anon_sym_LBRACE,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9014,20 +9285,19 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_li_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2195] = 5,
+  [1487] = 5,
     ACTIONS(324), 1,
       anon_sym_LF2,
     STATE(43), 1,
       aux_sym_help_file_repeat1,
     STATE(50), 1,
       sym__blank,
-    ACTIONS(322), 14,
+    ACTIONS(322), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9036,16 +9306,17 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(320), 16,
+    ACTIONS(320), 17,
       ts_builtin_sym_end,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_line_li_token1,
@@ -9053,7 +9324,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2239] = 6,
+  [1531] = 6,
     ACTIONS(27), 1,
       anon_sym_LF2,
     ACTIONS(310), 1,
@@ -9062,13 +9333,12 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_help_file_repeat1,
     STATE(50), 1,
       sym__blank,
-    ACTIONS(329), 14,
+    ACTIONS(329), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9077,23 +9347,24 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(327), 15,
+    ACTIONS(327), 16,
       ts_builtin_sym_end,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2285] = 5,
+  [1577] = 5,
     ACTIONS(331), 1,
       anon_sym_LF2,
     ACTIONS(334), 1,
@@ -9110,13 +9381,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__word_common_token3,
       anon_sym_PIPE,
       anon_sym_LBRACE,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9130,7 +9401,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_li_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2327] = 5,
+  [1619] = 5,
     ACTIONS(337), 1,
       anon_sym_LF2,
     ACTIONS(339), 1,
@@ -9147,13 +9418,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__word_common_token3,
       anon_sym_PIPE,
       anon_sym_LBRACE,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9167,14 +9438,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_li_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2369] = 2,
-    ACTIONS(343), 14,
+  [1661] = 2,
+    ACTIONS(343), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9183,16 +9453,17 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(341), 17,
+    ACTIONS(341), 18,
       ts_builtin_sym_end,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
@@ -9201,7 +9472,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2405] = 2,
+  [1697] = 2,
     ACTIONS(347), 3,
       anon_sym_LF2,
       aux_sym_h1_token1,
@@ -9214,13 +9485,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__word_common_token3,
       anon_sym_PIPE,
       anon_sym_LBRACE,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9235,7 +9506,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_code_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2441] = 2,
+  [1733] = 2,
     ACTIONS(351), 3,
       anon_sym_LF2,
       aux_sym_h1_token1,
@@ -9248,13 +9519,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__word_common_token3,
       anon_sym_PIPE,
       anon_sym_LBRACE,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9269,14 +9540,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_code_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2477] = 2,
-    ACTIONS(355), 14,
+  [1769] = 2,
+    ACTIONS(355), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9285,16 +9555,17 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(353), 17,
+    ACTIONS(353), 18,
       ts_builtin_sym_end,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
@@ -9303,14 +9574,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2513] = 2,
-    ACTIONS(357), 14,
+  [1805] = 2,
+    ACTIONS(357), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9319,15 +9589,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(359), 16,
+    ACTIONS(359), 17,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
@@ -9336,14 +9607,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2548] = 2,
-    ACTIONS(361), 14,
+  [1840] = 2,
+    ACTIONS(361), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9352,15 +9622,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(363), 16,
+    ACTIONS(363), 17,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
@@ -9369,14 +9640,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2583] = 2,
-    ACTIONS(365), 14,
+  [1875] = 2,
+    ACTIONS(365), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9385,15 +9655,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(367), 16,
+    ACTIONS(367), 17,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
@@ -9402,14 +9673,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2618] = 2,
-    ACTIONS(369), 14,
+  [1910] = 2,
+    ACTIONS(369), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9418,15 +9688,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(371), 16,
+    ACTIONS(371), 17,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
@@ -9435,14 +9706,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2653] = 2,
-    ACTIONS(373), 14,
+  [1945] = 2,
+    ACTIONS(373), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9451,15 +9721,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(375), 16,
+    ACTIONS(375), 17,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
@@ -9468,14 +9739,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2688] = 2,
-    ACTIONS(377), 14,
+  [1980] = 2,
+    ACTIONS(377), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9484,15 +9754,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(379), 16,
+    ACTIONS(379), 17,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
@@ -9501,14 +9772,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2723] = 2,
-    ACTIONS(381), 14,
+  [2015] = 2,
+    ACTIONS(381), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9517,15 +9787,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(383), 16,
+    ACTIONS(383), 17,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
@@ -9534,14 +9805,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2758] = 2,
-    ACTIONS(385), 14,
+  [2050] = 2,
+    ACTIONS(385), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9550,15 +9820,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(387), 16,
+    ACTIONS(387), 17,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
@@ -9567,14 +9838,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2793] = 2,
-    ACTIONS(389), 14,
+  [2085] = 2,
+    ACTIONS(389), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9583,15 +9853,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(391), 16,
+    ACTIONS(391), 17,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
@@ -9600,14 +9871,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2828] = 2,
-    ACTIONS(393), 14,
+  [2120] = 2,
+    ACTIONS(393), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9616,15 +9886,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(395), 16,
+    ACTIONS(395), 17,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
@@ -9633,7 +9904,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2863] = 2,
+  [2155] = 2,
     ACTIONS(351), 1,
       anon_sym_LF2,
     ACTIONS(349), 28,
@@ -9644,13 +9915,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__word_common_token3,
       anon_sym_PIPE,
       anon_sym_LBRACE,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9665,7 +9936,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_code_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2897] = 2,
+  [2189] = 2,
     ACTIONS(347), 1,
       anon_sym_LF2,
     ACTIONS(345), 28,
@@ -9676,13 +9947,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__word_common_token3,
       anon_sym_PIPE,
       anon_sym_LBRACE,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9697,13 +9968,12 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_code_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2931] = 2,
-    ACTIONS(361), 13,
+  [2223] = 2,
+    ACTIONS(361), 12,
       aux_sym_word_noli_token1,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9712,29 +9982,29 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(363), 15,
+    ACTIONS(363), 16,
       aux_sym_word_noli_token2,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
       aux_sym_line_li_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2964] = 2,
-    ACTIONS(365), 13,
+  [2256] = 2,
+    ACTIONS(365), 12,
       aux_sym_word_noli_token1,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -9743,29 +10013,61 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(367), 15,
+    ACTIONS(367), 16,
       aux_sym_word_noli_token2,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
       aux_sym_line_li_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2997] = 4,
-    ACTIONS(403), 1,
+  [2289] = 2,
+    ACTIONS(397), 12,
+      aux_sym_word_noli_token1,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+    ACTIONS(399), 16,
+      aux_sym_word_noli_token2,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      anon_sym_LF2,
+      aux_sym_line_li_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [2322] = 4,
+    ACTIONS(407), 1,
       aux_sym_optionlink_token1,
-    ACTIONS(401), 2,
+    ACTIONS(405), 2,
       aux_sym__word_common_token1,
       aux_sym__word_common_token2,
-    ACTIONS(399), 10,
+    ACTIONS(403), 10,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       anon_sym_LBRACE_RBRACE,
@@ -9776,141 +10078,106 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
       anon_sym_LF2,
-    ACTIONS(397), 15,
+    ACTIONS(401), 14,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_STAR,
       anon_sym_PIPE,
       anon_sym_LBRACE,
-      anon_sym_RBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3034] = 2,
-    ACTIONS(405), 13,
-      aux_sym_word_noli_token1,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym__word_common_token5,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-    ACTIONS(407), 15,
-      aux_sym_word_noli_token2,
-      anon_sym_STAR,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-      sym_url_word,
-      anon_sym_BQUOTE,
-  [3067] = 4,
+  [2358] = 4,
     ACTIONS(413), 1,
       aux_sym_uppercase_name_token2,
     STATE(67), 1,
       aux_sym_uppercase_name_repeat1,
-    ACTIONS(409), 12,
+    ACTIONS(409), 10,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-    ACTIONS(411), 13,
+    ACTIONS(411), 14,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3103] = 4,
+  [2393] = 4,
     ACTIONS(420), 1,
       aux_sym_uppercase_name_token2,
     STATE(70), 1,
       aux_sym_uppercase_name_repeat1,
-    ACTIONS(416), 12,
+    ACTIONS(416), 10,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-    ACTIONS(418), 13,
+    ACTIONS(418), 14,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3139] = 3,
+  [2428] = 3,
     ACTIONS(422), 2,
       aux_sym_codeblock_token1,
       anon_sym_LF,
-    ACTIONS(397), 8,
+    ACTIONS(401), 7,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       anon_sym_LF2,
-    ACTIONS(399), 17,
+    ACTIONS(403), 17,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
@@ -9918,62 +10185,60 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3173] = 4,
+  [2461] = 4,
     ACTIONS(420), 1,
       aux_sym_uppercase_name_token2,
     STATE(67), 1,
       aux_sym_uppercase_name_repeat1,
-    ACTIONS(424), 12,
+    ACTIONS(424), 10,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-    ACTIONS(426), 13,
+    ACTIONS(426), 14,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3209] = 3,
+  [2496] = 3,
     ACTIONS(428), 2,
       aux_sym_codeblock_token1,
       anon_sym_LF,
-    ACTIONS(397), 8,
+    ACTIONS(401), 7,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       anon_sym_LF2,
-    ACTIONS(399), 17,
+    ACTIONS(403), 17,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
@@ -9981,7 +10246,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3243] = 5,
+  [2529] = 5,
     ACTIONS(420), 1,
       aux_sym_uppercase_name_token2,
     STATE(67), 1,
@@ -9989,32 +10254,31 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(430), 2,
       anon_sym_STAR,
       anon_sym_LF2,
-    ACTIONS(426), 11,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      sym_url_word,
-      anon_sym_BQUOTE,
-    ACTIONS(424), 12,
+    ACTIONS(424), 10,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-  [3281] = 5,
+    ACTIONS(426), 12,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [2566] = 5,
     ACTIONS(420), 1,
       aux_sym_uppercase_name_token2,
     STATE(72), 1,
@@ -10022,51 +10286,49 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(432), 2,
       anon_sym_STAR,
       anon_sym_LF2,
-    ACTIONS(418), 11,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_RBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      sym_url_word,
-      anon_sym_BQUOTE,
-    ACTIONS(416), 12,
+    ACTIONS(416), 10,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       aux_sym_keycode_token4,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-  [3319] = 3,
+    ACTIONS(418), 12,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [2603] = 3,
     ACTIONS(434), 1,
       aux_sym_taglink_token1,
-    ACTIONS(399), 2,
+    ACTIONS(403), 2,
       aux_sym__word_common_token3,
       anon_sym_LF2,
-    ACTIONS(397), 23,
+    ACTIONS(401), 22,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       anon_sym_PIPE,
       anon_sym_LBRACE,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -10077,29 +10339,28 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3352] = 3,
+  [2635] = 3,
     ACTIONS(436), 1,
       anon_sym_LF,
-    ACTIONS(397), 8,
+    ACTIONS(401), 7,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       anon_sym_LF2,
-    ACTIONS(399), 17,
+    ACTIONS(403), 17,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
@@ -10107,12 +10368,11 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3385] = 3,
+  [2667] = 3,
     ACTIONS(442), 1,
       anon_sym_SQUOTE2,
-    ACTIONS(438), 8,
+    ACTIONS(438), 7,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_SQUOTE,
       anon_sym_PIPE,
       anon_sym_LBRACE,
@@ -10122,13 +10382,13 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(440), 17,
       anon_sym_STAR,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
@@ -10137,26 +10397,25 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LF2,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3418] = 3,
+  [2699] = 3,
     ACTIONS(444), 1,
       aux_sym_tag_token1,
-    ACTIONS(399), 2,
+    ACTIONS(403), 2,
       anon_sym_STAR,
       anon_sym_LF2,
-    ACTIONS(397), 23,
+    ACTIONS(401), 22,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       anon_sym_PIPE,
       anon_sym_LBRACE,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -10167,29 +10426,28 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3451] = 3,
+  [2731] = 3,
     ACTIONS(446), 1,
       anon_sym_LF,
-    ACTIONS(397), 8,
+    ACTIONS(401), 7,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
       anon_sym_LF2,
-    ACTIONS(399), 17,
+    ACTIONS(403), 17,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
@@ -10197,17 +10455,15 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3484] = 3,
+  [2763] = 3,
     ACTIONS(448), 1,
       aux_sym_argument_token1,
-    ACTIONS(399), 4,
-      anon_sym_RBRACE,
+    ACTIONS(403), 3,
       anon_sym_LBRACE_RBRACE,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
-    ACTIONS(397), 21,
+    ACTIONS(401), 21,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -10215,9 +10471,10 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -10227,14 +10484,12 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3517] = 2,
-    ACTIONS(450), 13,
+  [2795] = 2,
+    ACTIONS(450), 11,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
@@ -10242,24 +10497,24 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token2,
-    ACTIONS(452), 13,
+    ACTIONS(452), 14,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       anon_sym_LF2,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3548] = 2,
-    ACTIONS(454), 7,
+  [2825] = 2,
+    ACTIONS(454), 6,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
@@ -10269,13 +10524,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
@@ -10284,10 +10539,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LF2,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3578] = 2,
-    ACTIONS(458), 7,
+  [2854] = 2,
+    ACTIONS(458), 6,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
@@ -10297,13 +10551,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
@@ -10312,10 +10566,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LF2,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3608] = 2,
-    ACTIONS(462), 7,
+  [2883] = 2,
+    ACTIONS(462), 6,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
@@ -10325,13 +10578,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
@@ -10340,10 +10593,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LF2,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3638] = 2,
-    ACTIONS(466), 7,
+  [2912] = 2,
+    ACTIONS(466), 6,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
@@ -10353,13 +10605,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
@@ -10368,10 +10620,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LF2,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3668] = 2,
-    ACTIONS(470), 7,
+  [2941] = 2,
+    ACTIONS(470), 6,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
@@ -10381,13 +10632,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
@@ -10396,10 +10647,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LF2,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3698] = 2,
-    ACTIONS(474), 7,
+  [2970] = 2,
+    ACTIONS(474), 6,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
@@ -10409,13 +10659,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
@@ -10424,10 +10674,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LF2,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3728] = 2,
-    ACTIONS(478), 7,
+  [2999] = 2,
+    ACTIONS(478), 6,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
@@ -10437,13 +10686,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
@@ -10452,10 +10701,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LF2,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3758] = 2,
-    ACTIONS(482), 7,
+  [3028] = 2,
+    ACTIONS(482), 6,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
@@ -10465,13 +10713,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
@@ -10480,10 +10728,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LF2,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3788] = 2,
-    ACTIONS(486), 7,
+  [3057] = 2,
+    ACTIONS(486), 6,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
@@ -10493,13 +10740,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
@@ -10508,10 +10755,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LF2,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3818] = 2,
-    ACTIONS(490), 7,
+  [3086] = 2,
+    ACTIONS(490), 6,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
@@ -10521,13 +10767,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
@@ -10536,10 +10782,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LF2,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3848] = 2,
-    ACTIONS(494), 7,
+  [3115] = 2,
+    ACTIONS(494), 6,
       aux_sym_word_token1,
-      aux_sym_word_token2,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
@@ -10549,13 +10794,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_RBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
       anon_sym_LPAREN,
-      aux_sym__word_common_token5,
+      anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
+      anon_sym_COMMA,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
@@ -10564,7 +10809,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LF2,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3878] = 5,
+  [3144] = 5,
     ACTIONS(27), 1,
       anon_sym_LF2,
     ACTIONS(29), 1,
@@ -10576,7 +10821,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(94), 2,
       sym_line_li,
       aux_sym_block_repeat2,
-  [3895] = 5,
+  [3161] = 5,
     ACTIONS(27), 1,
       anon_sym_LF2,
     ACTIONS(29), 1,
@@ -10588,7 +10833,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(94), 2,
       sym_line_li,
       aux_sym_block_repeat2,
-  [3912] = 4,
+  [3178] = 4,
     ACTIONS(502), 1,
       anon_sym_LT,
     ACTIONS(505), 1,
@@ -10598,7 +10843,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(94), 2,
       sym_line_li,
       aux_sym_block_repeat2,
-  [3926] = 4,
+  [3192] = 4,
     ACTIONS(314), 1,
       anon_sym_LF2,
     ACTIONS(316), 1,
@@ -10607,7 +10852,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_codeblock_repeat1,
     STATE(49), 1,
       sym_line_code,
-  [3939] = 4,
+  [3205] = 4,
     ACTIONS(337), 1,
       anon_sym_LF2,
     ACTIONS(339), 1,
@@ -10616,142 +10861,133 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_codeblock_repeat1,
     STATE(61), 1,
       sym_line_code,
-  [3952] = 3,
+  [3218] = 3,
     ACTIONS(510), 1,
       anon_sym_STAR,
     ACTIONS(512), 1,
       anon_sym_LF2,
     STATE(25), 1,
       sym_tag,
-  [3962] = 1,
+  [3228] = 1,
     ACTIONS(514), 1,
       anon_sym_PIPE2,
-  [3966] = 1,
+  [3232] = 1,
     ACTIONS(516), 1,
       anon_sym_STAR2,
-  [3970] = 1,
+  [3236] = 1,
     ACTIONS(518), 1,
-      anon_sym_RBRACE2,
-  [3974] = 1,
+      anon_sym_RBRACE,
+  [3240] = 1,
     ACTIONS(520), 1,
       aux_sym_codespan_token1,
-  [3978] = 1,
+  [3244] = 1,
     ACTIONS(522), 1,
       ts_builtin_sym_end,
-  [3982] = 1,
+  [3248] = 1,
     ACTIONS(524), 1,
       anon_sym_SQUOTE2,
-  [3986] = 1,
+  [3252] = 1,
     ACTIONS(444), 1,
       aux_sym_tag_token1,
-  [3990] = 1,
+  [3256] = 1,
     ACTIONS(310), 1,
       aux_sym_line_li_token1,
-  [3994] = 1,
+  [3260] = 1,
     ACTIONS(526), 1,
       anon_sym_BQUOTE2,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
-  [SMALL_STATE(8)] = 0,
-  [SMALL_STATE(9)] = 77,
-  [SMALL_STATE(10)] = 154,
-  [SMALL_STATE(11)] = 231,
-  [SMALL_STATE(12)] = 308,
-  [SMALL_STATE(13)] = 385,
-  [SMALL_STATE(14)] = 462,
-  [SMALL_STATE(15)] = 539,
-  [SMALL_STATE(16)] = 616,
-  [SMALL_STATE(17)] = 693,
-  [SMALL_STATE(18)] = 764,
-  [SMALL_STATE(19)] = 837,
-  [SMALL_STATE(20)] = 908,
-  [SMALL_STATE(21)] = 979,
-  [SMALL_STATE(22)] = 1052,
-  [SMALL_STATE(23)] = 1123,
-  [SMALL_STATE(24)] = 1189,
-  [SMALL_STATE(25)] = 1255,
-  [SMALL_STATE(26)] = 1321,
-  [SMALL_STATE(27)] = 1387,
-  [SMALL_STATE(28)] = 1453,
-  [SMALL_STATE(29)] = 1516,
-  [SMALL_STATE(30)] = 1579,
-  [SMALL_STATE(31)] = 1642,
-  [SMALL_STATE(32)] = 1705,
-  [SMALL_STATE(33)] = 1749,
-  [SMALL_STATE(34)] = 1793,
-  [SMALL_STATE(35)] = 1837,
-  [SMALL_STATE(36)] = 1881,
-  [SMALL_STATE(37)] = 1927,
-  [SMALL_STATE(38)] = 1971,
-  [SMALL_STATE(39)] = 2015,
-  [SMALL_STATE(40)] = 2061,
-  [SMALL_STATE(41)] = 2105,
-  [SMALL_STATE(42)] = 2149,
-  [SMALL_STATE(43)] = 2195,
-  [SMALL_STATE(44)] = 2239,
-  [SMALL_STATE(45)] = 2285,
-  [SMALL_STATE(46)] = 2327,
-  [SMALL_STATE(47)] = 2369,
-  [SMALL_STATE(48)] = 2405,
-  [SMALL_STATE(49)] = 2441,
-  [SMALL_STATE(50)] = 2477,
-  [SMALL_STATE(51)] = 2513,
-  [SMALL_STATE(52)] = 2548,
-  [SMALL_STATE(53)] = 2583,
-  [SMALL_STATE(54)] = 2618,
-  [SMALL_STATE(55)] = 2653,
-  [SMALL_STATE(56)] = 2688,
-  [SMALL_STATE(57)] = 2723,
-  [SMALL_STATE(58)] = 2758,
-  [SMALL_STATE(59)] = 2793,
-  [SMALL_STATE(60)] = 2828,
-  [SMALL_STATE(61)] = 2863,
-  [SMALL_STATE(62)] = 2897,
-  [SMALL_STATE(63)] = 2931,
-  [SMALL_STATE(64)] = 2964,
-  [SMALL_STATE(65)] = 2997,
-  [SMALL_STATE(66)] = 3034,
-  [SMALL_STATE(67)] = 3067,
-  [SMALL_STATE(68)] = 3103,
-  [SMALL_STATE(69)] = 3139,
-  [SMALL_STATE(70)] = 3173,
-  [SMALL_STATE(71)] = 3209,
-  [SMALL_STATE(72)] = 3243,
-  [SMALL_STATE(73)] = 3281,
-  [SMALL_STATE(74)] = 3319,
-  [SMALL_STATE(75)] = 3352,
-  [SMALL_STATE(76)] = 3385,
-  [SMALL_STATE(77)] = 3418,
-  [SMALL_STATE(78)] = 3451,
-  [SMALL_STATE(79)] = 3484,
-  [SMALL_STATE(80)] = 3517,
-  [SMALL_STATE(81)] = 3548,
-  [SMALL_STATE(82)] = 3578,
-  [SMALL_STATE(83)] = 3608,
-  [SMALL_STATE(84)] = 3638,
-  [SMALL_STATE(85)] = 3668,
-  [SMALL_STATE(86)] = 3698,
-  [SMALL_STATE(87)] = 3728,
-  [SMALL_STATE(88)] = 3758,
-  [SMALL_STATE(89)] = 3788,
-  [SMALL_STATE(90)] = 3818,
-  [SMALL_STATE(91)] = 3848,
-  [SMALL_STATE(92)] = 3878,
-  [SMALL_STATE(93)] = 3895,
-  [SMALL_STATE(94)] = 3912,
-  [SMALL_STATE(95)] = 3926,
-  [SMALL_STATE(96)] = 3939,
-  [SMALL_STATE(97)] = 3952,
-  [SMALL_STATE(98)] = 3962,
-  [SMALL_STATE(99)] = 3966,
-  [SMALL_STATE(100)] = 3970,
-  [SMALL_STATE(101)] = 3974,
-  [SMALL_STATE(102)] = 3978,
-  [SMALL_STATE(103)] = 3982,
-  [SMALL_STATE(104)] = 3986,
-  [SMALL_STATE(105)] = 3990,
-  [SMALL_STATE(106)] = 3994,
+  [SMALL_STATE(17)] = 0,
+  [SMALL_STATE(18)] = 70,
+  [SMALL_STATE(19)] = 142,
+  [SMALL_STATE(20)] = 212,
+  [SMALL_STATE(21)] = 282,
+  [SMALL_STATE(22)] = 354,
+  [SMALL_STATE(23)] = 424,
+  [SMALL_STATE(24)] = 489,
+  [SMALL_STATE(25)] = 554,
+  [SMALL_STATE(26)] = 619,
+  [SMALL_STATE(27)] = 684,
+  [SMALL_STATE(28)] = 749,
+  [SMALL_STATE(29)] = 811,
+  [SMALL_STATE(30)] = 873,
+  [SMALL_STATE(31)] = 935,
+  [SMALL_STATE(32)] = 997,
+  [SMALL_STATE(33)] = 1041,
+  [SMALL_STATE(34)] = 1085,
+  [SMALL_STATE(35)] = 1129,
+  [SMALL_STATE(36)] = 1173,
+  [SMALL_STATE(37)] = 1219,
+  [SMALL_STATE(38)] = 1263,
+  [SMALL_STATE(39)] = 1307,
+  [SMALL_STATE(40)] = 1353,
+  [SMALL_STATE(41)] = 1397,
+  [SMALL_STATE(42)] = 1441,
+  [SMALL_STATE(43)] = 1487,
+  [SMALL_STATE(44)] = 1531,
+  [SMALL_STATE(45)] = 1577,
+  [SMALL_STATE(46)] = 1619,
+  [SMALL_STATE(47)] = 1661,
+  [SMALL_STATE(48)] = 1697,
+  [SMALL_STATE(49)] = 1733,
+  [SMALL_STATE(50)] = 1769,
+  [SMALL_STATE(51)] = 1805,
+  [SMALL_STATE(52)] = 1840,
+  [SMALL_STATE(53)] = 1875,
+  [SMALL_STATE(54)] = 1910,
+  [SMALL_STATE(55)] = 1945,
+  [SMALL_STATE(56)] = 1980,
+  [SMALL_STATE(57)] = 2015,
+  [SMALL_STATE(58)] = 2050,
+  [SMALL_STATE(59)] = 2085,
+  [SMALL_STATE(60)] = 2120,
+  [SMALL_STATE(61)] = 2155,
+  [SMALL_STATE(62)] = 2189,
+  [SMALL_STATE(63)] = 2223,
+  [SMALL_STATE(64)] = 2256,
+  [SMALL_STATE(65)] = 2289,
+  [SMALL_STATE(66)] = 2322,
+  [SMALL_STATE(67)] = 2358,
+  [SMALL_STATE(68)] = 2393,
+  [SMALL_STATE(69)] = 2428,
+  [SMALL_STATE(70)] = 2461,
+  [SMALL_STATE(71)] = 2496,
+  [SMALL_STATE(72)] = 2529,
+  [SMALL_STATE(73)] = 2566,
+  [SMALL_STATE(74)] = 2603,
+  [SMALL_STATE(75)] = 2635,
+  [SMALL_STATE(76)] = 2667,
+  [SMALL_STATE(77)] = 2699,
+  [SMALL_STATE(78)] = 2731,
+  [SMALL_STATE(79)] = 2763,
+  [SMALL_STATE(80)] = 2795,
+  [SMALL_STATE(81)] = 2825,
+  [SMALL_STATE(82)] = 2854,
+  [SMALL_STATE(83)] = 2883,
+  [SMALL_STATE(84)] = 2912,
+  [SMALL_STATE(85)] = 2941,
+  [SMALL_STATE(86)] = 2970,
+  [SMALL_STATE(87)] = 2999,
+  [SMALL_STATE(88)] = 3028,
+  [SMALL_STATE(89)] = 3057,
+  [SMALL_STATE(90)] = 3086,
+  [SMALL_STATE(91)] = 3115,
+  [SMALL_STATE(92)] = 3144,
+  [SMALL_STATE(93)] = 3161,
+  [SMALL_STATE(94)] = 3178,
+  [SMALL_STATE(95)] = 3192,
+  [SMALL_STATE(96)] = 3205,
+  [SMALL_STATE(97)] = 3218,
+  [SMALL_STATE(98)] = 3228,
+  [SMALL_STATE(99)] = 3232,
+  [SMALL_STATE(100)] = 3236,
+  [SMALL_STATE(101)] = 3240,
+  [SMALL_STATE(102)] = 3244,
+  [SMALL_STATE(103)] = 3248,
+  [SMALL_STATE(104)] = 3252,
+  [SMALL_STATE(105)] = 3256,
+  [SMALL_STATE(106)] = 3260,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -10760,7 +10996,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_help_file, 0),
   [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(87),
   [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
   [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
   [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(74),
   [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(79),
@@ -10780,7 +11016,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [43] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2),
   [45] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(87),
   [48] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(77),
-  [51] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(65),
+  [51] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(66),
   [54] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(87),
   [57] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(74),
   [60] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2), SHIFT_REPEAT(79),
@@ -10798,7 +11034,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [95] = {.entry = {.count = 1, .reusable = false}}, SHIFT(44),
   [97] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(87),
   [100] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(77),
-  [103] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(65),
+  [103] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(66),
   [106] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(87),
   [109] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(74),
   [112] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(79),
@@ -10815,7 +11051,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [143] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(87),
   [146] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(87),
   [149] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(77),
-  [152] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(65),
+  [152] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(66),
   [155] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(74),
   [158] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(79),
   [161] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2), SHIFT_REPEAT(88),
@@ -10856,7 +11092,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [236] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
   [238] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(85),
   [241] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(77),
-  [244] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(65),
+  [244] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(66),
   [247] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(85),
   [250] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(74),
   [253] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2), SHIFT_REPEAT(79),
@@ -10926,12 +11162,12 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [391] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h3, 3, .production_id = 6),
   [393] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line, 1),
   [395] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line, 1),
-  [397] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__word_common, 1),
-  [399] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__word_common, 1),
-  [401] = {.entry = {.count = 1, .reusable = false}}, SHIFT(76),
-  [403] = {.entry = {.count = 1, .reusable = false}}, SHIFT(103),
-  [405] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 1, .production_id = 17),
-  [407] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 1, .production_id = 17),
+  [397] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 1, .production_id = 17),
+  [399] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 1, .production_id = 17),
+  [401] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__word_common, 1),
+  [403] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__word_common, 1),
+  [405] = {.entry = {.count = 1, .reusable = false}}, SHIFT(76),
+  [407] = {.entry = {.count = 1, .reusable = false}}, SHIFT(103),
   [409] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_uppercase_name_repeat1, 2),
   [411] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_uppercase_name_repeat1, 2),
   [413] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_uppercase_name_repeat1, 2), SHIFT_REPEAT(80),


### PR DESCRIPTION
(Continues https://github.com/neovim/tree-sitter-vimdoc/pull/103 )

Problem:
In "vim.foo({bar})", {bar} is not recognized as (argument).

Solution:
Add more special-cases for plain (word).

Closes #102

# Notes

- also improves this `(url)` case: https://github.com/neovim/tree-sitter-vimdoc/blob/755b8011907be9427f73e4f3989e9ece584f0aa8/corpus/url.txt#L42