### PR TITLE
build: automate non-npm version updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-vimdoc"
 description = "Vim help file grammar for tree-sitter"
-version = "2.5.1"
+version = "2.5.2-dev.0"
 license = "Apache-2.0"
 keywords = ["incremental", "parsing", "neovim", "vimdoc"]
 categories = ["parsing", "text-editors"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 2.5.1
+VERSION := 2.5.2-dev.0
 
 LANGUAGE_NAME := tree-sitter-vimdoc
 
@@ -112,4 +112,11 @@ parser/vimdoc.so: $(SRCS)
 	@mkdir -p parser
 	$(CC) $(CFLAGS) $^ -o $@
 
-.PHONY: all install uninstall clean test
+update: VERSION := $(shell awk -F '"' '/^  "version"/{print $$4}' package.json)
+update:
+	sed -i Makefile -e 's/^VERSION := .*/VERSION := $(VERSION)/'
+	sed -i Cargo.toml -e 's/^version = .*/version = "$(VERSION)"/'
+	sed -i pyproject.toml -e 's/^version = .*/version = "$(VERSION)"/'
+	git add package.json package-lock.json Cargo.toml pyproject.toml Makefile
+
+.PHONY: all install uninstall clean test update

--- a/README.md
+++ b/README.md
@@ -64,8 +64,6 @@ Release
 Steps to perform a release:
 
 1. Bump and tag the version:
-
-   **First** bump `Cargo.toml`, `pyproject.toml`, and `Makefile` to the new version. **Then** bump the package:
    ```bash
    npm version patch -m "release %s"
    ```
@@ -77,8 +75,7 @@ Steps to perform a release:
 
 2. Bump to prerelease, without creating a tag:
    ```bash
-   npm version --no-git-tag-version prerelease --preid dev
-   git add package*.json Cargo.toml pyproject.toml Makefile
+   npm version prerelease --no-git-tag-version --preid dev
    git commit -m bump
    ```
 3. Push:

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "build": "tree-sitter generate --no-bindings",
     "test": "tree-sitter test",
     "install": "node-gyp-build",
-    "prebuildify": "prebuildify --napi --strip"
+    "prebuildify": "prebuildify --napi --strip",
+    "version": "make -s update"
   },
   "tree-sitter": [
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-vimdoc"
 description = "Vim help file grammar for tree-sitter"
-version = "2.5.1"
+version = "2.5.2-dev.0"
 keywords = ["incremental", "parsing", "tree-sitter", "vimdoc"]
 classifiers = [
   "Intended Audience :: Developers",


### PR DESCRIPTION
This also applies to prereleases for maximum consistency.