### PR TITLE
ci: don't run on push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,7 @@
 name: Run tree-sitter tests
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   test:
@@ -12,10 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
-      - name: Install Dependencies
-        run: npm install
-
-      - name: Run tests
-        run: npm test
+      - run: npm install
+      - run: npm test


### PR DESCRIPTION
There's no real reason to run on push as we're not using any caching.
