### PR TITLE
docs(readme): update release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,19 +64,23 @@ Release
 Steps to perform a release:
 
 1. Bump and tag the version:
-   ```
+   ```bash
    npm version patch -m "release %s"
    ```
    Choose `patch`/`minor`/`major` to indicate query compatibility:
      - `patch` for bugfixes (no changes to queries needed)
      - `minor` for added nodes (queries may need changes to use new nodes but will not error)
      - `major` for removed or renamed nodes (queries will error if not adapted), other breaking changes
+
+   Ensure that `Cargo.toml`, `pyproject.toml`, and `Makefile` also have the same version.
 2. Bump to prerelease, without creating a tag:
-   ```
-   npm version --no-git-tag-version prerelease --preid dev && git add package*.json && git commit -m bump
+   ```bash
+   npm version --no-git-tag-version prerelease --preid dev
+   git add package*.json Cargo.toml pyproject.toml Makefile
+   git commit -m bump
    ```
 3. Push:
-   ```
-   git push --follow-tags
+   ```bash
+   git push && git push --tags
    ```
 4. Release the tagged commit: https://github.com/neovim/tree-sitter-vimdoc/releases/new


### PR DESCRIPTION
The non-npm version bumps can't easily be automated (yet).