### PR TITLE
revert: "ci: don't run on push"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,10 @@
 name: Run tree-sitter tests
 
 on:
+  push:
+    branches: [ master ]
   pull_request:
+    branches: [ master ]
 
 jobs:
   test:
@@ -9,6 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
-      - run: npm install
-      - run: npm test
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
This reverts commit d1369fcf4740e42d4ae2322d1342954f07c534c1.

The reasoning is provided by @justinmk in
https://github.com/neovim/tree-sitter-vimdoc/pull/122#issuecomment-1951443830:

It's good to save CI time, but for low-activity repos I think we should
err on the side of explicitness.

Reasons in favor of CI on push:
  - to have a baseline, so one can see the history of status checks by looking at master (including squash-merged PRs)
  - for any (rare) commits that skip the PR process

Without this, we don't have a clear concept of "current status", except
whatever the last PR was (which also assumes a linear history).
