### PR TITLE
feat: better structured headings

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -4,8 +4,10 @@
 // - Rule Order: Tree-sitter will prefer the token that appears earlier in the
 //   grammar.
 //
-// https://tree-sitter.github.io/tree-sitter/creating-parsers
-// - Rules starting with underscore are hidden in the syntax tree.
+// https://github.com/nvim-treesitter/nvim-treesitter/wiki/Parser-Development
+// - Visibility: Prefer JS regex (/\n/) over literals ('\n') unless it should be
+//   exposed to queries as an anonymous node.
+//   Rules starting with underscore are hidden in the syntax tree.
 
 /// <reference types="tree-sitter-cli/dsl" />
 // @ts-check
@@ -15,6 +17,11 @@ const _li_token = /[-•][ ]+/;
 
 module.exports = grammar({
   name: 'vimdoc',
+
+  conflicts: $ => [
+    [$._line_noli, $._column_heading],
+    [$._column_heading],
+  ],
 
   extras: () => [/[\t ]/],
 
@@ -135,14 +142,14 @@ module.exports = grammar({
       '>',
       choice(
         alias(token.immediate(/[a-z0-9]+\n/), $.language),
-        token.immediate('\n')),
+        token.immediate(/\n/)),
       alias(repeat1(alias($.line_code, $.line)), $.code),
       // Codeblock ends if a line starts with non-whitespace.
       // Terminating "<" is consumed in other rules.
     )),
 
     // Lines.
-    _blank: () => field('blank', '\n'),
+    _blank: () => field('blank', /\n/),
     line: ($) => choice(
       $.column_heading,
       $.h1,
@@ -156,18 +163,18 @@ module.exports = grammar({
       optional(token.immediate('<')),  // Treat codeblock-terminating "<" as whitespace.
       _li_token,
       choice(
-        alias(seq(repeat1($._atom), '\n'), $.line),
+        alias(seq(repeat1($._atom), /\n/), $.line),
         seq(alias(repeat1($._atom), $.line), $.codeblock),
       ),
       repeat(alias($._line_noli, $.line)),
     )),
     // Codeblock lines: must be indented by at least 1 space/tab.
     // Line content (incl. whitespace) is captured as a single atom.
-    line_code: () => choice('\n', /[\t ]+[^\n]+\n/),
+    line_code: () => choice(/\n/, /[\t ]+[^\n]+\n/),
     _line_noli: ($) => seq(
       choice($._atom_noli, $._uppercase_words),
       repeat($._atom),
-      choice($.codeblock, '\n')
+      choice($.codeblock, /\n/)
     ),
 
     // Modeline: must start with "vim:" (optionally preceded by whitespace)
@@ -177,31 +184,38 @@ module.exports = grammar({
     // Intended for table column names per `:help help-writing`.
     // TODO: children should be $.word (plaintext), not $.atom.
     column_heading: ($) => seq(
-      field('name', seq(choice($._atom_noli, $._uppercase_words), repeat($._atom))),
-      '~',
-      token.immediate('\n'),
+      alias($._column_heading, $.heading),
+      alias('~', $.delimiter),
+      token.immediate(/\n/),
     ),
+    // aliasing a seq exposes every item separately: create hidden rule and alias that
+    _column_heading: $ => prec.dynamic(1, seq(
+      choice($._atom_noli, $._uppercase_words),
+      repeat($._atom)
+    )),
 
     h1: ($) =>
-      seq(
-        token.immediate(field('delimiter', /============+[\t ]*\n/)),
-        repeat1($._atom),
-        '\n',
-      ),
+      prec(1, seq(
+        alias(token.immediate(/============+[\t ]*\n/), $.delimiter),
+        alias(repeat1($._atom), $.heading),
+        optional(seq($.tag, repeat($._atom))),
+        /\n/,
+      )),
 
     h2: ($) =>
-      seq(
-        token.immediate(field('delimiter', /------------+[\t ]*\n/)),
-        repeat1($._atom),
-        '\n',
-      ),
+      prec(1, seq(
+        alias(token.immediate(/------------+[\t ]*\n/), $.delimiter),
+        alias(repeat1($._atom), $.heading),
+        optional(seq($.tag, repeat($._atom))),
+        /\n/,
+      )),
 
     // Heading 3: UPPERCASE NAME, followed by optional *tags*.
     h3: ($) =>
       seq(
-        field('name', $.uppercase_name),
+        alias($.uppercase_name, $.heading),
         optional(seq($.tag, repeat($._atom))),
-        '\n',
+        /\n/,
       ),
 
     tag: ($) => _word($,

--- a/grammar.js
+++ b/grammar.js
@@ -7,7 +7,7 @@
 // https://github.com/nvim-treesitter/nvim-treesitter/wiki/Parser-Development
 // - Visibility: Prefer JS regex (/\n/) over literals ('\n') unless it should be
 //   exposed to queries as an anonymous node.
-//   Rules starting with underscore are hidden in the syntax tree.
+// - Rules starting with underscore are hidden in the syntax tree.
 
 /// <reference types="tree-sitter-cli/dsl" />
 // @ts-check

--- a/queries/vimdoc/highlights.scm
+++ b/queries/vimdoc/highlights.scm
@@ -1,13 +1,19 @@
-(h1) @markup.heading.1
+(h1
+  (delimiter) @markup.heading.1
+  (heading) @markup.heading.1)
 
-(h2) @markup.heading.2
+(h2
+  (delimiter) @markup.heading.2
+  (heading) @markup.heading.2)
 
-(h3) @markup.heading.3
-
-(column_heading) @markup.heading.4
+(h3
+  (heading) @markup.heading.3)
 
 (column_heading
-  "~" @markup.heading.4.marker
+  (heading) @markup.heading.4)
+
+(column_heading
+  (delimiter) @markup.heading.4.marker
   (#set! conceal ""))
 
 (tag

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -485,8 +485,8 @@
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "STRING",
-                  "value": "\n"
+                  "type": "PATTERN",
+                  "value": "\\n"
                 }
               }
             ]
@@ -515,8 +515,8 @@
       "type": "FIELD",
       "name": "blank",
       "content": {
-        "type": "STRING",
-        "value": "\n"
+        "type": "PATTERN",
+        "value": "\\n"
       }
     },
     "line": {
@@ -589,8 +589,8 @@
                       }
                     },
                     {
-                      "type": "STRING",
-                      "value": "\n"
+                      "type": "PATTERN",
+                      "value": "\\n"
                     }
                   ]
                 },
@@ -639,8 +639,8 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "STRING",
-          "value": "\n"
+          "type": "PATTERN",
+          "value": "\\n"
         },
         {
           "type": "PATTERN",
@@ -679,8 +679,8 @@
               "name": "codeblock"
             },
             {
-              "type": "STRING",
-              "value": "\n"
+              "type": "PATTERN",
+              "value": "\\n"
             }
           ]
         }
@@ -701,111 +701,194 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "FIELD",
-          "name": "name",
+          "type": "ALIAS",
           "content": {
-            "type": "SEQ",
+            "type": "SYMBOL",
+            "name": "_column_heading"
+          },
+          "named": true,
+          "value": "heading"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "~"
+          },
+          "named": true,
+          "value": "delimiter"
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "PATTERN",
+            "value": "\\n"
+          }
+        }
+      ]
+    },
+    "_column_heading": {
+      "type": "PREC_DYNAMIC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
             "members": [
               {
-                "type": "CHOICE",
+                "type": "SYMBOL",
+                "name": "_atom_noli"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_uppercase_words"
+              }
+            ]
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_atom"
+            }
+          }
+        ]
+      }
+    },
+    "h1": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "PATTERN",
+                "value": "============+[\\t ]*\\n"
+              }
+            },
+            "named": true,
+            "value": "delimiter"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "REPEAT1",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_atom"
+              }
+            },
+            "named": true,
+            "value": "heading"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "_atom_noli"
+                    "name": "tag"
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "_uppercase_words"
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_atom"
+                    }
                   }
                 ]
               },
               {
-                "type": "REPEAT",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_atom"
-                }
+                "type": "BLANK"
               }
             ]
+          },
+          {
+            "type": "PATTERN",
+            "value": "\\n"
           }
-        },
-        {
-          "type": "STRING",
-          "value": "~"
-        },
-        {
-          "type": "IMMEDIATE_TOKEN",
-          "content": {
-            "type": "STRING",
-            "value": "\n"
-          }
-        }
-      ]
-    },
-    "h1": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "IMMEDIATE_TOKEN",
-          "content": {
-            "type": "FIELD",
-            "name": "delimiter",
-            "content": {
-              "type": "PATTERN",
-              "value": "============+[\\t ]*\\n"
-            }
-          }
-        },
-        {
-          "type": "REPEAT1",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_atom"
-          }
-        },
-        {
-          "type": "STRING",
-          "value": "\n"
-        }
-      ]
+        ]
+      }
     },
     "h2": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "IMMEDIATE_TOKEN",
-          "content": {
-            "type": "FIELD",
-            "name": "delimiter",
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
             "content": {
-              "type": "PATTERN",
-              "value": "------------+[\\t ]*\\n"
-            }
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "PATTERN",
+                "value": "------------+[\\t ]*\\n"
+              }
+            },
+            "named": true,
+            "value": "delimiter"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "REPEAT1",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_atom"
+              }
+            },
+            "named": true,
+            "value": "heading"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "tag"
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_atom"
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "PATTERN",
+            "value": "\\n"
           }
-        },
-        {
-          "type": "REPEAT1",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_atom"
-          }
-        },
-        {
-          "type": "STRING",
-          "value": "\n"
-        }
-      ]
+        ]
+      }
     },
     "h3": {
       "type": "SEQ",
       "members": [
         {
-          "type": "FIELD",
-          "name": "name",
+          "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
             "name": "uppercase_name"
-          }
+          },
+          "named": true,
+          "value": "heading"
         },
         {
           "type": "CHOICE",
@@ -832,8 +915,8 @@
           ]
         },
         {
-          "type": "STRING",
-          "value": "\n"
+          "type": "PATTERN",
+          "value": "\\n"
         }
       ]
     },
@@ -1054,7 +1137,15 @@
       "value": "[\\t ]"
     }
   ],
-  "conflicts": [],
+  "conflicts": [
+    [
+      "_line_noli",
+      "_column_heading"
+    ],
+    [
+      "_column_heading"
+    ]
+  ],
   "precedences": [],
   "externals": [],
   "inline": [],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -18,18 +18,7 @@
   {
     "type": "block",
     "named": true,
-    "fields": {
-      "blank": {
-        "multiple": true,
-        "required": false,
-        "types": [
-          {
-            "type": "\n",
-            "named": false
-          }
-        ]
-      }
-    },
+    "fields": {},
     "children": {
       "multiple": true,
       "required": true,
@@ -98,49 +87,20 @@
   {
     "type": "column_heading",
     "named": true,
-    "fields": {
-      "name": {
-        "multiple": true,
-        "required": true,
-        "types": [
-          {
-            "type": "argument",
-            "named": true
-          },
-          {
-            "type": "codespan",
-            "named": true
-          },
-          {
-            "type": "keycode",
-            "named": true
-          },
-          {
-            "type": "note",
-            "named": true
-          },
-          {
-            "type": "optionlink",
-            "named": true
-          },
-          {
-            "type": "tag",
-            "named": true
-          },
-          {
-            "type": "taglink",
-            "named": true
-          },
-          {
-            "type": "url",
-            "named": true
-          },
-          {
-            "type": "word",
-            "named": true
-          }
-        ]
-      }
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "delimiter",
+          "named": true
+        },
+        {
+          "type": "heading",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -157,6 +117,14 @@
         },
         {
           "type": "codespan",
+          "named": true
+        },
+        {
+          "type": "delimiter",
+          "named": true
+        },
+        {
+          "type": "heading",
           "named": true
         },
         {
@@ -207,6 +175,14 @@
           "named": true
         },
         {
+          "type": "delimiter",
+          "named": true
+        },
+        {
+          "type": "heading",
+          "named": true
+        },
+        {
           "type": "keycode",
           "named": true
         },
@@ -240,18 +216,58 @@
   {
     "type": "h3",
     "named": true,
-    "fields": {
-      "name": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "uppercase_name",
-            "named": true
-          }
-        ]
-      }
-    },
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "argument",
+          "named": true
+        },
+        {
+          "type": "codespan",
+          "named": true
+        },
+        {
+          "type": "heading",
+          "named": true
+        },
+        {
+          "type": "keycode",
+          "named": true
+        },
+        {
+          "type": "note",
+          "named": true
+        },
+        {
+          "type": "optionlink",
+          "named": true
+        },
+        {
+          "type": "tag",
+          "named": true
+        },
+        {
+          "type": "taglink",
+          "named": true
+        },
+        {
+          "type": "url",
+          "named": true
+        },
+        {
+          "type": "word",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "heading",
+    "named": true,
+    "fields": {},
     "children": {
       "multiple": true,
       "required": false,
@@ -298,18 +314,7 @@
   {
     "type": "help_file",
     "named": true,
-    "fields": {
-      "blank": {
-        "multiple": true,
-        "required": false,
-        "types": [
-          {
-            "type": "\n",
-            "named": false
-          }
-        ]
-      }
-    },
+    "fields": {},
     "children": {
       "multiple": true,
       "required": false,
@@ -470,11 +475,6 @@
     }
   },
   {
-    "type": "uppercase_name",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "url",
     "named": true,
     "fields": {
@@ -494,10 +494,6 @@
     "type": "word",
     "named": true,
     "fields": {}
-  },
-  {
-    "type": "\n",
-    "named": false
   },
   {
     "type": "'",
@@ -566,6 +562,10 @@
   {
     "type": "`",
     "named": false
+  },
+  {
+    "type": "delimiter",
+    "named": true
   },
   {
     "type": "language",

--- a/src/parser.c
+++ b/src/parser.c
@@ -13,15 +13,15 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 114
+#define STATE_COUNT 115
 #define LARGE_STATE_COUNT 17
-#define SYMBOL_COUNT 94
+#define SYMBOL_COUNT 95
 #define ALIAS_COUNT 1
 #define TOKEN_COUNT 57
 #define EXTERNAL_TOKEN_COUNT 0
-#define FIELD_COUNT 3
+#define FIELD_COUNT 2
 #define MAX_ALIAS_SEQUENCE_LENGTH 5
-#define PRODUCTION_ID_COUNT 21
+#define PRODUCTION_ID_COUNT 14
 
 enum ts_symbol_identifiers {
   aux_sym_word_token1 = 1,
@@ -61,8 +61,8 @@ enum ts_symbol_identifiers {
   aux_sym_uppercase_name_token2 = 35,
   anon_sym_LT = 36,
   aux_sym_codeblock_token1 = 37,
-  anon_sym_LF = 38,
-  anon_sym_LF2 = 39,
+  aux_sym_codeblock_token2 = 38,
+  aux_sym__blank_token1 = 39,
   aux_sym_line_li_token1 = 40,
   aux_sym_line_code_token1 = 41,
   sym_modeline = 42,
@@ -99,25 +99,26 @@ enum ts_symbol_identifiers {
   sym_line_code = 73,
   sym__line_noli = 74,
   sym_column_heading = 75,
-  sym_h1 = 76,
-  sym_h2 = 77,
-  sym_h3 = 78,
-  sym_tag = 79,
-  sym_url = 80,
-  sym_optionlink = 81,
-  sym_taglink = 82,
-  sym_codespan = 83,
-  sym_argument = 84,
-  aux_sym_help_file_repeat1 = 85,
-  aux_sym_help_file_repeat2 = 86,
-  aux_sym_help_file_repeat3 = 87,
-  aux_sym_uppercase_name_repeat1 = 88,
-  aux_sym_block_repeat1 = 89,
-  aux_sym_block_repeat2 = 90,
-  aux_sym_codeblock_repeat1 = 91,
-  aux_sym_line_li_repeat1 = 92,
-  aux_sym_line_li_repeat2 = 93,
-  alias_sym_code = 94,
+  sym__column_heading = 76,
+  sym_h1 = 77,
+  sym_h2 = 78,
+  sym_h3 = 79,
+  sym_tag = 80,
+  sym_url = 81,
+  sym_optionlink = 82,
+  sym_taglink = 83,
+  sym_codespan = 84,
+  sym_argument = 85,
+  aux_sym_help_file_repeat1 = 86,
+  aux_sym_help_file_repeat2 = 87,
+  aux_sym_help_file_repeat3 = 88,
+  aux_sym_uppercase_name_repeat1 = 89,
+  aux_sym_block_repeat1 = 90,
+  aux_sym_block_repeat2 = 91,
+  aux_sym_codeblock_repeat1 = 92,
+  aux_sym_line_li_repeat1 = 93,
+  aux_sym_line_li_repeat2 = 94,
+  alias_sym_code = 95,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -159,13 +160,13 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_uppercase_name_token2] = "uppercase_name_token2",
   [anon_sym_LT] = "<",
   [aux_sym_codeblock_token1] = "language",
-  [anon_sym_LF] = "\n",
-  [anon_sym_LF2] = "\n",
+  [aux_sym_codeblock_token2] = "codeblock_token2",
+  [aux_sym__blank_token1] = "_blank_token1",
   [aux_sym_line_li_token1] = "line_li_token1",
   [aux_sym_line_code_token1] = "line_code_token1",
   [sym_modeline] = "modeline",
-  [aux_sym_h1_token1] = "h1_token1",
-  [aux_sym_h2_token1] = "h2_token1",
+  [aux_sym_h1_token1] = "delimiter",
+  [aux_sym_h2_token1] = "delimiter",
   [aux_sym_tag_token1] = "word",
   [anon_sym_STAR2] = "*",
   [sym_url_word] = "word",
@@ -187,7 +188,7 @@ static const char * const ts_symbol_names[] = {
   [sym__word_common] = "_word_common",
   [sym_note] = "note",
   [sym_keycode] = "keycode",
-  [sym_uppercase_name] = "uppercase_name",
+  [sym_uppercase_name] = "heading",
   [sym__uppercase_words] = "_uppercase_words",
   [sym_block] = "block",
   [sym_codeblock] = "codeblock",
@@ -197,6 +198,7 @@ static const char * const ts_symbol_names[] = {
   [sym_line_code] = "line",
   [sym__line_noli] = "_line_noli",
   [sym_column_heading] = "column_heading",
+  [sym__column_heading] = "heading",
   [sym_h1] = "h1",
   [sym_h2] = "h2",
   [sym_h3] = "h3",
@@ -257,13 +259,13 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_uppercase_name_token2] = aux_sym_uppercase_name_token2,
   [anon_sym_LT] = anon_sym_LT,
   [aux_sym_codeblock_token1] = aux_sym_codeblock_token1,
-  [anon_sym_LF] = anon_sym_LF,
-  [anon_sym_LF2] = anon_sym_LF,
+  [aux_sym_codeblock_token2] = aux_sym_codeblock_token2,
+  [aux_sym__blank_token1] = aux_sym__blank_token1,
   [aux_sym_line_li_token1] = aux_sym_line_li_token1,
   [aux_sym_line_code_token1] = aux_sym_line_code_token1,
   [sym_modeline] = sym_modeline,
   [aux_sym_h1_token1] = aux_sym_h1_token1,
-  [aux_sym_h2_token1] = aux_sym_h2_token1,
+  [aux_sym_h2_token1] = aux_sym_h1_token1,
   [aux_sym_tag_token1] = sym_word,
   [anon_sym_STAR2] = anon_sym_STAR,
   [sym_url_word] = sym_word,
@@ -295,6 +297,7 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_line_code] = sym_line,
   [sym__line_noli] = sym__line_noli,
   [sym_column_heading] = sym_column_heading,
+  [sym__column_heading] = sym_uppercase_name,
   [sym_h1] = sym_h1,
   [sym_h2] = sym_h2,
   [sym_h3] = sym_h3,
@@ -469,12 +472,12 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [anon_sym_LF] = {
-    .visible = true,
+  [aux_sym_codeblock_token2] = {
+    .visible = false,
     .named = false,
   },
-  [anon_sym_LF2] = {
-    .visible = true,
+  [aux_sym__blank_token1] = {
+    .visible = false,
     .named = false,
   },
   [aux_sym_line_li_token1] = {
@@ -490,12 +493,12 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = true,
   },
   [aux_sym_h1_token1] = {
-    .visible = false,
-    .named = false,
+    .visible = true,
+    .named = true,
   },
   [aux_sym_h2_token1] = {
-    .visible = false,
-    .named = false,
+    .visible = true,
+    .named = true,
   },
   [aux_sym_tag_token1] = {
     .visible = true,
@@ -621,6 +624,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym__column_heading] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_h1] = {
     .visible = true,
     .named = true,
@@ -701,30 +708,19 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
 
 enum ts_field_identifiers {
   field_blank = 1,
-  field_name = 2,
-  field_text = 3,
+  field_text = 2,
 };
 
 static const char * const ts_field_names[] = {
   [0] = NULL,
   [field_blank] = "blank",
-  [field_name] = "name",
   [field_text] = "text",
 };
 
 static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
   [2] = {.index = 0, .length = 1},
   [3] = {.index = 1, .length = 1},
-  [4] = {.index = 2, .length = 1},
-  [6] = {.index = 3, .length = 1},
-  [7] = {.index = 4, .length = 2},
-  [8] = {.index = 6, .length = 1},
-  [9] = {.index = 7, .length = 1},
-  [13] = {.index = 8, .length = 1},
-  [14] = {.index = 9, .length = 2},
-  [18] = {.index = 11, .length = 2},
-  [19] = {.index = 13, .length = 1},
-  [20] = {.index = 14, .length = 2},
+  [5] = {.index = 2, .length = 1},
 };
 
 static const TSFieldMapEntry ts_field_map_entries[] = {
@@ -733,29 +729,7 @@ static const TSFieldMapEntry ts_field_map_entries[] = {
   [1] =
     {field_text, 0},
   [2] =
-    {field_blank, 0, .inherited = true},
-  [3] =
-    {field_name, 0},
-  [4] =
-    {field_blank, 0, .inherited = true},
-    {field_blank, 1, .inherited = true},
-  [6] =
-    {field_blank, 1, .inherited = true},
-  [7] =
     {field_text, 1},
-  [8] =
-    {field_blank, 2, .inherited = true},
-  [9] =
-    {field_blank, 1, .inherited = true},
-    {field_blank, 2, .inherited = true},
-  [11] =
-    {field_name, 0},
-    {field_name, 1},
-  [13] =
-    {field_blank, 3, .inherited = true},
-  [14] =
-    {field_blank, 2, .inherited = true},
-    {field_blank, 3, .inherited = true},
 };
 
 static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
@@ -763,28 +737,34 @@ static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE
   [1] = {
     [0] = sym_word,
   },
-  [5] = {
+  [4] = {
     [0] = sym_word,
     [1] = sym_word,
   },
-  [10] = {
+  [6] = {
     [2] = alias_sym_code,
   },
-  [11] = {
+  [7] = {
     [1] = sym_line,
     [2] = sym_line,
   },
-  [12] = {
+  [8] = {
     [1] = sym_line,
   },
-  [15] = {
+  [9] = {
+    [1] = sym_uppercase_name,
+  },
+  [10] = {
+    [1] = aux_sym_h1_token1,
+  },
+  [11] = {
     [2] = sym_line,
     [3] = sym_line,
   },
-  [16] = {
+  [12] = {
     [2] = sym_line,
   },
-  [17] = {
+  [13] = {
     [0] = sym_line,
   },
 };
@@ -799,9 +779,10 @@ static const uint16_t ts_non_terminal_alias_map[] = {
   aux_sym_codeblock_repeat1, 2,
     aux_sym_codeblock_repeat1,
     alias_sym_code,
-  aux_sym_line_li_repeat1, 2,
+  aux_sym_line_li_repeat1, 3,
     aux_sym_line_li_repeat1,
     sym_line,
+    sym_uppercase_name,
   0,
 };
 
@@ -852,9 +833,9 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [43] = 43,
   [44] = 44,
   [45] = 45,
-  [46] = 46,
+  [46] = 44,
   [47] = 43,
-  [48] = 44,
+  [48] = 48,
   [49] = 49,
   [50] = 50,
   [51] = 51,
@@ -867,19 +848,19 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [58] = 58,
   [59] = 59,
   [60] = 60,
-  [61] = 49,
-  [62] = 50,
-  [63] = 52,
-  [64] = 64,
-  [65] = 54,
+  [61] = 61,
+  [62] = 62,
+  [63] = 49,
+  [64] = 48,
+  [65] = 52,
   [66] = 66,
-  [67] = 67,
+  [67] = 57,
   [68] = 68,
   [69] = 69,
   [70] = 70,
   [71] = 71,
-  [72] = 67,
-  [73] = 73,
+  [72] = 72,
+  [73] = 69,
   [74] = 74,
   [75] = 75,
   [76] = 76,
@@ -920,6 +901,7 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [111] = 111,
   [112] = 112,
   [113] = 113,
+  [114] = 114,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -927,870 +909,844 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(33);
+      if (eof) ADVANCE(32);
       ADVANCE_MAP(
-        '\n', 585,
-        '\'', 689,
-        '(', 690,
-        '*', 691,
-        ',', 690,
-        '<', 686,
-        '>', 689,
-        '?', 689,
-        'A', 623,
-        'C', 632,
-        'D', 613,
-        'M', 617,
-        'N', 627,
-        'W', 607,
-        '[', 690,
-        '`', 689,
-        'h', 675,
-        '{', 680,
-        '|', 689,
-        '}', 689,
-        '~', 689,
+        '\n', 584,
+        '\'', 688,
+        '(', 689,
+        '*', 690,
+        ',', 689,
+        '<', 685,
+        '>', 688,
+        '?', 688,
+        'A', 622,
+        'C', 631,
+        'D', 612,
+        'M', 616,
+        'N', 626,
+        'W', 606,
+        '[', 689,
+        '`', 688,
+        'h', 674,
+        '{', 679,
+        '|', 688,
+        '}', 688,
+        '~', 688,
       );
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(30);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(688);
-      if (lookahead != 0) ADVANCE(689);
+          lookahead == ' ') SKIP(29);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(687);
+      if (lookahead != 0) ADVANCE(688);
       END_STATE();
     case 1:
-      if (lookahead == '\t') ADVANCE(24);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == ' ') ADVANCE(587);
-      if (lookahead != 0) ADVANCE(339);
+      if (lookahead == '\t') ADVANCE(23);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == ' ') ADVANCE(586);
+      if (lookahead != 0) ADVANCE(338);
       END_STATE();
     case 2:
       ADVANCE_MAP(
-        '\n', 585,
-        '\'', 355,
-        '(', 407,
-        '*', 351,
-        ',', 425,
-        '<', 134,
-        '>', 421,
-        'A', 79,
-        'C', 88,
-        'D', 70,
-        'M', 74,
-        'N', 83,
-        'W', 63,
-        '[', 413,
-        '`', 794,
-        'h', 126,
-        '{', 398,
-        '|', 394,
-        '~', 417,
+        '\n', 584,
+        '\'', 354,
+        '(', 406,
+        '*', 350,
+        ',', 424,
+        '<', 133,
+        '>', 420,
+        'A', 78,
+        'C', 87,
+        'D', 69,
+        'M', 73,
+        'N', 82,
+        'W', 62,
+        '[', 412,
+        '`', 793,
+        'h', 37,
+        '{', 397,
+        '|', 393,
+        '~', 416,
       );
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(6);
-      if (lookahead != 0) ADVANCE(135);
+          lookahead == ' ') SKIP(5);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(38);
+      if (lookahead != 0) ADVANCE(134);
       END_STATE();
     case 3:
       ADVANCE_MAP(
         '\n', 585,
-        '\'', 355,
-        '(', 407,
-        '*', 351,
-        ',', 425,
-        '<', 134,
-        '>', 421,
-        'A', 79,
-        'C', 88,
-        'D', 70,
-        'M', 74,
-        'N', 83,
-        'W', 63,
-        '[', 413,
-        '`', 794,
-        'h', 38,
-        '{', 398,
-        '|', 394,
-        '~', 417,
+        '\'', 688,
+        '(', 689,
+        '*', 350,
+        ',', 689,
+        '<', 685,
+        '>', 688,
+        'A', 622,
+        'C', 631,
+        'D', 612,
+        'M', 616,
+        'N', 626,
+        'W', 606,
+        '[', 689,
+        '`', 688,
+        'h', 676,
+        '{', 679,
+        '|', 681,
+        '~', 688,
       );
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(6);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
-      if (lookahead != 0) ADVANCE(135);
+          lookahead == ' ') SKIP(5);
+      if (lookahead != 0) ADVANCE(688);
       END_STATE();
     case 4:
       ADVANCE_MAP(
-        '\n', 586,
-        '\'', 689,
-        '(', 690,
-        '*', 351,
-        ',', 690,
-        '<', 686,
-        '>', 689,
-        'A', 623,
-        'C', 632,
-        'D', 613,
-        'M', 617,
-        'N', 627,
-        'W', 607,
-        '[', 690,
-        '`', 689,
-        'h', 677,
-        '{', 680,
-        '|', 682,
-        '~', 689,
+        '\n', 585,
+        '\'', 354,
+        '(', 406,
+        '*', 350,
+        ',', 424,
+        '<', 133,
+        '>', 420,
+        '?', 901,
+        'A', 78,
+        'C', 87,
+        'D', 69,
+        'M', 73,
+        'N', 82,
+        'W', 62,
+        '[', 412,
+        '`', 793,
+        'h', 125,
+        '{', 397,
+        '|', 393,
+        '~', 416,
       );
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(6);
-      if (lookahead != 0) ADVANCE(689);
+          lookahead == ' ') SKIP(5);
+      if (lookahead != 0) ADVANCE(134);
       END_STATE();
     case 5:
       ADVANCE_MAP(
-        '\n', 586,
-        '\'', 355,
-        '(', 407,
-        '*', 351,
-        ',', 425,
-        '<', 134,
-        '>', 421,
-        '?', 902,
-        'A', 79,
-        'C', 88,
-        'D', 70,
-        'M', 74,
-        'N', 83,
-        'W', 63,
-        '[', 413,
-        '`', 794,
-        'h', 126,
-        '{', 398,
-        '|', 394,
-        '~', 417,
+        '\n', 585,
+        '\'', 354,
+        '(', 406,
+        '*', 350,
+        ',', 424,
+        '<', 133,
+        '>', 420,
+        'A', 78,
+        'C', 87,
+        'D', 69,
+        'M', 73,
+        'N', 82,
+        'W', 62,
+        '[', 412,
+        '`', 793,
+        'h', 125,
+        '{', 397,
+        '|', 393,
+        '~', 416,
       );
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(6);
-      if (lookahead != 0) ADVANCE(135);
+          lookahead == ' ') SKIP(5);
+      if (lookahead != 0) ADVANCE(134);
       END_STATE();
     case 6:
       ADVANCE_MAP(
-        '\n', 586,
-        '\'', 355,
-        '(', 407,
-        '*', 351,
-        ',', 425,
-        '<', 134,
-        '>', 421,
-        'A', 79,
-        'C', 88,
-        'D', 70,
-        'M', 74,
-        'N', 83,
-        'W', 63,
-        '[', 413,
-        '`', 794,
-        'h', 126,
-        '{', 398,
-        '|', 394,
-        '~', 417,
+        '\n', 585,
+        '\'', 354,
+        '(', 406,
+        '*', 350,
+        ',', 424,
+        '<', 335,
+        '>', 420,
+        'A', 277,
+        'C', 286,
+        'D', 268,
+        'M', 271,
+        'N', 281,
+        'W', 261,
+        '[', 412,
+        '`', 793,
+        'h', 326,
+        '{', 397,
+        '|', 393,
+        '~', 416,
       );
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(6);
-      if (lookahead != 0) ADVANCE(135);
+      if (lookahead == '-' ||
+          lookahead == 0x2022) ADVANCE(26);
+      if (lookahead != 0) ADVANCE(336);
       END_STATE();
     case 7:
       ADVANCE_MAP(
-        '\n', 586,
-        '\'', 355,
-        '(', 407,
-        '*', 351,
-        ',', 425,
-        '<', 336,
-        '>', 421,
-        'A', 278,
-        'C', 287,
-        'D', 269,
-        'M', 272,
-        'N', 282,
-        'W', 262,
-        '[', 413,
-        '`', 794,
-        'h', 327,
-        '{', 398,
-        '|', 394,
-        '~', 417,
+        '\n', 585,
+        '\'', 354,
+        '(', 408,
+        '*', 350,
+        ',', 424,
+        '-', 25,
+        '<', 582,
+        '=', 257,
+        '>', 420,
+        'A', 229,
+        'C', 231,
+        'D', 227,
+        'M', 228,
+        'N', 230,
+        'W', 226,
+        '[', 412,
+        '`', 793,
+        'h', 326,
+        '{', 397,
+        '|', 393,
+        '~', 416,
+        0x2022, 26,
       );
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(7);
-      if (lookahead == '-' ||
-          lookahead == 0x2022) ADVANCE(27);
-      if (lookahead != 0) ADVANCE(337);
+          lookahead == ' ') SKIP(6);
+      if (lookahead == ')' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(232);
+      if (lookahead != 0) ADVANCE(336);
       END_STATE();
     case 8:
       ADVANCE_MAP(
-        '\n', 586,
-        '\'', 355,
-        '(', 409,
-        '*', 351,
-        ',', 425,
-        '-', 26,
-        '<', 583,
-        '=', 258,
-        '>', 421,
-        'A', 230,
-        'C', 232,
-        'D', 228,
-        'M', 229,
-        'N', 231,
-        'W', 227,
-        '[', 413,
-        '`', 794,
-        'h', 327,
-        '{', 398,
-        '|', 394,
-        '~', 417,
-        0x2022, 27,
+        '\n', 585,
+        '\'', 354,
+        '(', 408,
+        '*', 350,
+        ',', 424,
+        '-', 25,
+        '<', 582,
+        '=', 257,
+        '>', 420,
+        'A', 229,
+        'C', 231,
+        'D', 227,
+        'M', 228,
+        'N', 230,
+        'W', 226,
+        '[', 412,
+        '`', 793,
+        'h', 326,
+        '{', 397,
+        '|', 393,
+        '~', 416,
+        0x2022, 26,
+        '\t', 13,
+        ' ', 13,
       );
-      if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(7);
       if (lookahead == ')' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(233);
-      if (lookahead != 0) ADVANCE(337);
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(232);
+      if (lookahead != 0) ADVANCE(336);
       END_STATE();
     case 9:
       ADVANCE_MAP(
-        '\n', 586,
-        '\'', 355,
-        '(', 409,
-        '*', 351,
-        ',', 425,
-        '-', 26,
-        '<', 583,
-        '=', 258,
-        '>', 421,
-        'A', 230,
-        'C', 232,
-        'D', 228,
-        'M', 229,
-        'N', 231,
-        'W', 227,
-        '[', 413,
-        '`', 794,
-        'h', 327,
-        '{', 398,
-        '|', 394,
-        '~', 417,
-        0x2022, 27,
-        '\t', 14,
-        ' ', 14,
+        '\n', 585,
+        '\'', 354,
+        '(', 408,
+        '*', 350,
+        ',', 424,
+        '<', 582,
+        '>', 420,
+        'A', 229,
+        'C', 231,
+        'D', 227,
+        'M', 228,
+        'N', 230,
+        'W', 226,
+        '[', 412,
+        '`', 793,
+        'h', 326,
+        '{', 397,
+        '|', 393,
+        '~', 416,
       );
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(6);
+      if (lookahead == '-' ||
+          lookahead == 0x2022) ADVANCE(26);
       if (lookahead == ')' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(233);
-      if (lookahead != 0) ADVANCE(337);
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(232);
+      if (lookahead != 0) ADVANCE(336);
       END_STATE();
     case 10:
       ADVANCE_MAP(
-        '\n', 586,
-        '\'', 355,
-        '(', 409,
-        '*', 351,
-        ',', 425,
-        '<', 583,
-        '>', 421,
-        'A', 230,
-        'C', 232,
-        'D', 228,
-        'M', 229,
-        'N', 231,
-        'W', 227,
-        '[', 413,
-        '`', 794,
-        'h', 327,
-        '{', 398,
-        '|', 394,
-        '~', 417,
+        '\n', 585,
+        '\'', 354,
+        '(', 408,
+        '*', 350,
+        ',', 424,
+        '<', 582,
+        '>', 420,
+        'A', 229,
+        'C', 231,
+        'D', 227,
+        'M', 228,
+        'N', 230,
+        'W', 226,
+        '[', 412,
+        '`', 793,
+        'h', 326,
+        '{', 397,
+        '|', 393,
+        '~', 416,
+        '\t', 13,
+        ' ', 13,
+        '-', 26,
+        0x2022, 26,
       );
-      if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(7);
-      if (lookahead == '-' ||
-          lookahead == 0x2022) ADVANCE(27);
       if (lookahead == ')' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(233);
-      if (lookahead != 0) ADVANCE(337);
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(232);
+      if (lookahead != 0) ADVANCE(336);
       END_STATE();
     case 11:
       ADVANCE_MAP(
-        '\n', 586,
-        '\'', 355,
+        '\n', 585,
+        '\'', 354,
         '(', 409,
-        '*', 351,
-        ',', 425,
-        '<', 583,
-        '>', 421,
-        'A', 230,
-        'C', 232,
-        'D', 228,
-        'M', 229,
-        'N', 231,
-        'W', 227,
-        '[', 413,
-        '`', 794,
-        'h', 327,
-        '{', 398,
-        '|', 394,
-        '~', 417,
-        '\t', 14,
-        ' ', 14,
-        '-', 27,
-        0x2022, 27,
-      );
-      if (lookahead == ')' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(233);
-      if (lookahead != 0) ADVANCE(337);
-      END_STATE();
-    case 12:
-      ADVANCE_MAP(
-        '\n', 586,
-        '\'', 355,
-        '(', 410,
-        '*', 354,
-        ',', 427,
-        '<', 366,
-        '>', 424,
-        'A', 361,
-        'C', 363,
-        'D', 359,
-        'M', 360,
-        'N', 362,
-        'W', 358,
-        '[', 415,
-        '`', 797,
-        'h', 364,
-        '{', 399,
-        '|', 395,
-        '~', 420,
-      );
-      if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(6);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(365);
-      if (lookahead != 0) ADVANCE(367);
-      END_STATE();
-    case 13:
-      ADVANCE_MAP(
-        '\n', 586,
-        '\'', 355,
-        '(', 411,
-        '*', 351,
-        ',', 425,
-        '<', 134,
-        '>', 421,
-        'A', 43,
-        'C', 45,
-        'D', 41,
-        'M', 42,
-        'N', 44,
-        'W', 40,
-        '[', 413,
-        '`', 794,
-        'h', 126,
-        '{', 398,
-        '|', 394,
-        '~', 417,
-      );
-      if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(13);
-      if (lookahead == ')' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(46);
-      if (lookahead != 0) ADVANCE(135);
-      END_STATE();
-    case 14:
-      ADVANCE_MAP(
-        '\n', 586,
-        '\'', 356,
-        '(', 408,
-        '*', 352,
-        ',', 426,
-        '<', 225,
-        '>', 422,
-        'A', 170,
-        'C', 179,
-        'D', 161,
-        'M', 165,
-        'N', 174,
-        'W', 154,
-        '[', 414,
-        '`', 795,
-        'h', 217,
-        '{', 397,
-        '|', 393,
-        '~', 418,
-        '\t', 14,
-        ' ', 14,
-        '-', 1,
-        0x2022, 1,
-      );
-      if (lookahead != 0) ADVANCE(226);
-      END_STATE();
-    case 15:
-      ADVANCE_MAP(
-        '\n', 586,
-        '\'', 389,
-        '(', 407,
-        '*', 351,
-        ',', 425,
-        '<', 134,
-        '>', 421,
-        'A', 79,
-        'C', 88,
-        'D', 70,
-        'M', 74,
-        'N', 83,
-        'W', 63,
-        '[', 413,
-        '`', 794,
-        'h', 126,
-        '{', 398,
-        '|', 394,
-        '~', 417,
-      );
-      if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(6);
-      if (lookahead != 0) ADVANCE(135);
-      END_STATE();
-    case 16:
-      ADVANCE_MAP(
-        '\n', 586,
-        '\'', 791,
-        '(', 792,
-        '*', 791,
-        ',', 792,
-        '<', 789,
-        '>', 791,
-        'A', 730,
-        'C', 739,
-        'D', 720,
-        'M', 724,
-        'N', 734,
-        'W', 714,
-        '[', 792,
-        '`', 791,
-        'h', 781,
-        '{', 784,
-        '|', 394,
-        '~', 791,
-      );
-      if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(6);
-      if (lookahead != 0) ADVANCE(791);
-      END_STATE();
-    case 17:
-      ADVANCE_MAP(
-        '\n', 586,
-        '\'', 357,
-        '(', 412,
         '*', 353,
-        ',', 428,
-        '<', 897,
+        ',', 426,
+        '<', 365,
         '>', 423,
-        'A', 834,
-        'C', 843,
-        'D', 824,
-        'M', 828,
-        'N', 838,
-        'W', 817,
-        '[', 416,
+        'A', 360,
+        'C', 362,
+        'D', 358,
+        'M', 359,
+        'N', 361,
+        'W', 357,
+        '[', 414,
         '`', 796,
-        'h', 886,
-        '{', 400,
-        '|', 396,
-        '}', 135,
+        'h', 363,
+        '{', 398,
+        '|', 394,
         '~', 419,
       );
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(6);
-      if (lookahead != 0) ADVANCE(899);
+          lookahead == ' ') SKIP(5);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(364);
+      if (lookahead != 0) ADVANCE(366);
+      END_STATE();
+    case 12:
+      ADVANCE_MAP(
+        '\n', 585,
+        '\'', 354,
+        '(', 410,
+        '*', 350,
+        ',', 424,
+        '<', 133,
+        '>', 420,
+        'A', 42,
+        'C', 44,
+        'D', 40,
+        'M', 41,
+        'N', 43,
+        'W', 39,
+        '[', 412,
+        '`', 793,
+        'h', 125,
+        '{', 397,
+        '|', 393,
+        '~', 416,
+      );
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(12);
+      if (lookahead == ')' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(45);
+      if (lookahead != 0) ADVANCE(134);
+      END_STATE();
+    case 13:
+      ADVANCE_MAP(
+        '\n', 585,
+        '\'', 355,
+        '(', 407,
+        '*', 351,
+        ',', 425,
+        '<', 224,
+        '>', 421,
+        'A', 169,
+        'C', 178,
+        'D', 160,
+        'M', 164,
+        'N', 173,
+        'W', 153,
+        '[', 413,
+        '`', 794,
+        'h', 216,
+        '{', 396,
+        '|', 392,
+        '~', 417,
+        '\t', 13,
+        ' ', 13,
+        '-', 1,
+        0x2022, 1,
+      );
+      if (lookahead != 0) ADVANCE(225);
+      END_STATE();
+    case 14:
+      ADVANCE_MAP(
+        '\n', 585,
+        '\'', 356,
+        '(', 411,
+        '*', 352,
+        ',', 427,
+        '<', 896,
+        '>', 422,
+        'A', 833,
+        'C', 842,
+        'D', 823,
+        'M', 827,
+        'N', 837,
+        'W', 816,
+        '[', 415,
+        '`', 795,
+        'h', 885,
+        '{', 399,
+        '|', 395,
+        '}', 134,
+        '~', 418,
+      );
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(5);
+      if (lookahead != 0) ADVANCE(898);
+      END_STATE();
+    case 15:
+      ADVANCE_MAP(
+        '\n', 585,
+        '\'', 388,
+        '(', 406,
+        '*', 350,
+        ',', 424,
+        '<', 133,
+        '>', 420,
+        'A', 78,
+        'C', 87,
+        'D', 69,
+        'M', 73,
+        'N', 82,
+        'W', 62,
+        '[', 412,
+        '`', 793,
+        'h', 125,
+        '{', 397,
+        '|', 393,
+        '~', 416,
+      );
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(5);
+      if (lookahead != 0) ADVANCE(134);
+      END_STATE();
+    case 16:
+      ADVANCE_MAP(
+        '\n', 585,
+        '\'', 790,
+        '(', 791,
+        '*', 790,
+        ',', 791,
+        '<', 788,
+        '>', 790,
+        'A', 729,
+        'C', 738,
+        'D', 719,
+        'M', 723,
+        'N', 733,
+        'W', 713,
+        '[', 791,
+        '`', 790,
+        'h', 780,
+        '{', 783,
+        '|', 393,
+        '~', 790,
+      );
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(5);
+      if (lookahead != 0) ADVANCE(790);
+      END_STATE();
+    case 17:
+      if (lookahead == '\n') ADVANCE(585);
+      if (lookahead == '*') ADVANCE(690);
+      if (lookahead == '<') ADVANCE(581);
+      if (lookahead == '`') ADVANCE(798);
+      if (lookahead == '|') ADVANCE(792);
+      if (lookahead == '}') ADVANCE(900);
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(18);
+      if (lookahead == '-' ||
+          lookahead == 0x2022) ADVANCE(24);
       END_STATE();
     case 18:
-      if (lookahead == '\n') ADVANCE(586);
-      if (lookahead == '*') ADVANCE(691);
-      if (lookahead == '<') ADVANCE(582);
-      if (lookahead == '`') ADVANCE(799);
-      if (lookahead == '|') ADVANCE(793);
-      if (lookahead == '}') ADVANCE(901);
+      if (lookahead == '\n') ADVANCE(585);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(19);
+          lookahead == ' ') SKIP(18);
       if (lookahead == '-' ||
-          lookahead == 0x2022) ADVANCE(25);
+          lookahead == 0x2022) ADVANCE(24);
       END_STATE();
     case 19:
-      if (lookahead == '\n') ADVANCE(586);
-      if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(19);
-      if (lookahead == '-' ||
-          lookahead == 0x2022) ADVANCE(25);
+      if (lookahead == '\n') ADVANCE(589);
+      if (lookahead != 0) ADVANCE(19);
       END_STATE();
     case 20:
-      if (lookahead == '\n') ADVANCE(590);
-      if (lookahead != 0) ADVANCE(20);
+      if (lookahead == '\n') ADVANCE(591);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(20);
       END_STATE();
     case 21:
-      if (lookahead == '\n') ADVANCE(592);
+      if (lookahead == '\n') ADVANCE(590);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(21);
       END_STATE();
     case 22:
-      if (lookahead == '\n') ADVANCE(591);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '>') ADVANCE(456);
+      if (lookahead != 0) ADVANCE(23);
       END_STATE();
     case 23:
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '>') ADVANCE(457);
-      if (lookahead != 0) ADVANCE(24);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead != 0) ADVANCE(23);
       END_STATE();
     case 24:
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead != 0) ADVANCE(24);
+      if (lookahead == ' ') ADVANCE(587);
       END_STATE();
     case 25:
-      if (lookahead == ' ') ADVANCE(588);
+      if (lookahead == ' ') ADVANCE(587);
+      if (lookahead == '-') ADVANCE(348);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n') ADVANCE(349);
       END_STATE();
     case 26:
-      if (lookahead == ' ') ADVANCE(588);
-      if (lookahead == '-') ADVANCE(349);
+      if (lookahead == ' ') ADVANCE(587);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(350);
+          lookahead != '\n') ADVANCE(349);
       END_STATE();
     case 27:
-      if (lookahead == ' ') ADVANCE(588);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(350);
+      if (lookahead == '>') ADVANCE(454);
       END_STATE();
     case 28:
-      if (lookahead == '>') ADVANCE(455);
-      END_STATE();
-    case 29:
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '`') ADVANCE(798);
+          lookahead != '`') ADVANCE(797);
+      END_STATE();
+    case 29:
+      if (eof) ADVANCE(32);
+      ADVANCE_MAP(
+        '\n', 585,
+        '\'', 354,
+        '(', 406,
+        '*', 350,
+        ',', 424,
+        '<', 133,
+        '>', 420,
+        'A', 78,
+        'C', 87,
+        'D', 69,
+        'M', 73,
+        'N', 82,
+        'W', 62,
+        '[', 412,
+        '`', 793,
+        'h', 125,
+        '{', 397,
+        '|', 391,
+        '~', 416,
+      );
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(29);
+      if (lookahead != 0) ADVANCE(134);
       END_STATE();
     case 30:
-      if (eof) ADVANCE(33);
+      if (eof) ADVANCE(32);
       ADVANCE_MAP(
-        '\n', 586,
-        '\'', 355,
-        '(', 407,
-        '*', 351,
-        ',', 425,
-        '<', 134,
-        '>', 421,
-        'A', 79,
-        'C', 88,
-        'D', 70,
-        'M', 74,
-        'N', 83,
-        'W', 63,
-        '[', 413,
-        '`', 794,
-        'h', 126,
-        '{', 398,
-        '|', 392,
-        '~', 417,
+        '\n', 585,
+        '\'', 354,
+        '(', 406,
+        '*', 350,
+        ',', 424,
+        '<', 335,
+        '>', 420,
+        'A', 277,
+        'C', 286,
+        'D', 268,
+        'M', 271,
+        'N', 281,
+        'W', 261,
+        '[', 412,
+        '`', 793,
+        'h', 326,
+        'v', 306,
+        '{', 397,
+        '|', 393,
+        '~', 416,
       );
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(30);
-      if (lookahead != 0) ADVANCE(135);
+      if (lookahead == '-' ||
+          lookahead == 0x2022) ADVANCE(26);
+      if (lookahead != 0) ADVANCE(336);
       END_STATE();
     case 31:
-      if (eof) ADVANCE(33);
+      if (eof) ADVANCE(32);
       ADVANCE_MAP(
-        '\n', 586,
-        '\'', 355,
-        '(', 407,
-        '*', 351,
-        ',', 425,
-        '<', 336,
-        '>', 421,
-        'A', 278,
-        'C', 287,
-        'D', 269,
-        'M', 272,
-        'N', 282,
-        'W', 262,
-        '[', 413,
-        '`', 794,
-        'h', 327,
-        'v', 307,
-        '{', 398,
-        '|', 394,
-        '~', 417,
+        '\n', 585,
+        '\'', 354,
+        '(', 408,
+        '*', 350,
+        ',', 424,
+        '-', 25,
+        '<', 582,
+        '=', 257,
+        '>', 420,
+        'A', 229,
+        'C', 231,
+        'D', 227,
+        'M', 228,
+        'N', 230,
+        'W', 226,
+        '[', 412,
+        '`', 793,
+        'h', 326,
+        'v', 306,
+        '{', 397,
+        '|', 393,
+        '~', 416,
+        0x2022, 26,
       );
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(31);
-      if (lookahead == '-' ||
-          lookahead == 0x2022) ADVANCE(27);
-      if (lookahead != 0) ADVANCE(337);
-      END_STATE();
-    case 32:
-      if (eof) ADVANCE(33);
-      ADVANCE_MAP(
-        '\n', 586,
-        '\'', 355,
-        '(', 409,
-        '*', 351,
-        ',', 425,
-        '-', 26,
-        '<', 583,
-        '=', 258,
-        '>', 421,
-        'A', 230,
-        'C', 232,
-        'D', 228,
-        'M', 229,
-        'N', 231,
-        'W', 227,
-        '[', 413,
-        '`', 794,
-        'h', 327,
-        'v', 307,
-        '{', 398,
-        '|', 394,
-        '~', 417,
-        0x2022, 27,
-      );
-      if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(31);
+          lookahead == ' ') SKIP(30);
       if (lookahead == ')' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(233);
-      if (lookahead != 0) ADVANCE(337);
+          ('B' <= lookahead && lookahead <= 'Z')) ADVANCE(232);
+      if (lookahead != 0) ADVANCE(336);
+      END_STATE();
+    case 32:
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 33:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '\n') ADVANCE(583);
+      if (lookahead == ':') ADVANCE(129);
+      if (lookahead == 's') ADVANCE(34);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(38);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 34:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(584);
-      if (lookahead == ':') ADVANCE(130);
-      if (lookahead == 's') ADVANCE(35);
+      if (lookahead == '\n') ADVANCE(583);
+      if (lookahead == ':') ADVANCE(129);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(38);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 35:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(584);
-      if (lookahead == ':') ADVANCE(130);
+      if (lookahead == '\n') ADVANCE(583);
+      if (lookahead == 'p') ADVANCE(33);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(38);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 36:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(584);
-      if (lookahead == 'p') ADVANCE(34);
+      if (lookahead == '\n') ADVANCE(583);
+      if (lookahead == 't') ADVANCE(35);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(38);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 37:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(584);
+      if (lookahead == '\n') ADVANCE(583);
       if (lookahead == 't') ADVANCE(36);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(38);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 38:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(584);
-      if (lookahead == 't') ADVANCE(37);
+      if (lookahead == '\n') ADVANCE(583);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(38);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 39:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\n') ADVANCE(584);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '(' &&
-          lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
-      END_STATE();
-    case 40:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'A') ADVANCE(569);
-      if (lookahead == 'a') ADVANCE(118);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'A') ADVANCE(568);
+      if (lookahead == 'a') ADVANCE(117);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           (lookahead < ',' || '.' < lookahead) &&
-          (lookahead < 'A' || '[' < lookahead)) ADVANCE(135);
+          (lookahead < 'A' || '[' < lookahead)) ADVANCE(134);
+      END_STATE();
+    case 40:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'E') ADVANCE(566);
+      if (lookahead == 'e') ADVANCE(115);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(575);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          (lookahead < ',' || '.' < lookahead) &&
+          (lookahead < 'A' || '[' < lookahead)) ADVANCE(134);
       END_STATE();
     case 41:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'E') ADVANCE(567);
-      if (lookahead == 'e') ADVANCE(116);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'E') ADVANCE(571);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           (lookahead < ',' || '.' < lookahead) &&
-          (lookahead < 'A' || '[' < lookahead)) ADVANCE(135);
+          (lookahead < 'A' || '[' < lookahead)) ADVANCE(134);
       END_STATE();
     case 42:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'E') ADVANCE(572);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'L') ADVANCE(570);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           (lookahead < ',' || '.' < lookahead) &&
-          (lookahead < 'A' || '[' < lookahead)) ADVANCE(135);
+          (lookahead < 'A' || '[' < lookahead)) ADVANCE(134);
       END_STATE();
     case 43:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'L') ADVANCE(571);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'O') ADVANCE(572);
+      if (lookahead == 'o') ADVANCE(122);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           (lookahead < ',' || '.' < lookahead) &&
-          (lookahead < 'A' || '[' < lookahead)) ADVANCE(135);
+          (lookahead < 'A' || '[' < lookahead)) ADVANCE(134);
       END_STATE();
     case 44:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'O') ADVANCE(573);
-      if (lookahead == 'o') ADVANCE(123);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'T') ADVANCE(567);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           (lookahead < ',' || '.' < lookahead) &&
-          (lookahead < 'A' || '[' < lookahead)) ADVANCE(135);
+          (lookahead < 'A' || '[' < lookahead)) ADVANCE(134);
       END_STATE();
     case 45:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'T') ADVANCE(568);
+      if (lookahead == '(') ADVANCE(580);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           (lookahead < ',' || '.' < lookahead) &&
-          (lookahead < 'A' || '[' < lookahead)) ADVANCE(135);
+          (lookahead < 'A' || '[' < lookahead)) ADVANCE(134);
       END_STATE();
     case 46:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          (lookahead < ',' || '.' < lookahead) &&
-          (lookahead < 'A' || '[' < lookahead)) ADVANCE(135);
-      END_STATE();
-    case 47:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '-') ADVANCE(61);
-      if (lookahead == '>') ADVANCE(451);
+      if (lookahead == '-') ADVANCE(60);
+      if (lookahead == '>') ADVANCE(450);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(59);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
@@ -1798,9 +1754,33 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '(' &&
           lookahead != ',' &&
           lookahead != '-' &&
-          (lookahead < 'A' || '[' < lookahead)) ADVANCE(135);
+          (lookahead < 'A' || '[' < lookahead)) ADVANCE(134);
+      END_STATE();
+    case 47:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '-') ADVANCE(130);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '-' &&
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 48:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '-') ADVANCE(65);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '-' &&
+          lookahead != '[') ADVANCE(134);
+      END_STATE();
+    case 49:
       ACCEPT_TOKEN(aux_sym_word_token1);
       if (lookahead == '-') ADVANCE(131);
       if (lookahead != 0 &&
@@ -1810,19 +1790,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '(' &&
           lookahead != ',' &&
           lookahead != '-' &&
-          lookahead != '[') ADVANCE(135);
-      END_STATE();
-    case 49:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '-') ADVANCE(66);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '(' &&
-          lookahead != ',' &&
-          lookahead != '-' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 50:
       ACCEPT_TOKEN(aux_sym_word_token1);
@@ -1834,46 +1802,22 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '(' &&
           lookahead != ',' &&
           lookahead != '-' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 51:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '-') ADVANCE(133);
+      if (lookahead == ':') ADVANCE(431);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '-' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 52:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == ':') ADVANCE(432);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '(' &&
-          lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
-      END_STATE();
-    case 53:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == ':') ADVANCE(429);
-      if (lookahead == 's') ADVANCE(56);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '(' &&
-          lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
-      END_STATE();
-    case 54:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == ':') ADVANCE(130);
+      if (lookahead == ':') ADVANCE(428);
       if (lookahead == 's') ADVANCE(55);
       if (lookahead != 0 &&
           lookahead != '\t' &&
@@ -1881,71 +1825,83 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
+      END_STATE();
+    case 53:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == ':') ADVANCE(129);
+      if (lookahead == 's') ADVANCE(54);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(134);
+      END_STATE();
+    case 54:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == ':') ADVANCE(129);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 55:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == ':') ADVANCE(130);
+      if (lookahead == ':') ADVANCE(434);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 56:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == ':') ADVANCE(435);
+      if (lookahead == ':') ADVANCE(440);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 57:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == ':') ADVANCE(441);
+      if (lookahead == ':') ADVANCE(437);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 58:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == ':') ADVANCE(438);
+      if (lookahead == ':') ADVANCE(447);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 59:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == ':') ADVANCE(448);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '(' &&
-          lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
-      END_STATE();
-    case 60:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '>') ADVANCE(451);
+      if (lookahead == '>') ADVANCE(450);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(59);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
@@ -1953,302 +1909,291 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '(' &&
           lookahead != ',' &&
           lookahead != '-' &&
-          (lookahead < 'A' || '[' < lookahead)) ADVANCE(135);
+          (lookahead < 'A' || '[' < lookahead)) ADVANCE(134);
       END_STATE();
-    case 61:
+    case 60:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '>') ADVANCE(454);
+      if (lookahead == '>') ADVANCE(453);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(28);
+          lookahead == '[') ADVANCE(27);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(59);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(62);
+          lookahead != '\n') ADVANCE(61);
+      END_STATE();
+    case 61:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == '>') ADVANCE(454);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 62:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '>') ADVANCE(455);
+      if (lookahead == 'A') ADVANCE(84);
+      if (lookahead == 'a') ADVANCE(117);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 63:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'A') ADVANCE(85);
-      if (lookahead == 'a') ADVANCE(118);
+      if (lookahead == 'A') ADVANCE(91);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 64:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'A') ADVANCE(92);
+      if (lookahead == 'A') ADVANCE(49);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 65:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'A') ADVANCE(50);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '(' &&
-          lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
-      END_STATE();
-    case 66:
-      ACCEPT_TOKEN(aux_sym_word_token1);
       ADVANCE_MAP(
-        'B', 483,
-        'D', 479,
-        'I', 481,
-        'P', 475,
-        'S', 473,
-        '{', 477,
-        '\t', 458,
-        ' ', 458,
-        '(', 458,
-        ',', 458,
-        '[', 458,
+        'B', 482,
+        'D', 478,
+        'I', 480,
+        'P', 474,
+        'S', 472,
+        '{', 476,
+        '\t', 457,
+        ' ', 457,
+        '(', 457,
+        ',', 457,
+        '[', 457,
       );
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(458);
+          lookahead != '\n') ADVANCE(457);
+      END_STATE();
+    case 66:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'C') ADVANCE(63);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 67:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'C') ADVANCE(64);
+      if (lookahead == 'D') ADVANCE(113);
+      if (lookahead == 'U') ADVANCE(114);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 68:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'D') ADVANCE(114);
-      if (lookahead == 'U') ADVANCE(115);
+      if (lookahead == 'D') ADVANCE(58);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 69:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'D') ADVANCE(59);
+      if (lookahead == 'E') ADVANCE(83);
+      if (lookahead == 'e') ADVANCE(115);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 70:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'E') ADVANCE(84);
-      if (lookahead == 'e') ADVANCE(116);
+      if (lookahead == 'E') ADVANCE(51);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 71:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'E') ADVANCE(52);
+      if (lookahead == 'E') ADVANCE(66);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 72:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'E') ADVANCE(67);
+      if (lookahead == 'E') ADVANCE(68);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 73:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'E') ADVANCE(69);
+      if (lookahead == 'E') ADVANCE(89);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 74:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'E') ADVANCE(90);
+      if (lookahead == 'F') ADVANCE(92);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 75:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'F') ADVANCE(93);
+      if (lookahead == 'G') ADVANCE(56);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 76:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'G') ADVANCE(57);
+      if (lookahead == 'I') ADVANCE(74);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 77:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'I') ADVANCE(75);
+      if (lookahead == 'I') ADVANCE(81);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 78:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'I') ADVANCE(82);
+      if (lookahead == 'L') ADVANCE(88);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 79:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'L') ADVANCE(89);
+      if (lookahead == 'L') ADVANCE(48);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 80:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'L') ADVANCE(49);
+      if (lookahead == 'N') ADVANCE(77);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 81:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'N') ADVANCE(78);
+      if (lookahead == 'N') ADVANCE(75);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 82:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'N') ADVANCE(76);
+      if (lookahead == 'O') ADVANCE(90);
+      if (lookahead == 'o') ADVANCE(122);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 83:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'O') ADVANCE(91);
-      if (lookahead == 'o') ADVANCE(123);
+      if (lookahead == 'P') ADVANCE(86);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 84:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'P') ADVANCE(87);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '(' &&
-          lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
-      END_STATE();
-    case 85:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'R') ADVANCE(81);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '(' &&
-          lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
-      END_STATE();
-    case 86:
       ACCEPT_TOKEN(aux_sym_word_token1);
       if (lookahead == 'R') ADVANCE(80);
       if (lookahead != 0 &&
@@ -2257,152 +2202,185 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
+      END_STATE();
+    case 85:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'R') ADVANCE(79);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(134);
+      END_STATE();
+    case 86:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'R') ADVANCE(71);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 87:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'R') ADVANCE(72);
+      if (lookahead == 'T') ADVANCE(85);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 88:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'T') ADVANCE(86);
+      if (lookahead == 'T') ADVANCE(47);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 89:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'T') ADVANCE(48);
+      if (lookahead == 'T') ADVANCE(64);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 90:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'T') ADVANCE(65);
+      if (lookahead == 'T') ADVANCE(70);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 91:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'T') ADVANCE(71);
+      if (lookahead == 'T') ADVANCE(72);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 92:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'T') ADVANCE(73);
+      if (lookahead == 'T') ADVANCE(50);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 93:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'T') ADVANCE(51);
+      if (lookahead == 'a') ADVANCE(108);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 94:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'a') ADVANCE(109);
+      if (lookahead == 'a') ADVANCE(126);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 95:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'a') ADVANCE(127);
+      if (lookahead == 'a') ADVANCE(118);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 96:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'a') ADVANCE(119);
+      if (lookahead == 'c') ADVANCE(94);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 97:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'c') ADVANCE(95);
+      if (lookahead == 'd') ADVANCE(443);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 98:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'd') ADVANCE(444);
+      if (lookahead == 'e') ADVANCE(52);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 99:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'e') ADVANCE(53);
+      if (lookahead == 'e') ADVANCE(96);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 100:
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (lookahead == 'e') ADVANCE(67);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ',' &&
+          lookahead != '[') ADVANCE(134);
+      END_STATE();
+    case 101:
       ACCEPT_TOKEN(aux_sym_word_token1);
       if (lookahead == 'e') ADVANCE(97);
       if (lookahead != 0 &&
@@ -2411,338 +2389,327 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
-      END_STATE();
-    case 101:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'e') ADVANCE(68);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '(' &&
-          lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 102:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'e') ADVANCE(98);
+      if (lookahead == 'e') ADVANCE(93);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 103:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'e') ADVANCE(94);
+      if (lookahead == 'e') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 104:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'e') ADVANCE(121);
+      if (lookahead == 'g') ADVANCE(100);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 105:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'g') ADVANCE(101);
+      if (lookahead == 'g') ADVANCE(57);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 106:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'g') ADVANCE(58);
+      if (lookahead == 'h') ADVANCE(95);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 107:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'h') ADVANCE(96);
+      if (lookahead == 'i') ADVANCE(111);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 108:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'i') ADVANCE(112);
+      if (lookahead == 'k') ADVANCE(490);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 109:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'k') ADVANCE(491);
+      if (lookahead == 'l') ADVANCE(490);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 110:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'l') ADVANCE(491);
+      if (lookahead == 'n') ADVANCE(107);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 111:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'n') ADVANCE(108);
+      if (lookahead == 'n') ADVANCE(105);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 112:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'n') ADVANCE(106);
+      if (lookahead == 'n') ADVANCE(490);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 113:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'n') ADVANCE(491);
+      if (lookahead == 'o') ADVANCE(127);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 114:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'o') ADVANCE(128);
+      if (lookahead == 'p') ADVANCE(490);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 115:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'p') ADVANCE(491);
+      if (lookahead == 'p') ADVANCE(119);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 116:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'p') ADVANCE(120);
+      if (lookahead == 'p') ADVANCE(53);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 117:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'p') ADVANCE(54);
+      if (lookahead == 'r') ADVANCE(110);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 118:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'r') ADVANCE(111);
+      if (lookahead == 'r') ADVANCE(128);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 119:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'r') ADVANCE(129);
+      if (lookahead == 'r') ADVANCE(99);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 120:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'r') ADVANCE(100);
+      if (lookahead == 'r') ADVANCE(123);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 121:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'r') ADVANCE(124);
+      if (lookahead == 's') ADVANCE(103);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 122:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 's') ADVANCE(104);
+      if (lookahead == 't') ADVANCE(98);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 123:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 't') ADVANCE(99);
+      if (lookahead == 't') ADVANCE(490);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 124:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 't') ADVANCE(491);
+      if (lookahead == 't') ADVANCE(116);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 125:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 't') ADVANCE(117);
+      if (lookahead == 't') ADVANCE(124);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 126:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 't') ADVANCE(125);
+      if (lookahead == 't') ADVANCE(101);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 127:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 't') ADVANCE(102);
+      if (lookahead == 'w') ADVANCE(112);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 128:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == 'w') ADVANCE(113);
+      if (lookahead == '}') ADVANCE(492);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
       END_STATE();
     case 129:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '}') ADVANCE(493);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(134);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(695);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '(' &&
-          lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != ' ') ADVANCE(694);
       END_STATE();
     case 130:
       ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(135);
-      if (lookahead == '(' ||
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(696);
+          lookahead == '[') ADVANCE(499);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(695);
+          lookahead != '\n') ADVANCE(499);
       END_STATE();
     case 131:
       ACCEPT_TOKEN(aux_sym_word_token1);
@@ -2750,10 +2717,10 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == ' ' ||
           lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(500);
+          lookahead == '[') ADVANCE(494);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(500);
+          lookahead != '\n') ADVANCE(494);
       END_STATE();
     case 132:
       ACCEPT_TOKEN(aux_sym_word_token1);
@@ -2761,34 +2728,23 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == ' ' ||
           lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(495);
+          lookahead == '[') ADVANCE(485);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(495);
+          lookahead != '\n') ADVANCE(485);
       END_STATE();
     case 133:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(486);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(486);
-      END_STATE();
-    case 134:
       ACCEPT_TOKEN(aux_sym_word_token1);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(47);
+          lookahead == 'S') ADVANCE(46);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(59);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
@@ -2796,9 +2752,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '(' &&
           lookahead != ',' &&
           lookahead != '-' &&
-          (lookahead < 'A' || '[' < lookahead)) ADVANCE(135);
+          (lookahead < 'A' || '[' < lookahead)) ADVANCE(134);
       END_STATE();
-    case 135:
+    case 134:
       ACCEPT_TOKEN(aux_sym_word_token1);
       if (lookahead != 0 &&
           lookahead != '\t' &&
@@ -2806,182 +2762,167 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ',' &&
-          lookahead != '[') ADVANCE(135);
+          lookahead != '[') ADVANCE(134);
+      END_STATE();
+    case 135:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(589);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(19);
+      if (lookahead != 0) ADVANCE(135);
       END_STATE();
     case 136:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
       if (lookahead == '\n') ADVANCE(590);
+      if (lookahead == '=') ADVANCE(136);
       if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(20);
-      if (lookahead != 0) ADVANCE(136);
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0 &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 137:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(591);
-      if (lookahead == '=') ADVANCE(137);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '-') ADVANCE(156);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(22);
-      if (lookahead != 0 &&
-          lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 138:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '-') ADVANCE(157);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '-') ADVANCE(151);
+      if (lookahead == '>') ADVANCE(452);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
-      END_STATE();
-    case 139:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '-') ADVANCE(152);
-      if (lookahead == '>') ADVANCE(453);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
+          lookahead == '[') ADVANCE(23);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
-      if (lookahead != 0) ADVANCE(226);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      if (lookahead != 0) ADVANCE(225);
+      END_STATE();
+    case 139:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '-') ADVANCE(221);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 140:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
+      if (lookahead == '\n') ADVANCE(588);
       if (lookahead == '-') ADVANCE(222);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 141:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
+      if (lookahead == '\n') ADVANCE(588);
       if (lookahead == '-') ADVANCE(223);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 142:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '-') ADVANCE(224);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == ':') ADVANCE(432);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 143:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == ':') ADVANCE(433);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
-      END_STATE();
-    case 144:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == ':') ADVANCE(430);
-      if (lookahead == 's') ADVANCE(147);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
-      END_STATE();
-    case 145:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == ':') ADVANCE(221);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == ':') ADVANCE(429);
       if (lookahead == 's') ADVANCE(146);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
+      END_STATE();
+    case 144:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == ':') ADVANCE(220);
+      if (lookahead == 's') ADVANCE(145);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
+      END_STATE();
+    case 145:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == ':') ADVANCE(220);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 146:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == ':') ADVANCE(221);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == ':') ADVANCE(435);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 147:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == ':') ADVANCE(436);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == ':') ADVANCE(441);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 148:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == ':') ADVANCE(442);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == ':') ADVANCE(438);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 149:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == ':') ADVANCE(439);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == ':') ADVANCE(448);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 150:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == ':') ADVANCE(449);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
-      END_STATE();
-    case 151:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '>') ADVANCE(453);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
-      if (lookahead != 0) ADVANCE(226);
-      END_STATE();
-    case 152:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
+      if (lookahead == '\n') ADVANCE(588);
       if (lookahead == '>') ADVANCE(452);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
@@ -2991,906 +2932,931 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
-      if (lookahead != 0) ADVANCE(153);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      if (lookahead != 0) ADVANCE(225);
+      END_STATE();
+    case 151:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '>') ADVANCE(451);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(22);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      if (lookahead != 0) ADVANCE(152);
+      END_STATE();
+    case 152:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '>') ADVANCE(455);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 153:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '>') ADVANCE(456);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'A') ADVANCE(175);
+      if (lookahead == 'a') ADVANCE(208);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 154:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'A') ADVANCE(176);
-      if (lookahead == 'a') ADVANCE(209);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'A') ADVANCE(182);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 155:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'A') ADVANCE(183);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'A') ADVANCE(140);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 156:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'A') ADVANCE(141);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+      ADVANCE_MAP(
+        '\n', 588,
+        'B', 463,
+        'D', 461,
+        'I', 462,
+        'P', 459,
+        'S', 458,
+        '{', 460,
+        '\t', 465,
+        ' ', 465,
+        '(', 465,
+        '[', 465,
+      );
+      if (lookahead != 0) ADVANCE(464);
       END_STATE();
     case 157:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      ADVANCE_MAP(
-        '\n', 589,
-        'B', 464,
-        'D', 462,
-        'I', 463,
-        'P', 460,
-        'S', 459,
-        '{', 461,
-        '\t', 466,
-        ' ', 466,
-        '(', 466,
-        '[', 466,
-      );
-      if (lookahead != 0) ADVANCE(465);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'C') ADVANCE(154);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 158:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'C') ADVANCE(155);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'D') ADVANCE(204);
+      if (lookahead == 'U') ADVANCE(205);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 159:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'D') ADVANCE(205);
-      if (lookahead == 'U') ADVANCE(206);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'D') ADVANCE(149);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 160:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'D') ADVANCE(150);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'E') ADVANCE(174);
+      if (lookahead == 'e') ADVANCE(206);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 161:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'E') ADVANCE(175);
-      if (lookahead == 'e') ADVANCE(207);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'E') ADVANCE(142);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 162:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'E') ADVANCE(143);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'E') ADVANCE(157);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 163:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'E') ADVANCE(158);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'E') ADVANCE(159);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 164:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'E') ADVANCE(160);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'E') ADVANCE(180);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 165:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'E') ADVANCE(181);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'F') ADVANCE(183);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 166:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'F') ADVANCE(184);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'G') ADVANCE(147);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 167:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'G') ADVANCE(148);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'I') ADVANCE(165);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 168:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'I') ADVANCE(166);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'I') ADVANCE(172);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 169:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'I') ADVANCE(173);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'L') ADVANCE(179);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 170:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'L') ADVANCE(180);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'L') ADVANCE(137);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 171:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'L') ADVANCE(138);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'N') ADVANCE(168);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 172:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'N') ADVANCE(169);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'N') ADVANCE(166);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 173:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'N') ADVANCE(167);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'O') ADVANCE(181);
+      if (lookahead == 'o') ADVANCE(213);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 174:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'O') ADVANCE(182);
-      if (lookahead == 'o') ADVANCE(214);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'P') ADVANCE(177);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 175:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'P') ADVANCE(178);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
-      END_STATE();
-    case 176:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'R') ADVANCE(172);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
-      END_STATE();
-    case 177:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
+      if (lookahead == '\n') ADVANCE(588);
       if (lookahead == 'R') ADVANCE(171);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
+      END_STATE();
+    case 176:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'R') ADVANCE(170);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
+      END_STATE();
+    case 177:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'R') ADVANCE(162);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 178:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'R') ADVANCE(163);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'T') ADVANCE(176);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 179:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'T') ADVANCE(177);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'T') ADVANCE(139);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 180:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'T') ADVANCE(140);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'T') ADVANCE(155);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 181:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'T') ADVANCE(156);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'T') ADVANCE(161);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 182:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'T') ADVANCE(162);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'T') ADVANCE(163);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 183:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'T') ADVANCE(164);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'T') ADVANCE(141);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 184:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'T') ADVANCE(142);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'a') ADVANCE(199);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 185:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'a') ADVANCE(200);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'a') ADVANCE(217);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 186:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'a') ADVANCE(218);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'a') ADVANCE(209);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 187:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'a') ADVANCE(210);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'c') ADVANCE(185);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 188:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'c') ADVANCE(186);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'd') ADVANCE(444);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 189:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'd') ADVANCE(445);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'e') ADVANCE(143);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 190:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'e') ADVANCE(144);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'e') ADVANCE(187);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 191:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'e') ADVANCE(158);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
+      END_STATE();
+    case 192:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '\n') ADVANCE(588);
       if (lookahead == 'e') ADVANCE(188);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
-      END_STATE();
-    case 192:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'e') ADVANCE(159);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 193:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'e') ADVANCE(189);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'e') ADVANCE(184);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 194:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'e') ADVANCE(185);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'e') ADVANCE(211);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 195:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'e') ADVANCE(212);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'g') ADVANCE(191);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 196:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'g') ADVANCE(192);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'g') ADVANCE(148);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 197:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'g') ADVANCE(149);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'h') ADVANCE(186);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 198:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'h') ADVANCE(187);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'i') ADVANCE(202);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 199:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'i') ADVANCE(203);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'k') ADVANCE(491);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 200:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'k') ADVANCE(492);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'l') ADVANCE(491);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 201:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'l') ADVANCE(492);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'n') ADVANCE(198);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 202:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'n') ADVANCE(199);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'n') ADVANCE(196);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 203:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'n') ADVANCE(197);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'n') ADVANCE(491);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 204:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'n') ADVANCE(492);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'o') ADVANCE(218);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 205:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'o') ADVANCE(219);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'p') ADVANCE(491);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 206:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'p') ADVANCE(492);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'p') ADVANCE(210);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 207:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'p') ADVANCE(211);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'p') ADVANCE(144);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 208:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'p') ADVANCE(145);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'r') ADVANCE(201);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 209:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'r') ADVANCE(202);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'r') ADVANCE(219);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 210:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'r') ADVANCE(220);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'r') ADVANCE(190);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 211:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'r') ADVANCE(191);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'r') ADVANCE(214);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 212:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'r') ADVANCE(215);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 's') ADVANCE(194);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 213:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 's') ADVANCE(195);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 't') ADVANCE(189);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 214:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 't') ADVANCE(190);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 't') ADVANCE(491);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 215:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 't') ADVANCE(492);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 't') ADVANCE(207);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 216:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 't') ADVANCE(208);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 't') ADVANCE(215);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 217:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 't') ADVANCE(216);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 't') ADVANCE(192);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 218:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 't') ADVANCE(193);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'w') ADVANCE(203);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 219:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'w') ADVANCE(204);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '}') ADVANCE(493);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 220:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '}') ADVANCE(494);
+      if (lookahead == '\n') ADVANCE(588);
       if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead == '(' ||
+          lookahead == '[') ADVANCE(692);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(225);
+      if (lookahead != 0) ADVANCE(691);
       END_STATE();
     case 221:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
+      if (lookahead == '\n') ADVANCE(588);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(24);
-      if (lookahead == '(' ||
-          lookahead == '[') ADVANCE(693);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(226);
-      if (lookahead != 0) ADVANCE(692);
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(501);
+      if (lookahead != 0) ADVANCE(500);
       END_STATE();
     case 222:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
+      if (lookahead == '\n') ADVANCE(588);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(502);
-      if (lookahead != 0) ADVANCE(501);
+          lookahead == '[') ADVANCE(496);
+      if (lookahead != 0) ADVANCE(495);
       END_STATE();
     case 223:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
+      if (lookahead == '\n') ADVANCE(588);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(497);
-      if (lookahead != 0) ADVANCE(496);
+          lookahead == '[') ADVANCE(487);
+      if (lookahead != 0) ADVANCE(486);
       END_STATE();
     case 224:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(488);
-      if (lookahead != 0) ADVANCE(487);
-      END_STATE();
-    case 225:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
       ADVANCE_MAP(
-        '\n', 589,
-        '\t', 24,
-        ' ', 24,
-        '(', 24,
-        '[', 24,
-        'A', 139,
-        'C', 139,
-        'D', 139,
-        'M', 139,
-        'S', 139,
+        '\n', 588,
+        '\t', 23,
+        ' ', 23,
+        '(', 23,
+        '[', 23,
+        'A', 138,
+        'C', 138,
+        'D', 138,
+        'M', 138,
+        'S', 138,
       );
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
-      if (lookahead != 0) ADVANCE(226);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
-    case 226:
+    case 225:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\n') ADVANCE(589);
+      if (lookahead == '\n') ADVANCE(588);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
-    case 227:
+    case 226:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'A') ADVANCE(530);
-      if (lookahead == 'a') ADVANCE(319);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'A') ADVANCE(529);
+      if (lookahead == 'a') ADVANCE(318);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          (lookahead < 'A' || '[' < lookahead)) ADVANCE(337);
+          (lookahead < 'A' || '[' < lookahead)) ADVANCE(336);
+      END_STATE();
+    case 227:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'E') ADVANCE(527);
+      if (lookahead == 'e') ADVANCE(316);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(543);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          (lookahead < 'A' || '[' < lookahead)) ADVANCE(336);
       END_STATE();
     case 228:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'E') ADVANCE(528);
-      if (lookahead == 'e') ADVANCE(317);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'E') ADVANCE(532);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          (lookahead < 'A' || '[' < lookahead)) ADVANCE(337);
+          (lookahead < 'A' || '[' < lookahead)) ADVANCE(336);
       END_STATE();
     case 229:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'E') ADVANCE(533);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'L') ADVANCE(531);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          (lookahead < 'A' || '[' < lookahead)) ADVANCE(337);
+          (lookahead < 'A' || '[' < lookahead)) ADVANCE(336);
       END_STATE();
     case 230:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'L') ADVANCE(532);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'O') ADVANCE(533);
+      if (lookahead == 'o') ADVANCE(324);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          (lookahead < 'A' || '[' < lookahead)) ADVANCE(337);
+          (lookahead < 'A' || '[' < lookahead)) ADVANCE(336);
       END_STATE();
     case 231:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'O') ADVANCE(534);
-      if (lookahead == 'o') ADVANCE(325);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'T') ADVANCE(528);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          (lookahead < 'A' || '[' < lookahead)) ADVANCE(337);
+          (lookahead < 'A' || '[' < lookahead)) ADVANCE(336);
       END_STATE();
     case 232:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'T') ADVANCE(529);
+      if (lookahead == '(') ADVANCE(544);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          (lookahead < 'A' || '[' < lookahead)) ADVANCE(337);
+          (lookahead < 'A' || '[' < lookahead)) ADVANCE(336);
       END_STATE();
     case 233:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          (lookahead < 'A' || '[' < lookahead)) ADVANCE(337);
-      END_STATE();
-    case 234:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '-') ADVANCE(260);
-      if (lookahead == '>') ADVANCE(451);
+      if (lookahead == '-') ADVANCE(259);
+      if (lookahead == '>') ADVANCE(450);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(259);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(258);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          (lookahead < 'A' || '[' < lookahead)) ADVANCE(337);
+          (lookahead < 'A' || '[' < lookahead)) ADVANCE(336);
+      END_STATE();
+    case 234:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '-') ADVANCE(264);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 235:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '-') ADVANCE(265);
+      if (lookahead == '-') ADVANCE(331);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 236:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
@@ -3900,7 +3866,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 237:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
@@ -3910,119 +3876,119 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 238:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '-') ADVANCE(334);
+      if (lookahead == ':') ADVANCE(431);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 239:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == ':') ADVANCE(432);
+      if (lookahead == ':') ADVANCE(428);
+      if (lookahead == 's') ADVANCE(240);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 240:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == ':') ADVANCE(429);
-      if (lookahead == 's') ADVANCE(241);
+      if (lookahead == ':') ADVANCE(434);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 241:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == ':') ADVANCE(435);
+      if (lookahead == ':') ADVANCE(440);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 242:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == ':') ADVANCE(441);
+      if (lookahead == ':') ADVANCE(437);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 243:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == ':') ADVANCE(438);
+      if (lookahead == ':') ADVANCE(447);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 244:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == ':') ADVANCE(448);
+      if (lookahead == ':') ADVANCE(334);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 245:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == ':') ADVANCE(335);
+      if (lookahead == ':') ADVANCE(330);
+      if (lookahead == 's') ADVANCE(246);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 246:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == ':') ADVANCE(331);
-      if (lookahead == 's') ADVANCE(247);
+      if (lookahead == ':') ADVANCE(330);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 247:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == ':') ADVANCE(331);
+      if (lookahead == '=') ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 248:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(137);
+      if (lookahead == '=') ADVANCE(247);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 249:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
@@ -4032,7 +3998,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 250:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
@@ -4042,7 +4008,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 251:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
@@ -4052,7 +4018,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 252:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
@@ -4062,7 +4028,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 253:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
@@ -4072,7 +4038,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 254:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
@@ -4082,7 +4048,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 255:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
@@ -4092,7 +4058,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 256:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
@@ -4102,7 +4068,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 257:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
@@ -4112,302 +4078,282 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 258:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '=') ADVANCE(257);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
-      END_STATE();
-    case 259:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '>') ADVANCE(451);
+      if (lookahead == '>') ADVANCE(450);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(259);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(258);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          (lookahead < 'A' || '[' < lookahead)) ADVANCE(337);
+          (lookahead < 'A' || '[' < lookahead)) ADVANCE(336);
+      END_STATE();
+    case 259:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == '>') ADVANCE(453);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(27);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(258);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n') ADVANCE(260);
       END_STATE();
     case 260:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
       if (lookahead == '>') ADVANCE(454);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(28);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(259);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(261);
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 261:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '>') ADVANCE(455);
+      if (lookahead == 'A') ADVANCE(283);
+      if (lookahead == 'a') ADVANCE(318);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 262:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'A') ADVANCE(284);
-      if (lookahead == 'a') ADVANCE(319);
+      if (lookahead == 'A') ADVANCE(290);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 263:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'A') ADVANCE(291);
+      if (lookahead == 'A') ADVANCE(236);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 264:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'A') ADVANCE(237);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
-      END_STATE();
-    case 265:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
       ADVANCE_MAP(
-        'B', 484,
-        'D', 480,
-        'I', 482,
-        'P', 476,
-        'S', 474,
-        '{', 478,
-        '\t', 458,
-        ' ', 458,
-        '(', 458,
-        '[', 458,
+        'B', 483,
+        'D', 479,
+        'I', 481,
+        'P', 475,
+        'S', 473,
+        '{', 477,
+        '\t', 457,
+        ' ', 457,
+        '(', 457,
+        '[', 457,
       );
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(458);
+          lookahead != '\n') ADVANCE(457);
+      END_STATE();
+    case 265:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'C') ADVANCE(262);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 266:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'C') ADVANCE(263);
+      if (lookahead == 'D') ADVANCE(314);
+      if (lookahead == 'U') ADVANCE(315);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 267:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'D') ADVANCE(315);
-      if (lookahead == 'U') ADVANCE(316);
+      if (lookahead == 'D') ADVANCE(243);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 268:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'D') ADVANCE(244);
+      if (lookahead == 'E') ADVANCE(282);
+      if (lookahead == 'e') ADVANCE(316);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 269:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'E') ADVANCE(283);
-      if (lookahead == 'e') ADVANCE(317);
+      if (lookahead == 'E') ADVANCE(265);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 270:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'E') ADVANCE(266);
+      if (lookahead == 'E') ADVANCE(267);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 271:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'E') ADVANCE(268);
+      if (lookahead == 'E') ADVANCE(288);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 272:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'E') ADVANCE(289);
+      if (lookahead == 'E') ADVANCE(238);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 273:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'E') ADVANCE(239);
+      if (lookahead == 'F') ADVANCE(291);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 274:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'F') ADVANCE(292);
+      if (lookahead == 'G') ADVANCE(241);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 275:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'G') ADVANCE(242);
+      if (lookahead == 'I') ADVANCE(273);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 276:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'I') ADVANCE(274);
+      if (lookahead == 'I') ADVANCE(280);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 277:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'I') ADVANCE(281);
+      if (lookahead == 'L') ADVANCE(287);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 278:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'L') ADVANCE(288);
+      if (lookahead == 'L') ADVANCE(234);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 279:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'L') ADVANCE(235);
+      if (lookahead == 'N') ADVANCE(276);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 280:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'N') ADVANCE(277);
+      if (lookahead == 'N') ADVANCE(274);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 281:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'N') ADVANCE(275);
+      if (lookahead == 'O') ADVANCE(289);
+      if (lookahead == 'o') ADVANCE(324);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 282:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'O') ADVANCE(290);
-      if (lookahead == 'o') ADVANCE(325);
+      if (lookahead == 'P') ADVANCE(285);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 283:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'P') ADVANCE(286);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
-      END_STATE();
-    case 284:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'R') ADVANCE(280);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
-      END_STATE();
-    case 285:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
       if (lookahead == 'R') ADVANCE(279);
       if (lookahead != 0 &&
@@ -4415,139 +4361,169 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
+      END_STATE();
+    case 284:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'R') ADVANCE(278);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(336);
+      END_STATE();
+    case 285:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'R') ADVANCE(269);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 286:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'R') ADVANCE(270);
+      if (lookahead == 'T') ADVANCE(284);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 287:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'T') ADVANCE(285);
+      if (lookahead == 'T') ADVANCE(235);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 288:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'T') ADVANCE(236);
+      if (lookahead == 'T') ADVANCE(263);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 289:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'T') ADVANCE(264);
+      if (lookahead == 'T') ADVANCE(272);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 290:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'T') ADVANCE(273);
+      if (lookahead == 'T') ADVANCE(270);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 291:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'T') ADVANCE(271);
+      if (lookahead == 'T') ADVANCE(237);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 292:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'T') ADVANCE(238);
+      if (lookahead == 'a') ADVANCE(308);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 293:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'a') ADVANCE(309);
+      if (lookahead == 'a') ADVANCE(327);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 294:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'a') ADVANCE(328);
+      if (lookahead == 'a') ADVANCE(319);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 295:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'a') ADVANCE(320);
+      if (lookahead == 'c') ADVANCE(293);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 296:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'c') ADVANCE(294);
+      if (lookahead == 'd') ADVANCE(443);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 297:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'd') ADVANCE(444);
+      if (lookahead == 'e') ADVANCE(239);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 298:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'e') ADVANCE(240);
+      if (lookahead == 'e') ADVANCE(295);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 299:
+      ACCEPT_TOKEN(aux_sym_word_noli_token1);
+      if (lookahead == 'e') ADVANCE(266);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != '[') ADVANCE(336);
+      END_STATE();
+    case 300:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
       if (lookahead == 'e') ADVANCE(296);
       if (lookahead != 0 &&
@@ -4555,419 +4531,407 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
-      END_STATE();
-    case 300:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'e') ADVANCE(267);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 301:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'e') ADVANCE(297);
+      if (lookahead == 'e') ADVANCE(292);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 302:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'e') ADVANCE(293);
+      if (lookahead == 'e') ADVANCE(321);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 303:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'e') ADVANCE(322);
+      if (lookahead == 'g') ADVANCE(299);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 304:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'g') ADVANCE(300);
+      if (lookahead == 'g') ADVANCE(242);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 305:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'g') ADVANCE(243);
+      if (lookahead == 'h') ADVANCE(294);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 306:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'h') ADVANCE(295);
+      if (lookahead == 'i') ADVANCE(310);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 307:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'i') ADVANCE(311);
+      if (lookahead == 'i') ADVANCE(312);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 308:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'i') ADVANCE(313);
+      if (lookahead == 'k') ADVANCE(490);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 309:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'k') ADVANCE(491);
+      if (lookahead == 'l') ADVANCE(490);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 310:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'l') ADVANCE(491);
+      if (lookahead == 'm') ADVANCE(244);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 311:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'm') ADVANCE(245);
+      if (lookahead == 'n') ADVANCE(490);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 312:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'n') ADVANCE(491);
+      if (lookahead == 'n') ADVANCE(304);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 313:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'n') ADVANCE(305);
+      if (lookahead == 'n') ADVANCE(307);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 314:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'n') ADVANCE(308);
+      if (lookahead == 'o') ADVANCE(328);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 315:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'o') ADVANCE(329);
+      if (lookahead == 'p') ADVANCE(490);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 316:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'p') ADVANCE(491);
+      if (lookahead == 'p') ADVANCE(320);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 317:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'p') ADVANCE(321);
+      if (lookahead == 'p') ADVANCE(245);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 318:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'p') ADVANCE(246);
+      if (lookahead == 'r') ADVANCE(313);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 319:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'r') ADVANCE(314);
+      if (lookahead == 'r') ADVANCE(329);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 320:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'r') ADVANCE(330);
+      if (lookahead == 'r') ADVANCE(298);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 321:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'r') ADVANCE(299);
+      if (lookahead == 'r') ADVANCE(323);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 322:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'r') ADVANCE(324);
+      if (lookahead == 's') ADVANCE(302);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 323:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 's') ADVANCE(303);
+      if (lookahead == 't') ADVANCE(490);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 324:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 't') ADVANCE(491);
+      if (lookahead == 't') ADVANCE(297);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 325:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 't') ADVANCE(298);
+      if (lookahead == 't') ADVANCE(317);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 326:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 't') ADVANCE(318);
+      if (lookahead == 't') ADVANCE(325);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 327:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 't') ADVANCE(326);
+      if (lookahead == 't') ADVANCE(300);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 328:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 't') ADVANCE(301);
+      if (lookahead == 'w') ADVANCE(311);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 329:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == 'w') ADVANCE(312);
+      if (lookahead == '}') ADVANCE(492);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
       END_STATE();
     case 330:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '}') ADVANCE(493);
+      if (lookahead == '(' ||
+          lookahead == '[') ADVANCE(695);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(336);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != ' ') ADVANCE(693);
       END_STATE();
     case 331:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '(' ||
-          lookahead == '[') ADVANCE(696);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(337);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(499);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(694);
+          lookahead != '\n') ADVANCE(499);
       END_STATE();
     case 332:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(500);
+          lookahead == '[') ADVANCE(494);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(500);
+          lookahead != '\n') ADVANCE(494);
       END_STATE();
     case 333:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(495);
+          lookahead == '[') ADVANCE(485);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(495);
+          lookahead != '\n') ADVANCE(485);
       END_STATE();
     case 334:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(486);
+          lookahead == '[') ADVANCE(19);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(486);
+          lookahead != '\n') ADVANCE(135);
       END_STATE();
     case 335:
-      ACCEPT_TOKEN(aux_sym_word_noli_token1);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(20);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(136);
-      END_STATE();
-    case 336:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(234);
+          lookahead == 'S') ADVANCE(233);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(259);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(258);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          (lookahead < 'A' || '[' < lookahead)) ADVANCE(337);
+          (lookahead < 'A' || '[' < lookahead)) ADVANCE(336);
       END_STATE();
-    case 337:
+    case 336:
       ACCEPT_TOKEN(aux_sym_word_noli_token1);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
-          lookahead != '[') ADVANCE(337);
+          lookahead != '[') ADVANCE(336);
+      END_STATE();
+    case 337:
+      ACCEPT_TOKEN(aux_sym_word_noli_token2);
+      if (lookahead == '\n') ADVANCE(591);
+      if (lookahead == '-') ADVANCE(337);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(20);
+      if (lookahead != 0) ADVANCE(349);
       END_STATE();
     case 338:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '\n') ADVANCE(592);
-      if (lookahead == '-') ADVANCE(338);
+      if (lookahead == '\n') ADVANCE(588);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(350);
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(338);
       END_STATE();
     case 339:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(339);
-      END_STATE();
-    case 340:
-      ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(338);
+      if (lookahead == '-') ADVANCE(337);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(350);
+          lookahead != ' ') ADVANCE(349);
+      END_STATE();
+    case 340:
+      ACCEPT_TOKEN(aux_sym_word_noli_token2);
+      if (lookahead == '-') ADVANCE(339);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(349);
       END_STATE();
     case 341:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
@@ -4975,7 +4939,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(350);
+          lookahead != ' ') ADVANCE(349);
       END_STATE();
     case 342:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
@@ -4983,7 +4947,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(350);
+          lookahead != ' ') ADVANCE(349);
       END_STATE();
     case 343:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
@@ -4991,7 +4955,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(350);
+          lookahead != ' ') ADVANCE(349);
       END_STATE();
     case 344:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
@@ -4999,7 +4963,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(350);
+          lookahead != ' ') ADVANCE(349);
       END_STATE();
     case 345:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
@@ -5007,7 +4971,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(350);
+          lookahead != ' ') ADVANCE(349);
       END_STATE();
     case 346:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
@@ -5015,7 +4979,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(350);
+          lookahead != ' ') ADVANCE(349);
       END_STATE();
     case 347:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
@@ -5023,7 +4987,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(350);
+          lookahead != ' ') ADVANCE(349);
       END_STATE();
     case 348:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
@@ -5031,1076 +4995,1068 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(350);
+          lookahead != ' ') ADVANCE(349);
       END_STATE();
     case 349:
       ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead == '-') ADVANCE(348);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(350);
+          lookahead != ' ') ADVANCE(349);
       END_STATE();
     case 350:
-      ACCEPT_TOKEN(aux_sym_word_noli_token2);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(350);
+      ACCEPT_TOKEN(anon_sym_STAR);
       END_STATE();
     case 351:
       ACCEPT_TOKEN(anon_sym_STAR);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 352:
       ACCEPT_TOKEN(anon_sym_STAR);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(899);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 353:
       ACCEPT_TOKEN(anon_sym_STAR);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 354:
-      ACCEPT_TOKEN(anon_sym_STAR);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      ACCEPT_TOKEN(anon_sym_SQUOTE);
       END_STATE();
     case 355:
       ACCEPT_TOKEN(anon_sym_SQUOTE);
-      END_STATE();
-    case 356:
-      ACCEPT_TOKEN(anon_sym_SQUOTE);
-      if (lookahead == '\n') ADVANCE(589);
+      if (lookahead == '\n') ADVANCE(588);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
-    case 357:
+    case 356:
       ACCEPT_TOKEN(anon_sym_SQUOTE);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
+      END_STATE();
+    case 357:
+      ACCEPT_TOKEN(aux_sym__word_common_token1);
+      if (lookahead == 'A') ADVANCE(84);
+      if (lookahead == 'a') ADVANCE(382);
+      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 358:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == 'A') ADVANCE(85);
-      if (lookahead == 'a') ADVANCE(383);
-      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (lookahead == 'E') ADVANCE(83);
+      if (lookahead == 'e') ADVANCE(381);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 359:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == 'E') ADVANCE(84);
-      if (lookahead == 'e') ADVANCE(382);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (lookahead == 'E') ADVANCE(89);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 360:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == 'E') ADVANCE(90);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (lookahead == 'L') ADVANCE(88);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 361:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == 'L') ADVANCE(89);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (lookahead == 'O') ADVANCE(90);
+      if (lookahead == 'o') ADVANCE(384);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 362:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == 'O') ADVANCE(91);
-      if (lookahead == 'o') ADVANCE(385);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (lookahead == 'T') ADVANCE(85);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 363:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == 'T') ADVANCE(86);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (lookahead == 't') ADVANCE(699);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(387);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(700);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '\'' &&
+          lookahead != '(') ADVANCE(387);
       END_STATE();
     case 364:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == 't') ADVANCE(700);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(388);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(701);
+          lookahead == '[') ADVANCE(387);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(700);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '\'' &&
-          lookahead != '(') ADVANCE(388);
+          lookahead != '(') ADVANCE(387);
       END_STATE();
     case 365:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(388);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(701);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '\'' &&
-          lookahead != '(') ADVANCE(388);
-      END_STATE();
-    case 366:
       ACCEPT_TOKEN(aux_sym__word_common_token1);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(47);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(371);
+          lookahead == 'S') ADVANCE(46);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(370);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(60);
+          lookahead == '_') ADVANCE(59);
+      END_STATE();
+    case 366:
+      ACCEPT_TOKEN(aux_sym__word_common_token1);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 367:
-      ACCEPT_TOKEN(aux_sym__word_common_token1);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      ACCEPT_TOKEN(aux_sym__word_common_token2);
+      if (lookahead == ':') ADVANCE(428);
+      if (lookahead == 's') ADVANCE(368);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 368:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == ':') ADVANCE(429);
-      if (lookahead == 's') ADVANCE(369);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (lookahead == ':') ADVANCE(434);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 369:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == ':') ADVANCE(435);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (lookahead == ':') ADVANCE(437);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 370:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == ':') ADVANCE(438);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
-      END_STATE();
-    case 371:
-      ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == '>') ADVANCE(451);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(371);
+      if (lookahead == '>') ADVANCE(450);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(370);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(60);
+          lookahead == '_') ADVANCE(59);
+      END_STATE();
+    case 371:
+      ACCEPT_TOKEN(aux_sym__word_common_token2);
+      if (lookahead == 'a') ADVANCE(385);
+      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 372:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == 'a') ADVANCE(386);
-      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (lookahead == 'c') ADVANCE(371);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 373:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == 'c') ADVANCE(372);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (lookahead == 'd') ADVANCE(446);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 374:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == 'd') ADVANCE(447);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (lookahead == 'e') ADVANCE(367);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 375:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == 'e') ADVANCE(368);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (lookahead == 'e') ADVANCE(372);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 376:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
       if (lookahead == 'e') ADVANCE(373);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 377:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == 'e') ADVANCE(374);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (lookahead == 'g') ADVANCE(369);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 378:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == 'g') ADVANCE(370);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (lookahead == 'i') ADVANCE(380);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 379:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == 'i') ADVANCE(381);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (lookahead == 'n') ADVANCE(378);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 380:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == 'n') ADVANCE(379);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (lookahead == 'n') ADVANCE(377);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 381:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == 'n') ADVANCE(378);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (lookahead == 'p') ADVANCE(383);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 382:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == 'p') ADVANCE(384);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (lookahead == 'r') ADVANCE(379);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 383:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == 'r') ADVANCE(380);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (lookahead == 'r') ADVANCE(375);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 384:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == 'r') ADVANCE(376);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (lookahead == 't') ADVANCE(374);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 385:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == 't') ADVANCE(375);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (lookahead == 't') ADVANCE(376);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 386:
       ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (lookahead == 't') ADVANCE(377);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
-      END_STATE();
-    case 387:
-      ACCEPT_TOKEN(aux_sym__word_common_token2);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(696);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
+          lookahead == '[') ADVANCE(695);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(386);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '(' &&
           lookahead != ')' &&
-          lookahead != ']') ADVANCE(695);
+          lookahead != ']') ADVANCE(694);
+      END_STATE();
+    case 387:
+      ACCEPT_TOKEN(aux_sym__word_common_token2);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 388:
-      ACCEPT_TOKEN(aux_sym__word_common_token2);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      ACCEPT_TOKEN(anon_sym_SQUOTE2);
       END_STATE();
     case 389:
-      ACCEPT_TOKEN(anon_sym_SQUOTE2);
+      ACCEPT_TOKEN(aux_sym__word_common_token3);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '|') ADVANCE(389);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 390:
       ACCEPT_TOKEN(aux_sym__word_common_token3);
-      if (lookahead == '\n') ADVANCE(589);
       if (lookahead == '|') ADVANCE(390);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
       END_STATE();
     case 391:
-      ACCEPT_TOKEN(aux_sym__word_common_token3);
-      if (lookahead == '|') ADVANCE(391);
+      ACCEPT_TOKEN(anon_sym_PIPE);
       END_STATE();
     case 392:
       ACCEPT_TOKEN(anon_sym_PIPE);
-      END_STATE();
-    case 393:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '|') ADVANCE(390);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '|') ADVANCE(389);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
+      END_STATE();
+    case 393:
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == '|') ADVANCE(390);
       END_STATE();
     case 394:
       ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '|') ADVANCE(391);
+      if (lookahead == '|') ADVANCE(390);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 395:
       ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '|') ADVANCE(391);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
-      END_STATE();
-    case 396:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '|') ADVANCE(890);
+      if (lookahead == '|') ADVANCE(889);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '|' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
+      END_STATE();
+    case 396:
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '{') ADVANCE(402);
+      if (lookahead == '}') ADVANCE(401);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 397:
       ACCEPT_TOKEN(anon_sym_LBRACE);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '{') ADVANCE(403);
-      if (lookahead == '}') ADVANCE(402);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+      if (lookahead == '{') ADVANCE(404);
+      if (lookahead == '}') ADVANCE(400);
       END_STATE();
     case 398:
       ACCEPT_TOKEN(anon_sym_LBRACE);
-      if (lookahead == '{') ADVANCE(405);
-      if (lookahead == '}') ADVANCE(401);
+      if (lookahead == '{') ADVANCE(404);
+      if (lookahead == '}') ADVANCE(400);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 399:
       ACCEPT_TOKEN(anon_sym_LBRACE);
-      if (lookahead == '{') ADVANCE(405);
-      if (lookahead == '}') ADVANCE(401);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
-      END_STATE();
-    case 400:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
-      if (lookahead == '{') ADVANCE(889);
-      if (lookahead == '}') ADVANCE(401);
+      if (lookahead == '{') ADVANCE(888);
+      if (lookahead == '}') ADVANCE(400);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(899);
+          lookahead != ' ') ADVANCE(898);
+      END_STATE();
+    case 400:
+      ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
       END_STATE();
     case 401:
       ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
-      END_STATE();
-    case 402:
-      ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
-      if (lookahead == '\n') ADVANCE(589);
+      if (lookahead == '\n') ADVANCE(588);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
+      END_STATE();
+    case 402:
+      ACCEPT_TOKEN(aux_sym__word_common_token4);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '{') ADVANCE(402);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(403);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 403:
       ACCEPT_TOKEN(aux_sym__word_common_token4);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '{') ADVANCE(403);
+      if (lookahead == '\n') ADVANCE(588);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(404);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(403);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 404:
       ACCEPT_TOKEN(aux_sym__word_common_token4);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(404);
-      if (lookahead != 0) ADVANCE(226);
+      if (lookahead == '{') ADVANCE(404);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(405);
       END_STATE();
     case 405:
       ACCEPT_TOKEN(aux_sym__word_common_token4);
-      if (lookahead == '{') ADVANCE(405);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(406);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(405);
       END_STATE();
     case 406:
-      ACCEPT_TOKEN(aux_sym__word_common_token4);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(406);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
       END_STATE();
     case 407:
       ACCEPT_TOKEN(anon_sym_LPAREN);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 408:
       ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 409:
       ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 410:
       ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      if (lookahead == '(' ||
+          lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(580);
       END_STATE();
     case 411:
       ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(581);
-      END_STATE();
-    case 412:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(900);
+          lookahead != '}') ADVANCE(899);
+      END_STATE();
+    case 412:
+      ACCEPT_TOKEN(anon_sym_LBRACK);
       END_STATE();
     case 413:
       ACCEPT_TOKEN(anon_sym_LBRACK);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 414:
       ACCEPT_TOKEN(anon_sym_LBRACK);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 415:
       ACCEPT_TOKEN(anon_sym_LBRACK);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
-      END_STATE();
-    case 416:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(900);
+          lookahead != '}') ADVANCE(899);
+      END_STATE();
+    case 416:
+      ACCEPT_TOKEN(anon_sym_TILDE);
       END_STATE();
     case 417:
       ACCEPT_TOKEN(anon_sym_TILDE);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 418:
       ACCEPT_TOKEN(anon_sym_TILDE);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(899);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 419:
       ACCEPT_TOKEN(anon_sym_TILDE);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 420:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      ACCEPT_TOKEN(anon_sym_GT);
       END_STATE();
     case 421:
       ACCEPT_TOKEN(anon_sym_GT);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 422:
       ACCEPT_TOKEN(anon_sym_GT);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(899);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 423:
       ACCEPT_TOKEN(anon_sym_GT);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 424:
-      ACCEPT_TOKEN(anon_sym_GT);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
     case 425:
       ACCEPT_TOKEN(anon_sym_COMMA);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 426:
       ACCEPT_TOKEN(anon_sym_COMMA);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 427:
       ACCEPT_TOKEN(anon_sym_COMMA);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
-      END_STATE();
-    case 428:
-      ACCEPT_TOKEN(anon_sym_COMMA);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(900);
+          lookahead != '}') ADVANCE(899);
+      END_STATE();
+    case 428:
+      ACCEPT_TOKEN(anon_sym_Note_COLON);
       END_STATE();
     case 429:
       ACCEPT_TOKEN(anon_sym_Note_COLON);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 430:
       ACCEPT_TOKEN(anon_sym_Note_COLON);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
-      END_STATE();
-    case 431:
-      ACCEPT_TOKEN(anon_sym_Note_COLON);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
+      END_STATE();
+    case 431:
+      ACCEPT_TOKEN(anon_sym_NOTE_COLON);
       END_STATE();
     case 432:
       ACCEPT_TOKEN(anon_sym_NOTE_COLON);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 433:
       ACCEPT_TOKEN(anon_sym_NOTE_COLON);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
-      END_STATE();
-    case 434:
-      ACCEPT_TOKEN(anon_sym_NOTE_COLON);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
+      END_STATE();
+    case 434:
+      ACCEPT_TOKEN(anon_sym_Notes_COLON);
       END_STATE();
     case 435:
       ACCEPT_TOKEN(anon_sym_Notes_COLON);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 436:
       ACCEPT_TOKEN(anon_sym_Notes_COLON);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
-      END_STATE();
-    case 437:
-      ACCEPT_TOKEN(anon_sym_Notes_COLON);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
+      END_STATE();
+    case 437:
+      ACCEPT_TOKEN(anon_sym_Warning_COLON);
       END_STATE();
     case 438:
       ACCEPT_TOKEN(anon_sym_Warning_COLON);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 439:
       ACCEPT_TOKEN(anon_sym_Warning_COLON);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
-      END_STATE();
-    case 440:
-      ACCEPT_TOKEN(anon_sym_Warning_COLON);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
+      END_STATE();
+    case 440:
+      ACCEPT_TOKEN(anon_sym_WARNING_COLON);
       END_STATE();
     case 441:
       ACCEPT_TOKEN(anon_sym_WARNING_COLON);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 442:
       ACCEPT_TOKEN(anon_sym_WARNING_COLON);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
-      END_STATE();
-    case 443:
-      ACCEPT_TOKEN(anon_sym_WARNING_COLON);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
+      END_STATE();
+    case 443:
+      ACCEPT_TOKEN(anon_sym_Deprecated);
       END_STATE();
     case 444:
       ACCEPT_TOKEN(anon_sym_Deprecated);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 445:
       ACCEPT_TOKEN(anon_sym_Deprecated);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(899);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 446:
       ACCEPT_TOKEN(anon_sym_Deprecated);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 447:
-      ACCEPT_TOKEN(anon_sym_Deprecated);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
+      ACCEPT_TOKEN(anon_sym_DEPRECATED_COLON);
       END_STATE();
     case 448:
       ACCEPT_TOKEN(anon_sym_DEPRECATED_COLON);
-      END_STATE();
-    case 449:
-      ACCEPT_TOKEN(anon_sym_DEPRECATED_COLON);
-      if (lookahead == '\n') ADVANCE(589);
+      if (lookahead == '\n') ADVANCE(588);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
-    case 450:
+    case 449:
       ACCEPT_TOKEN(anon_sym_DEPRECATED_COLON);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
+      END_STATE();
+    case 450:
+      ACCEPT_TOKEN(aux_sym_keycode_token1);
       END_STATE();
     case 451:
       ACCEPT_TOKEN(aux_sym_keycode_token1);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '>') ADVANCE(455);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 452:
       ACCEPT_TOKEN(aux_sym_keycode_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '>') ADVANCE(456);
+      if (lookahead == '\n') ADVANCE(588);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 453:
       ACCEPT_TOKEN(aux_sym_keycode_token1);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+      if (lookahead == '>') ADVANCE(454);
       END_STATE();
     case 454:
-      ACCEPT_TOKEN(aux_sym_keycode_token1);
-      if (lookahead == '>') ADVANCE(455);
+      ACCEPT_TOKEN(aux_sym_keycode_token2);
       END_STATE();
     case 455:
       ACCEPT_TOKEN(aux_sym_keycode_token2);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 456:
       ACCEPT_TOKEN(aux_sym_keycode_token2);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead != 0) ADVANCE(23);
       END_STATE();
     case 457:
-      ACCEPT_TOKEN(aux_sym_keycode_token2);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead != 0) ADVANCE(24);
+      ACCEPT_TOKEN(aux_sym_keycode_token3);
       END_STATE();
     case 458:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'H') ADVANCE(167);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 459:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'H') ADVANCE(168);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'a') ADVANCE(195);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 460:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'a') ADVANCE(196);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'c') ADVANCE(197);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 461:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'c') ADVANCE(198);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'e') ADVANCE(200);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 462:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'e') ADVANCE(201);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'n') ADVANCE(212);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 463:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'n') ADVANCE(213);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == 'r') ADVANCE(193);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 464:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == 'r') ADVANCE(194);
+      if (lookahead == '\n') ADVANCE(588);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 465:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead != 0) ADVANCE(23);
       END_STATE();
     case 466:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead != 0) ADVANCE(24);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'H') ADVANCE(561);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 467:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'H') ADVANCE(562);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'a') ADVANCE(104);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 468:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'a') ADVANCE(105);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'e') ADVANCE(109);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 469:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'e') ADVANCE(110);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'n') ADVANCE(121);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 470:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'n') ADVANCE(122);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'r') ADVANCE(102);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 471:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'r') ADVANCE(103);
+      if (lookahead == '(') ADVANCE(580);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 472:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+      if (lookahead == 'H') ADVANCE(76);
       END_STATE();
     case 473:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'H') ADVANCE(77);
+      if (lookahead == 'H') ADVANCE(275);
       END_STATE();
     case 474:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'H') ADVANCE(276);
+      if (lookahead == 'a') ADVANCE(104);
       END_STATE();
     case 475:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'a') ADVANCE(105);
+      if (lookahead == 'a') ADVANCE(303);
       END_STATE();
     case 476:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'a') ADVANCE(304);
+      if (lookahead == 'c') ADVANCE(106);
       END_STATE();
     case 477:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'c') ADVANCE(107);
+      if (lookahead == 'c') ADVANCE(305);
       END_STATE();
     case 478:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'c') ADVANCE(306);
+      if (lookahead == 'e') ADVANCE(109);
       END_STATE();
     case 479:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'e') ADVANCE(110);
+      if (lookahead == 'e') ADVANCE(309);
       END_STATE();
     case 480:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'e') ADVANCE(310);
+      if (lookahead == 'n') ADVANCE(121);
       END_STATE();
     case 481:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'n') ADVANCE(122);
+      if (lookahead == 'n') ADVANCE(322);
       END_STATE();
     case 482:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'n') ADVANCE(323);
+      if (lookahead == 'r') ADVANCE(102);
       END_STATE();
     case 483:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'r') ADVANCE(103);
+      if (lookahead == 'r') ADVANCE(301);
       END_STATE();
     case 484:
       ACCEPT_TOKEN(aux_sym_keycode_token3);
-      if (lookahead == 'r') ADVANCE(302);
-      END_STATE();
-    case 485:
-      ACCEPT_TOKEN(aux_sym_keycode_token3);
       if (lookahead == '(' ||
           lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(581);
+          lookahead == '_') ADVANCE(580);
+      END_STATE();
+    case 485:
+      ACCEPT_TOKEN(aux_sym_keycode_token4);
       END_STATE();
     case 486:
       ACCEPT_TOKEN(aux_sym_keycode_token4);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 487:
       ACCEPT_TOKEN(aux_sym_keycode_token4);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead != 0) ADVANCE(23);
       END_STATE();
     case 488:
       ACCEPT_TOKEN(aux_sym_keycode_token4);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead != 0) ADVANCE(24);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 489:
       ACCEPT_TOKEN(aux_sym_keycode_token4);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
-      END_STATE();
-    case 490:
-      ACCEPT_TOKEN(aux_sym_keycode_token4);
       if (lookahead == '(' ||
           lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(581);
+          lookahead == '_') ADVANCE(580);
+      END_STATE();
+    case 490:
+      ACCEPT_TOKEN(aux_sym_keycode_token5);
       END_STATE();
     case 491:
       ACCEPT_TOKEN(aux_sym_keycode_token5);
-      END_STATE();
-    case 492:
-      ACCEPT_TOKEN(aux_sym_keycode_token5);
-      if (lookahead == '\n') ADVANCE(589);
+      if (lookahead == '\n') ADVANCE(588);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
+      END_STATE();
+    case 492:
+      ACCEPT_TOKEN(anon_sym_CTRL_DASH_LBRACEchar_RBRACE);
       END_STATE();
     case 493:
       ACCEPT_TOKEN(anon_sym_CTRL_DASH_LBRACEchar_RBRACE);
-      END_STATE();
-    case 494:
-      ACCEPT_TOKEN(anon_sym_CTRL_DASH_LBRACEchar_RBRACE);
-      if (lookahead == '\n') ADVANCE(589);
+      if (lookahead == '\n') ADVANCE(588);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
+      END_STATE();
+    case 494:
+      ACCEPT_TOKEN(aux_sym_keycode_token6);
       END_STATE();
     case 495:
       ACCEPT_TOKEN(aux_sym_keycode_token6);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '(' ||
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
       END_STATE();
     case 496:
       ACCEPT_TOKEN(aux_sym_keycode_token6);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead != 0) ADVANCE(23);
       END_STATE();
     case 497:
       ACCEPT_TOKEN(aux_sym_keycode_token6);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead != 0) ADVANCE(24);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 498:
       ACCEPT_TOKEN(aux_sym_keycode_token6);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
-      END_STATE();
-    case 499:
-      ACCEPT_TOKEN(aux_sym_keycode_token6);
       if (lookahead == '(' ||
           lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(581);
+          lookahead == '_') ADVANCE(580);
+      END_STATE();
+    case 499:
+      ACCEPT_TOKEN(aux_sym_keycode_token7);
       END_STATE();
     case 500:
       ACCEPT_TOKEN(aux_sym_keycode_token7);
-      END_STATE();
-    case 501:
-      ACCEPT_TOKEN(aux_sym_keycode_token7);
-      if (lookahead == '\n') ADVANCE(589);
+      if (lookahead == '\n') ADVANCE(588);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
+      END_STATE();
+    case 501:
+      ACCEPT_TOKEN(aux_sym_keycode_token7);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead != 0) ADVANCE(23);
       END_STATE();
     case 502:
       ACCEPT_TOKEN(aux_sym_keycode_token7);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead != 0) ADVANCE(24);
-      END_STATE();
-    case 503:
-      ACCEPT_TOKEN(aux_sym_keycode_token7);
-      if (lookahead == '(') ADVANCE(581);
+      if (lookahead == '(') ADVANCE(580);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
-    case 504:
+    case 503:
       ACCEPT_TOKEN(aux_sym_keycode_token7);
       if (lookahead == '(' ||
           lookahead == ')' ||
@@ -6108,465 +6064,475 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(581);
+          lookahead == '_') ADVANCE(580);
+      END_STATE();
+    case 504:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == '-') ADVANCE(540);
+      if (lookahead == ')' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 505:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == '-') ADVANCE(513);
+      if (lookahead == ')' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(543);
+      END_STATE();
+    case 506:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(544);
       if (lookahead == '-') ADVANCE(541);
       if (lookahead == ')' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
-      END_STATE();
-    case 506:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == '-') ADVANCE(514);
-      if (lookahead == ')' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 507:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
+      if (lookahead == '(') ADVANCE(544);
       if (lookahead == '-') ADVANCE(542);
       if (lookahead == ')' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 508:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == '-') ADVANCE(543);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == ':') ADVANCE(431);
       if (lookahead == ')' ||
+          lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 509:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == ':') ADVANCE(432);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == ':') ADVANCE(440);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 510:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == ':') ADVANCE(441);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == ':') ADVANCE(447);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 511:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == ':') ADVANCE(448);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'A') ADVANCE(534);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 512:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'A') ADVANCE(535);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'A') ADVANCE(506);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 513:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'A') ADVANCE(507);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
-      END_STATE();
-    case 514:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
       ADVANCE_MAP(
-        '(', 545,
-        'B', 540,
-        'D', 538,
-        'I', 539,
-        'P', 537,
-        'S', 522,
-        '{', 478,
-        '\t', 458,
-        ' ', 458,
-        '[', 458,
+        '(', 544,
+        'B', 539,
+        'D', 537,
+        'I', 538,
+        'P', 536,
+        'S', 521,
+        '{', 477,
+        '\t', 457,
+        ' ', 457,
+        '[', 457,
       );
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(458);
+          lookahead != '\n') ADVANCE(457);
+      END_STATE();
+    case 514:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'C') ADVANCE(511);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 515:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'C') ADVANCE(512);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'D') ADVANCE(510);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 516:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'D') ADVANCE(511);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'E') ADVANCE(508);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 517:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'E') ADVANCE(509);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'E') ADVANCE(514);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 518:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
+      if (lookahead == '(') ADVANCE(544);
       if (lookahead == 'E') ADVANCE(515);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 519:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'E') ADVANCE(516);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'F') ADVANCE(535);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 520:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'F') ADVANCE(536);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'G') ADVANCE(509);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 521:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'G') ADVANCE(510);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'H') ADVANCE(522);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 522:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'H') ADVANCE(523);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'I') ADVANCE(519);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 523:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'I') ADVANCE(520);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'I') ADVANCE(526);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 524:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'I') ADVANCE(527);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'L') ADVANCE(505);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 525:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'L') ADVANCE(506);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'N') ADVANCE(523);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 526:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'N') ADVANCE(524);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'N') ADVANCE(520);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 527:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'N') ADVANCE(521);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'P') ADVANCE(530);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 528:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'P') ADVANCE(531);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'R') ADVANCE(524);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 529:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
+      if (lookahead == '(') ADVANCE(544);
       if (lookahead == 'R') ADVANCE(525);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 530:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'R') ADVANCE(526);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'R') ADVANCE(517);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 531:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'R') ADVANCE(518);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'T') ADVANCE(504);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 532:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'T') ADVANCE(505);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'T') ADVANCE(512);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 533:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'T') ADVANCE(513);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'T') ADVANCE(516);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 534:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'T') ADVANCE(517);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'T') ADVANCE(518);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 535:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'T') ADVANCE(519);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'T') ADVANCE(507);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 536:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'T') ADVANCE(508);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'a') ADVANCE(303);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 537:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'a') ADVANCE(304);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'e') ADVANCE(309);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 538:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'e') ADVANCE(310);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'n') ADVANCE(322);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 539:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'n') ADVANCE(323);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == 'r') ADVANCE(301);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 540:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == 'r') ADVANCE(302);
+      if (lookahead == '(') ADVANCE(544);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == '[') ADVANCE(499);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n') ADVANCE(499);
       END_STATE();
     case 541:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
+      if (lookahead == '(') ADVANCE(544);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
-          lookahead == '[') ADVANCE(500);
+          lookahead == '[') ADVANCE(494);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(500);
+          lookahead != '\n') ADVANCE(494);
       END_STATE();
     case 542:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
+      if (lookahead == '(') ADVANCE(544);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
-          lookahead == '[') ADVANCE(495);
+          lookahead == '[') ADVANCE(485);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
+          lookahead == '_') ADVANCE(543);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(495);
+          lookahead != '\n') ADVANCE(485);
       END_STATE();
     case 543:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '[') ADVANCE(486);
+      if (lookahead == '(') ADVANCE(544);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(544);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(486);
+          lookahead == '_') ADVANCE(543);
       END_STATE();
     case 544:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(') ADVANCE(545);
-      if (lookahead == ')' ||
+      if (lookahead == '(' ||
+          lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -6574,428 +6540,418 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '_') ADVANCE(544);
       END_STATE();
     case 545:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token1);
-      if (lookahead == '(' ||
-          lookahead == ')' ||
-          lookahead == '-' ||
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == '-') ADVANCE(576);
+      if (lookahead == ')' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(545);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 546:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
+      if (lookahead == '(') ADVANCE(580);
       if (lookahead == '-') ADVANCE(577);
       if (lookahead == ')' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 547:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
+      if (lookahead == '(') ADVANCE(580);
       if (lookahead == '-') ADVANCE(578);
       if (lookahead == ')' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 548:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
+      if (lookahead == '(') ADVANCE(580);
       if (lookahead == '-') ADVANCE(579);
       if (lookahead == ')' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 549:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == '-') ADVANCE(580);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == ':') ADVANCE(431);
       if (lookahead == ')' ||
+          lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 550:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == ':') ADVANCE(432);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == ':') ADVANCE(440);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 551:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == ':') ADVANCE(441);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == ':') ADVANCE(447);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 552:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == ':') ADVANCE(448);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'A') ADVANCE(573);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 553:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'A') ADVANCE(574);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'A') ADVANCE(547);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 554:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'A') ADVANCE(548);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'C') ADVANCE(552);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 555:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'C') ADVANCE(553);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'D') ADVANCE(551);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 556:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'D') ADVANCE(552);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'E') ADVANCE(549);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 557:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'E') ADVANCE(550);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'E') ADVANCE(554);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 558:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
+      if (lookahead == '(') ADVANCE(580);
       if (lookahead == 'E') ADVANCE(555);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 559:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'E') ADVANCE(556);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'F') ADVANCE(574);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 560:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'F') ADVANCE(575);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'G') ADVANCE(550);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 561:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'G') ADVANCE(551);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'I') ADVANCE(559);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 562:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'I') ADVANCE(560);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'I') ADVANCE(565);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 563:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'I') ADVANCE(566);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'L') ADVANCE(546);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 564:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'L') ADVANCE(547);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'N') ADVANCE(562);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 565:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'N') ADVANCE(563);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'N') ADVANCE(560);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 566:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'N') ADVANCE(561);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'P') ADVANCE(569);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 567:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'P') ADVANCE(570);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'R') ADVANCE(563);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 568:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
+      if (lookahead == '(') ADVANCE(580);
       if (lookahead == 'R') ADVANCE(564);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 569:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'R') ADVANCE(565);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'R') ADVANCE(557);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 570:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'R') ADVANCE(558);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'T') ADVANCE(545);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 571:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'T') ADVANCE(546);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'T') ADVANCE(553);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 572:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'T') ADVANCE(554);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'T') ADVANCE(556);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 573:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'T') ADVANCE(557);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'T') ADVANCE(558);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 574:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'T') ADVANCE(559);
+      if (lookahead == '(') ADVANCE(580);
+      if (lookahead == 'T') ADVANCE(548);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 575:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == 'T') ADVANCE(549);
+      if (lookahead == '(') ADVANCE(580);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
+          lookahead == '_') ADVANCE(575);
       END_STATE();
     case 576:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(581);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(576);
-      END_STATE();
-    case 577:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(504);
+      if (lookahead == '(') ADVANCE(503);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(500);
+          lookahead == '[') ADVANCE(499);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(503);
+          lookahead == '_') ADVANCE(502);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(500);
+          lookahead != '\n') ADVANCE(499);
       END_STATE();
-    case 578:
+    case 577:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
       ADVANCE_MAP(
-        '(', 485,
-        'B', 471,
-        'D', 469,
-        'I', 470,
-        'P', 468,
-        'S', 467,
-        '{', 477,
-        '\t', 458,
-        ' ', 458,
-        ',', 458,
-        '[', 458,
+        '(', 484,
+        'B', 470,
+        'D', 468,
+        'I', 469,
+        'P', 467,
+        'S', 466,
+        '{', 476,
+        '\t', 457,
+        ' ', 457,
+        ',', 457,
+        '[', 457,
       );
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(472);
+          lookahead == '_') ADVANCE(471);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(458);
+          lookahead != '\n') ADVANCE(457);
+      END_STATE();
+    case 578:
+      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
+      if (lookahead == '(') ADVANCE(498);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(494);
+      if (lookahead == ')' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(497);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n') ADVANCE(494);
       END_STATE();
     case 579:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(499);
+      if (lookahead == '(') ADVANCE(489);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(495);
+          lookahead == '[') ADVANCE(485);
       if (lookahead == ')' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(498);
+          lookahead == '_') ADVANCE(488);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(495);
+          lookahead != '\n') ADVANCE(485);
       END_STATE();
     case 580:
-      ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
-      if (lookahead == '(') ADVANCE(490);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(486);
-      if (lookahead == ')' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(489);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(486);
-      END_STATE();
-    case 581:
       ACCEPT_TOKEN(aux_sym_uppercase_name_token2);
       if (lookahead == '(' ||
           lookahead == ')' ||
@@ -7003,196 +6959,205 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(581);
+          lookahead == '_') ADVANCE(580);
       END_STATE();
-    case 582:
+    case 581:
       ACCEPT_TOKEN(anon_sym_LT);
       END_STATE();
-    case 583:
+    case 582:
       ACCEPT_TOKEN(anon_sym_LT);
       if (lookahead == 'A' ||
           lookahead == 'C' ||
           lookahead == 'D' ||
           lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(234);
+          lookahead == 'S') ADVANCE(233);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(259);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(258);
       END_STATE();
-    case 584:
+    case 583:
       ACCEPT_TOKEN(aux_sym_codeblock_token1);
       END_STATE();
+    case 584:
+      ACCEPT_TOKEN(aux_sym_codeblock_token2);
+      END_STATE();
     case 585:
-      ACCEPT_TOKEN(anon_sym_LF);
+      ACCEPT_TOKEN(aux_sym__blank_token1);
       END_STATE();
     case 586:
-      ACCEPT_TOKEN(anon_sym_LF2);
+      ACCEPT_TOKEN(aux_sym_line_li_token1);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == ' ') ADVANCE(586);
+      if (lookahead != 0) ADVANCE(23);
       END_STATE();
     case 587:
       ACCEPT_TOKEN(aux_sym_line_li_token1);
-      if (lookahead == '\n') ADVANCE(589);
       if (lookahead == ' ') ADVANCE(587);
-      if (lookahead != 0) ADVANCE(24);
       END_STATE();
     case 588:
-      ACCEPT_TOKEN(aux_sym_line_li_token1);
-      if (lookahead == ' ') ADVANCE(588);
-      END_STATE();
-    case 589:
       ACCEPT_TOKEN(aux_sym_line_code_token1);
       END_STATE();
-    case 590:
+    case 589:
       ACCEPT_TOKEN(sym_modeline);
       END_STATE();
-    case 591:
+    case 590:
       ACCEPT_TOKEN(aux_sym_h1_token1);
       END_STATE();
-    case 592:
+    case 591:
       ACCEPT_TOKEN(aux_sym_h2_token1);
+      END_STATE();
+    case 592:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '-') ADVANCE(688);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(689);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 593:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '-') ADVANCE(689);
+      if (lookahead == '-') ADVANCE(608);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 594:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '-') ADVANCE(609);
+      if (lookahead == '-') ADVANCE(604);
+      if (lookahead == '>') ADVANCE(688);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
-      END_STATE();
-    case 595:
-      ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '-') ADVANCE(605);
-      if (lookahead == '>') ADVANCE(689);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(602);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(601);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
+      END_STATE();
+    case 595:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == ':') ADVANCE(688);
+      if (lookahead == 's') ADVANCE(596);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(689);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 596:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == ':') ADVANCE(689);
-      if (lookahead == 's') ADVANCE(597);
+      if (lookahead == ':') ADVANCE(688);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 597:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == ':') ADVANCE(689);
+      if (lookahead == ':') ADVANCE(683);
+      if (lookahead == 's') ADVANCE(599);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(687);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 598:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == ':') ADVANCE(684);
+      if (lookahead == ':') ADVANCE(683);
       if (lookahead == 's') ADVANCE(600);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(688);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 599:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == ':') ADVANCE(684);
-      if (lookahead == 's') ADVANCE(601);
+      if (lookahead == ':') ADVANCE(683);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(687);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 600:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == ':') ADVANCE(684);
+      if (lookahead == ':') ADVANCE(683);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(688);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 601:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == ':') ADVANCE(684);
+      if (lookahead == '>') ADVANCE(688);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
-      END_STATE();
-    case 602:
-      ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '>') ADVANCE(689);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(602);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(601);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
+      END_STATE();
+    case 602:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '>') ADVANCE(688);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(689);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 603:
       ACCEPT_TOKEN(aux_sym_tag_token1);
       if (lookahead == '>') ADVANCE(689);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
@@ -7201,1056 +7166,1055 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 604:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '>') ADVANCE(690);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '*') ADVANCE(690);
-      END_STATE();
-    case 605:
-      ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '>') ADVANCE(603);
+      if (lookahead == '>') ADVANCE(602);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(604);
+          lookahead == '[') ADVANCE(603);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(602);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(601);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(603);
+          lookahead != '*') ADVANCE(602);
+      END_STATE();
+    case 605:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'A') ADVANCE(592);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(689);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 606:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'A') ADVANCE(593);
+      if (lookahead == 'A') ADVANCE(628);
+      if (lookahead == 'a') ADVANCE(665);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 607:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'A') ADVANCE(629);
-      if (lookahead == 'a') ADVANCE(666);
+      if (lookahead == 'A') ADVANCE(635);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 608:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'A') ADVANCE(636);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
-      END_STATE();
-    case 609:
-      ACCEPT_TOKEN(aux_sym_tag_token1);
       ADVANCE_MAP(
-        'B', 670,
-        'D', 646,
-        'I', 660,
-        'P', 638,
-        'S', 620,
-        '{', 641,
-        '(', 690,
-        ',', 690,
-        '[', 690,
+        'B', 669,
+        'D', 645,
+        'I', 659,
+        'P', 637,
+        'S', 619,
+        '{', 640,
+        '(', 689,
+        ',', 689,
+        '[', 689,
       );
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
+      END_STATE();
+    case 609:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'C') ADVANCE(607);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(689);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 610:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'C') ADVANCE(608);
+      if (lookahead == 'D') ADVANCE(596);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 611:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'D') ADVANCE(597);
+      if (lookahead == 'D') ADVANCE(660);
+      if (lookahead == 'U') ADVANCE(661);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 612:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'D') ADVANCE(661);
-      if (lookahead == 'U') ADVANCE(662);
+      if (lookahead == 'E') ADVANCE(627);
+      if (lookahead == 'e') ADVANCE(663);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 613:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'E') ADVANCE(628);
-      if (lookahead == 'e') ADVANCE(664);
+      if (lookahead == 'E') ADVANCE(596);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 614:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'E') ADVANCE(597);
+      if (lookahead == 'E') ADVANCE(609);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 615:
       ACCEPT_TOKEN(aux_sym_tag_token1);
       if (lookahead == 'E') ADVANCE(610);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 616:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'E') ADVANCE(611);
+      if (lookahead == 'E') ADVANCE(633);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 617:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'E') ADVANCE(634);
+      if (lookahead == 'F') ADVANCE(632);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 618:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'F') ADVANCE(633);
+      if (lookahead == 'G') ADVANCE(596);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 619:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'G') ADVANCE(597);
+      if (lookahead == 'H') ADVANCE(620);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 620:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'H') ADVANCE(621);
+      if (lookahead == 'I') ADVANCE(617);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 621:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'I') ADVANCE(618);
+      if (lookahead == 'I') ADVANCE(625);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 622:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'I') ADVANCE(626);
+      if (lookahead == 'L') ADVANCE(632);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 623:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'L') ADVANCE(633);
+      if (lookahead == 'L') ADVANCE(593);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 624:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'L') ADVANCE(594);
+      if (lookahead == 'N') ADVANCE(621);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 625:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'N') ADVANCE(622);
+      if (lookahead == 'N') ADVANCE(618);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 626:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'N') ADVANCE(619);
+      if (lookahead == 'O') ADVANCE(634);
+      if (lookahead == 'o') ADVANCE(672);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 627:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'O') ADVANCE(635);
-      if (lookahead == 'o') ADVANCE(673);
+      if (lookahead == 'P') ADVANCE(630);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 628:
-      ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'P') ADVANCE(631);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
-      END_STATE();
-    case 629:
-      ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'R') ADVANCE(625);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
-      END_STATE();
-    case 630:
       ACCEPT_TOKEN(aux_sym_tag_token1);
       if (lookahead == 'R') ADVANCE(624);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
+      END_STATE();
+    case 629:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'R') ADVANCE(623);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(689);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(688);
+      END_STATE();
+    case 630:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'R') ADVANCE(614);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(689);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 631:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'R') ADVANCE(615);
+      if (lookahead == 'T') ADVANCE(629);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 632:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'T') ADVANCE(630);
+      if (lookahead == 'T') ADVANCE(592);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 633:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'T') ADVANCE(593);
+      if (lookahead == 'T') ADVANCE(605);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 634:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'T') ADVANCE(606);
+      if (lookahead == 'T') ADVANCE(613);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 635:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'T') ADVANCE(614);
+      if (lookahead == 'T') ADVANCE(615);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 636:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'T') ADVANCE(616);
+      if (lookahead == 'a') ADVANCE(654);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 637:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'a') ADVANCE(655);
+      if (lookahead == 'a') ADVANCE(651);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 638:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'a') ADVANCE(652);
+      if (lookahead == 'a') ADVANCE(666);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 639:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'a') ADVANCE(667);
+      if (lookahead == 'a') ADVANCE(677);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 640:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'a') ADVANCE(678);
+      if (lookahead == 'c') ADVANCE(652);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 641:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'c') ADVANCE(653);
+      if (lookahead == 'c') ADVANCE(639);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 642:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'c') ADVANCE(640);
+      if (lookahead == 'd') ADVANCE(688);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 643:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'd') ADVANCE(689);
+      if (lookahead == 'e') ADVANCE(595);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 644:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'e') ADVANCE(596);
+      if (lookahead == 'e') ADVANCE(641);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 645:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'e') ADVANCE(655);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(689);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(688);
+      END_STATE();
+    case 646:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'e') ADVANCE(611);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(689);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(688);
+      END_STATE();
+    case 647:
       ACCEPT_TOKEN(aux_sym_tag_token1);
       if (lookahead == 'e') ADVANCE(642);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
-      END_STATE();
-    case 646:
-      ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'e') ADVANCE(656);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
-      END_STATE();
-    case 647:
-      ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'e') ADVANCE(612);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 648:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'e') ADVANCE(643);
+      if (lookahead == 'e') ADVANCE(667);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 649:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'e') ADVANCE(668);
+      if (lookahead == 'e') ADVANCE(636);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 650:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'e') ADVANCE(637);
+      if (lookahead == 'g') ADVANCE(596);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 651:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'g') ADVANCE(597);
+      if (lookahead == 'g') ADVANCE(646);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 652:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'g') ADVANCE(647);
+      if (lookahead == 'h') ADVANCE(638);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 653:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'h') ADVANCE(639);
+      if (lookahead == 'i') ADVANCE(658);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 654:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'i') ADVANCE(659);
+      if (lookahead == 'k') ADVANCE(688);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 655:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'k') ADVANCE(689);
+      if (lookahead == 'l') ADVANCE(688);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 656:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'l') ADVANCE(689);
+      if (lookahead == 'n') ADVANCE(688);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 657:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'n') ADVANCE(689);
+      if (lookahead == 'n') ADVANCE(653);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 658:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'n') ADVANCE(654);
+      if (lookahead == 'n') ADVANCE(650);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 659:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'n') ADVANCE(651);
+      if (lookahead == 'n') ADVANCE(670);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 660:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'n') ADVANCE(671);
+      if (lookahead == 'o') ADVANCE(678);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 661:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'o') ADVANCE(679);
+      if (lookahead == 'p') ADVANCE(688);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 662:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'p') ADVANCE(689);
+      if (lookahead == 'p') ADVANCE(597);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(687);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 663:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == 'p') ADVANCE(668);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(689);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(688);
+      END_STATE();
+    case 664:
       ACCEPT_TOKEN(aux_sym_tag_token1);
       if (lookahead == 'p') ADVANCE(598);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(688);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
-      END_STATE();
-    case 664:
-      ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'p') ADVANCE(669);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 665:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'p') ADVANCE(599);
+      if (lookahead == 'r') ADVANCE(657);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 666:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'r') ADVANCE(658);
+      if (lookahead == 'r') ADVANCE(682);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 667:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'r') ADVANCE(683);
+      if (lookahead == 'r') ADVANCE(671);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 668:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'r') ADVANCE(672);
+      if (lookahead == 'r') ADVANCE(644);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 669:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'r') ADVANCE(645);
+      if (lookahead == 'r') ADVANCE(649);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 670:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'r') ADVANCE(650);
+      if (lookahead == 's') ADVANCE(648);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 671:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 's') ADVANCE(649);
+      if (lookahead == 't') ADVANCE(688);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 672:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 't') ADVANCE(689);
+      if (lookahead == 't') ADVANCE(643);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 673:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 't') ADVANCE(644);
+      if (lookahead == 't') ADVANCE(662);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(687);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 674:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 't') ADVANCE(663);
+      if (lookahead == 't') ADVANCE(673);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(688);
+          lookahead == '[') ADVANCE(689);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(687);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 675:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 't') ADVANCE(674);
+      if (lookahead == 't') ADVANCE(664);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(688);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 676:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 't') ADVANCE(665);
+      if (lookahead == 't') ADVANCE(675);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 677:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 't') ADVANCE(676);
+      if (lookahead == 't') ADVANCE(647);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 678:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 't') ADVANCE(648);
+      if (lookahead == 'w') ADVANCE(656);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 679:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == 'w') ADVANCE(657);
+      if (lookahead == '{') ADVANCE(680);
+      if (lookahead == '}') ADVANCE(688);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 680:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '{') ADVANCE(681);
-      if (lookahead == '}') ADVANCE(689);
+      if (lookahead == '{') ADVANCE(680);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(686);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 681:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '{') ADVANCE(681);
+      if (lookahead == '|') ADVANCE(681);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(687);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 682:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '|') ADVANCE(682);
+      if (lookahead == '}') ADVANCE(688);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 683:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '}') ADVANCE(689);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(688);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
+          lookahead == '[') ADVANCE(684);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          (lookahead < '(' || '*' < lookahead)) ADVANCE(683);
       END_STATE();
     case 684:
       ACCEPT_TOKEN(aux_sym_tag_token1);
       if (lookahead == ')' ||
           lookahead == ']') ADVANCE(689);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(685);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          (lookahead < '(' || '*' < lookahead)) ADVANCE(684);
-      END_STATE();
-    case 685:
-      ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(690);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != ')' &&
-          lookahead != '*') ADVANCE(685);
+          lookahead != '*') ADVANCE(684);
+      END_STATE();
+    case 685:
+      ACCEPT_TOKEN(aux_sym_tag_token1);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(689);
+      if (lookahead == 'A' ||
+          lookahead == 'C' ||
+          lookahead == 'D' ||
+          lookahead == 'M' ||
+          lookahead == 'S') ADVANCE(594);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(601);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 686:
       ACCEPT_TOKEN(aux_sym_tag_token1);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
-      if (lookahead == 'A' ||
-          lookahead == 'C' ||
-          lookahead == 'D' ||
-          lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(595);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(602);
+          lookahead == '[') ADVANCE(689);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(686);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 687:
       ACCEPT_TOKEN(aux_sym_tag_token1);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(687);
+          lookahead == '[') ADVANCE(689);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(687);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 688:
       ACCEPT_TOKEN(aux_sym_tag_token1);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(688);
+          lookahead == '[') ADVANCE(689);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '*') ADVANCE(689);
+          lookahead != '*') ADVANCE(688);
       END_STATE();
     case 689:
       ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(690);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
@@ -8258,40 +8222,45 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '*') ADVANCE(689);
       END_STATE();
     case 690:
-      ACCEPT_TOKEN(aux_sym_tag_token1);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '*') ADVANCE(690);
+      ACCEPT_TOKEN(anon_sym_STAR2);
       END_STATE();
     case 691:
-      ACCEPT_TOKEN(anon_sym_STAR2);
+      ACCEPT_TOKEN(sym_url_word);
+      if (lookahead == '\n') ADVANCE(588);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead == '(' ||
+          lookahead == '[') ADVANCE(692);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(225);
+      if (lookahead != 0) ADVANCE(691);
       END_STATE();
     case 692:
       ACCEPT_TOKEN(sym_url_word);
-      if (lookahead == '\n') ADVANCE(589);
+      if (lookahead == '\n') ADVANCE(588);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(24);
-      if (lookahead == '(' ||
-          lookahead == '[') ADVANCE(693);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(226);
+          lookahead == ' ' ||
+          lookahead == ')' ||
+          lookahead == ']') ADVANCE(23);
       if (lookahead != 0) ADVANCE(692);
       END_STATE();
     case 693:
       ACCEPT_TOKEN(sym_url_word);
-      if (lookahead == '\n') ADVANCE(589);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == ')' ||
-          lookahead == ']') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(693);
+      if (lookahead == '(' ||
+          lookahead == '[') ADVANCE(695);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '(' &&
+          lookahead != ')' &&
+          lookahead != ']') ADVANCE(693);
       END_STATE();
     case 694:
       ACCEPT_TOKEN(sym_url_word);
       if (lookahead == '(' ||
-          lookahead == '[') ADVANCE(696);
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(695);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
@@ -8302,210 +8271,206 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 695:
       ACCEPT_TOKEN(sym_url_word);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(696);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '(' &&
           lookahead != ')' &&
           lookahead != ']') ADVANCE(695);
       END_STATE();
     case 696:
-      ACCEPT_TOKEN(sym_url_word);
+      ACCEPT_TOKEN(aux_sym_optionlink_token1);
+      if (lookahead == ':') ADVANCE(386);
+      if (lookahead == 's') ADVANCE(697);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(387);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(700);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != ')' &&
-          lookahead != ']') ADVANCE(696);
+          lookahead != '\'' &&
+          lookahead != '(') ADVANCE(387);
       END_STATE();
     case 697:
       ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == ':') ADVANCE(387);
-      if (lookahead == 's') ADVANCE(698);
+      if (lookahead == ':') ADVANCE(386);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(388);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(701);
+          lookahead == '[') ADVANCE(387);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(700);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '\'' &&
-          lookahead != '(') ADVANCE(388);
+          lookahead != '(') ADVANCE(387);
       END_STATE();
     case 698:
       ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == ':') ADVANCE(387);
+      if (lookahead == 'p') ADVANCE(696);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(388);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(701);
+          lookahead == '[') ADVANCE(387);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(700);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '\'' &&
-          lookahead != '(') ADVANCE(388);
+          lookahead != '(') ADVANCE(387);
       END_STATE();
     case 699:
       ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == 'p') ADVANCE(697);
+      if (lookahead == 't') ADVANCE(698);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(388);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(701);
+          lookahead == '[') ADVANCE(387);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(700);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '\'' &&
-          lookahead != '(') ADVANCE(388);
+          lookahead != '(') ADVANCE(387);
       END_STATE();
     case 700:
       ACCEPT_TOKEN(aux_sym_optionlink_token1);
-      if (lookahead == 't') ADVANCE(699);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(388);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(701);
+          lookahead == '[') ADVANCE(387);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(700);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '\'' &&
-          lookahead != '(') ADVANCE(388);
+          lookahead != '(') ADVANCE(387);
       END_STATE();
     case 701:
-      ACCEPT_TOKEN(aux_sym_optionlink_token1);
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '-') ADVANCE(790);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(388);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(701);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '\'' &&
-          lookahead != '(') ADVANCE(388);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 702:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '-') ADVANCE(791);
+      if (lookahead == '-') ADVANCE(715);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 703:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '-') ADVANCE(716);
+      if (lookahead == '-') ADVANCE(711);
+      if (lookahead == '>') ADVANCE(790);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
-      END_STATE();
-    case 704:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '-') ADVANCE(712);
-      if (lookahead == '>') ADVANCE(791);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(709);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(708);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
+      END_STATE();
+    case 704:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == ':') ADVANCE(790);
+      if (lookahead == 's') ADVANCE(705);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(791);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 705:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == ':') ADVANCE(791);
-      if (lookahead == 's') ADVANCE(706);
+      if (lookahead == ':') ADVANCE(790);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 706:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == ':') ADVANCE(791);
+      if (lookahead == ':') ADVANCE(786);
+      if (lookahead == 's') ADVANCE(707);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 707:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == ':') ADVANCE(787);
-      if (lookahead == 's') ADVANCE(708);
+      if (lookahead == ':') ADVANCE(786);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 708:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == ':') ADVANCE(787);
+      if (lookahead == '>') ADVANCE(790);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
-      END_STATE();
-    case 709:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '>') ADVANCE(791);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(709);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(708);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
+      END_STATE();
+    case 709:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == '>') ADVANCE(790);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(791);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 710:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
       if (lookahead == '>') ADVANCE(791);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
@@ -8514,941 +8479,942 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 711:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '>') ADVANCE(792);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(792);
-      END_STATE();
-    case 712:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '>') ADVANCE(710);
+      if (lookahead == '>') ADVANCE(709);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(711);
+          lookahead == '[') ADVANCE(710);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(709);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(708);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(710);
+          lookahead != '|') ADVANCE(709);
+      END_STATE();
+    case 712:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'A') ADVANCE(701);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(791);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 713:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'A') ADVANCE(702);
+      if (lookahead == 'A') ADVANCE(735);
+      if (lookahead == 'a') ADVANCE(771);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 714:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'A') ADVANCE(736);
-      if (lookahead == 'a') ADVANCE(772);
+      if (lookahead == 'A') ADVANCE(742);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 715:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'A') ADVANCE(743);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
-      END_STATE();
-    case 716:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
       ADVANCE_MAP(
-        'B', 775,
-        'D', 753,
-        'I', 767,
-        'P', 745,
-        'S', 727,
-        '{', 748,
-        '(', 792,
-        ',', 792,
-        '[', 792,
+        'B', 774,
+        'D', 752,
+        'I', 766,
+        'P', 744,
+        'S', 726,
+        '{', 747,
+        '(', 791,
+        ',', 791,
+        '[', 791,
       );
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '{' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
+      END_STATE();
+    case 716:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'C') ADVANCE(714);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(791);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 717:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'C') ADVANCE(715);
+      if (lookahead == 'D') ADVANCE(705);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 718:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'D') ADVANCE(706);
+      if (lookahead == 'D') ADVANCE(767);
+      if (lookahead == 'U') ADVANCE(768);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 719:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'D') ADVANCE(768);
-      if (lookahead == 'U') ADVANCE(769);
+      if (lookahead == 'E') ADVANCE(734);
+      if (lookahead == 'e') ADVANCE(769);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 720:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'E') ADVANCE(735);
-      if (lookahead == 'e') ADVANCE(770);
+      if (lookahead == 'E') ADVANCE(705);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 721:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'E') ADVANCE(706);
+      if (lookahead == 'E') ADVANCE(716);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 722:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
       if (lookahead == 'E') ADVANCE(717);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 723:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'E') ADVANCE(718);
+      if (lookahead == 'E') ADVANCE(740);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 724:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'E') ADVANCE(741);
+      if (lookahead == 'F') ADVANCE(739);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 725:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'F') ADVANCE(740);
+      if (lookahead == 'G') ADVANCE(705);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 726:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'G') ADVANCE(706);
+      if (lookahead == 'H') ADVANCE(727);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 727:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'H') ADVANCE(728);
+      if (lookahead == 'I') ADVANCE(724);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 728:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'I') ADVANCE(725);
+      if (lookahead == 'I') ADVANCE(732);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 729:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'I') ADVANCE(733);
+      if (lookahead == 'L') ADVANCE(739);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 730:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'L') ADVANCE(740);
+      if (lookahead == 'L') ADVANCE(702);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 731:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'L') ADVANCE(703);
+      if (lookahead == 'N') ADVANCE(728);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 732:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'N') ADVANCE(729);
+      if (lookahead == 'N') ADVANCE(725);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 733:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'N') ADVANCE(726);
+      if (lookahead == 'O') ADVANCE(741);
+      if (lookahead == 'o') ADVANCE(778);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 734:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'O') ADVANCE(742);
-      if (lookahead == 'o') ADVANCE(779);
+      if (lookahead == 'P') ADVANCE(737);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 735:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'P') ADVANCE(738);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
-      END_STATE();
-    case 736:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'R') ADVANCE(732);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
-      END_STATE();
-    case 737:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
       if (lookahead == 'R') ADVANCE(731);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
+      END_STATE();
+    case 736:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'R') ADVANCE(730);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(791);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(790);
+      END_STATE();
+    case 737:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'R') ADVANCE(721);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(791);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 738:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'R') ADVANCE(722);
+      if (lookahead == 'T') ADVANCE(736);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 739:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'T') ADVANCE(737);
+      if (lookahead == 'T') ADVANCE(701);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 740:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'T') ADVANCE(702);
+      if (lookahead == 'T') ADVANCE(712);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 741:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'T') ADVANCE(713);
+      if (lookahead == 'T') ADVANCE(720);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 742:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'T') ADVANCE(721);
+      if (lookahead == 'T') ADVANCE(722);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 743:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'T') ADVANCE(723);
+      if (lookahead == 'a') ADVANCE(761);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 744:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'a') ADVANCE(762);
+      if (lookahead == 'a') ADVANCE(758);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 745:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'a') ADVANCE(759);
+      if (lookahead == 'a') ADVANCE(781);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 746:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'a') ADVANCE(782);
+      if (lookahead == 'a') ADVANCE(772);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 747:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'a') ADVANCE(773);
+      if (lookahead == 'c') ADVANCE(759);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 748:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'c') ADVANCE(760);
+      if (lookahead == 'c') ADVANCE(745);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 749:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'c') ADVANCE(746);
+      if (lookahead == 'd') ADVANCE(790);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 750:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'd') ADVANCE(791);
+      if (lookahead == 'e') ADVANCE(704);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 751:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'e') ADVANCE(705);
+      if (lookahead == 'e') ADVANCE(748);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 752:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'e') ADVANCE(762);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(791);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(790);
+      END_STATE();
+    case 753:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == 'e') ADVANCE(718);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(791);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(790);
+      END_STATE();
+    case 754:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
       if (lookahead == 'e') ADVANCE(749);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
-      END_STATE();
-    case 753:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'e') ADVANCE(763);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
-      END_STATE();
-    case 754:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'e') ADVANCE(719);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 755:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'e') ADVANCE(750);
+      if (lookahead == 'e') ADVANCE(775);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 756:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'e') ADVANCE(776);
+      if (lookahead == 'e') ADVANCE(743);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 757:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'e') ADVANCE(744);
+      if (lookahead == 'g') ADVANCE(705);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 758:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'g') ADVANCE(706);
+      if (lookahead == 'g') ADVANCE(753);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 759:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'g') ADVANCE(754);
+      if (lookahead == 'h') ADVANCE(746);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 760:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'h') ADVANCE(747);
+      if (lookahead == 'i') ADVANCE(765);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 761:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'i') ADVANCE(766);
+      if (lookahead == 'k') ADVANCE(790);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 762:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'k') ADVANCE(791);
+      if (lookahead == 'l') ADVANCE(790);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 763:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'l') ADVANCE(791);
+      if (lookahead == 'n') ADVANCE(790);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 764:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'n') ADVANCE(791);
+      if (lookahead == 'n') ADVANCE(760);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 765:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'n') ADVANCE(761);
+      if (lookahead == 'n') ADVANCE(757);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 766:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'n') ADVANCE(758);
+      if (lookahead == 'n') ADVANCE(776);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 767:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'n') ADVANCE(777);
+      if (lookahead == 'o') ADVANCE(782);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 768:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'o') ADVANCE(783);
+      if (lookahead == 'p') ADVANCE(790);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 769:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'p') ADVANCE(791);
+      if (lookahead == 'p') ADVANCE(773);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 770:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'p') ADVANCE(774);
+      if (lookahead == 'p') ADVANCE(706);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 771:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'p') ADVANCE(707);
+      if (lookahead == 'r') ADVANCE(764);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 772:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'r') ADVANCE(765);
+      if (lookahead == 'r') ADVANCE(785);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 773:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'r') ADVANCE(786);
+      if (lookahead == 'r') ADVANCE(751);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 774:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'r') ADVANCE(752);
+      if (lookahead == 'r') ADVANCE(756);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 775:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'r') ADVANCE(757);
+      if (lookahead == 'r') ADVANCE(777);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 776:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'r') ADVANCE(778);
+      if (lookahead == 's') ADVANCE(755);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 777:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 's') ADVANCE(756);
+      if (lookahead == 't') ADVANCE(790);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 778:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 't') ADVANCE(791);
+      if (lookahead == 't') ADVANCE(750);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 779:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 't') ADVANCE(751);
+      if (lookahead == 't') ADVANCE(770);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 780:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 't') ADVANCE(771);
+      if (lookahead == 't') ADVANCE(779);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 781:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 't') ADVANCE(780);
+      if (lookahead == 't') ADVANCE(754);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 782:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 't') ADVANCE(755);
+      if (lookahead == 'w') ADVANCE(763);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 783:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == 'w') ADVANCE(764);
+      if (lookahead == '{') ADVANCE(784);
+      if (lookahead == '}') ADVANCE(790);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          (lookahead < '{' || '}' < lookahead)) ADVANCE(790);
       END_STATE();
     case 784:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '{') ADVANCE(785);
-      if (lookahead == '}') ADVANCE(791);
+      if (lookahead == '{') ADVANCE(784);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          (lookahead < '{' || '}' < lookahead)) ADVANCE(791);
-      END_STATE();
-    case 785:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '{') ADVANCE(785);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(790);
+          lookahead == '[') ADVANCE(791);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(789);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '{' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
-    case 786:
+    case 785:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '}') ADVANCE(791);
+      if (lookahead == '}') ADVANCE(790);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '|' &&
-          lookahead != '}') ADVANCE(791);
+          lookahead != '}') ADVANCE(790);
+      END_STATE();
+    case 786:
+      ACCEPT_TOKEN(aux_sym_taglink_token1);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(790);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(787);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '|') ADVANCE(786);
       END_STATE();
     case 787:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
       if (lookahead == ')' ||
           lookahead == ']') ADVANCE(791);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(788);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
@@ -9457,52 +9423,50 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 788:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(792);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(791);
+      if (lookahead == 'A' ||
+          lookahead == 'C' ||
+          lookahead == 'D' ||
+          lookahead == 'M' ||
+          lookahead == 'S') ADVANCE(703);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(708);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(788);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 789:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
-      if (lookahead == 'A' ||
-          lookahead == 'C' ||
-          lookahead == 'D' ||
-          lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(704);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(709);
+          lookahead == '[') ADVANCE(791);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(789);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 790:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(790);
+          lookahead == '[') ADVANCE(791);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '|') ADVANCE(791);
+          lookahead != '|') ADVANCE(790);
       END_STATE();
     case 791:
       ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(792);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
@@ -9510,238 +9474,239 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '|') ADVANCE(791);
       END_STATE();
     case 792:
-      ACCEPT_TOKEN(aux_sym_taglink_token1);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '|') ADVANCE(792);
+      ACCEPT_TOKEN(anon_sym_PIPE2);
       END_STATE();
     case 793:
-      ACCEPT_TOKEN(anon_sym_PIPE2);
+      ACCEPT_TOKEN(anon_sym_BQUOTE);
       END_STATE();
     case 794:
       ACCEPT_TOKEN(anon_sym_BQUOTE);
-      END_STATE();
-    case 795:
-      ACCEPT_TOKEN(anon_sym_BQUOTE);
-      if (lookahead == '\n') ADVANCE(589);
+      if (lookahead == '\n') ADVANCE(588);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
           lookahead == '(' ||
-          lookahead == '[') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(226);
+          lookahead == '[') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(225);
+      END_STATE();
+    case 795:
+      ACCEPT_TOKEN(anon_sym_BQUOTE);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(899);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 796:
       ACCEPT_TOKEN(anon_sym_BQUOTE);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(387);
       END_STATE();
     case 797:
-      ACCEPT_TOKEN(anon_sym_BQUOTE);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(388);
-      END_STATE();
-    case 798:
       ACCEPT_TOKEN(aux_sym_codespan_token1);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '`') ADVANCE(798);
+          lookahead != '`') ADVANCE(797);
       END_STATE();
-    case 799:
+    case 798:
       ACCEPT_TOKEN(anon_sym_BQUOTE2);
       END_STATE();
-    case 800:
+    case 799:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '-') ADVANCE(816);
-      if (lookahead == '>') ADVANCE(899);
+      if (lookahead == '-') ADVANCE(815);
+      if (lookahead == '>') ADVANCE(898);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(813);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(812);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
+      END_STATE();
+    case 800:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '-') ADVANCE(890);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(899);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 801:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '-') ADVANCE(819);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(899);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(898);
+      END_STATE();
+    case 802:
       ACCEPT_TOKEN(aux_sym_argument_token1);
       if (lookahead == '-') ADVANCE(891);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
-      END_STATE();
-    case 802:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '-') ADVANCE(820);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 803:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '-') ADVANCE(892);
+      if (lookahead == '-') ADVANCE(895);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 804:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '-') ADVANCE(896);
+      if (lookahead == ':') ADVANCE(433);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 805:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ':') ADVANCE(434);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
-      END_STATE();
-    case 806:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ':') ADVANCE(431);
-      if (lookahead == 's') ADVANCE(809);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
-      END_STATE();
-    case 807:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ':') ADVANCE(894);
+      if (lookahead == ':') ADVANCE(430);
       if (lookahead == 's') ADVANCE(808);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
+      END_STATE();
+    case 806:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ':') ADVANCE(893);
+      if (lookahead == 's') ADVANCE(807);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(899);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(898);
+      END_STATE();
+    case 807:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == ':') ADVANCE(893);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(899);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 808:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ':') ADVANCE(894);
+      if (lookahead == ':') ADVANCE(436);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 809:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ':') ADVANCE(437);
+      if (lookahead == ':') ADVANCE(442);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 810:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ':') ADVANCE(443);
+      if (lookahead == ':') ADVANCE(439);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 811:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ':') ADVANCE(440);
+      if (lookahead == ':') ADVANCE(449);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 812:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == ':') ADVANCE(450);
+      if (lookahead == '>') ADVANCE(898);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
-      END_STATE();
-    case 813:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '>') ADVANCE(899);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(813);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(812);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
+      END_STATE();
+    case 813:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '>') ADVANCE(898);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(899);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 814:
       ACCEPT_TOKEN(aux_sym_argument_token1);
       if (lookahead == '>') ADVANCE(899);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
@@ -9750,962 +9715,966 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 815:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '>') ADVANCE(900);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(900);
-      END_STATE();
-    case 816:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '>') ADVANCE(814);
-      if (lookahead == '}') ADVANCE(62);
+      if (lookahead == '>') ADVANCE(813);
+      if (lookahead == '}') ADVANCE(61);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(28);
+          lookahead == ' ') ADVANCE(27);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(815);
+          lookahead == '[') ADVANCE(814);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(813);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(812);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(814);
+          lookahead != '\n') ADVANCE(813);
+      END_STATE();
+    case 816:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'A') ADVANCE(839);
+      if (lookahead == 'a') ADVANCE(876);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(899);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 817:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'A') ADVANCE(840);
-      if (lookahead == 'a') ADVANCE(877);
+      if (lookahead == 'A') ADVANCE(846);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 818:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'A') ADVANCE(847);
+      if (lookahead == 'A') ADVANCE(802);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 819:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'A') ADVANCE(803);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
-      END_STATE();
-    case 820:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
       ADVANCE_MAP(
-        'B', 880,
-        'D', 858,
-        'I', 872,
-        'P', 850,
-        'S', 831,
-        '{', 853,
-        '}', 458,
-        '\t', 458,
-        ' ', 458,
-        '(', 900,
-        ',', 900,
-        '[', 900,
+        'B', 879,
+        'D', 857,
+        'I', 871,
+        'P', 849,
+        'S', 830,
+        '{', 852,
+        '}', 457,
+        '\t', 457,
+        ' ', 457,
+        '(', 899,
+        ',', 899,
+        '[', 899,
       );
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(899);
+          lookahead != '\n') ADVANCE(898);
+      END_STATE();
+    case 820:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'C') ADVANCE(817);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(899);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 821:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'C') ADVANCE(818);
+      if (lookahead == 'D') ADVANCE(872);
+      if (lookahead == 'U') ADVANCE(873);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 822:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'D') ADVANCE(873);
-      if (lookahead == 'U') ADVANCE(874);
+      if (lookahead == 'D') ADVANCE(811);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 823:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'D') ADVANCE(812);
+      if (lookahead == 'E') ADVANCE(838);
+      if (lookahead == 'e') ADVANCE(874);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 824:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'E') ADVANCE(839);
-      if (lookahead == 'e') ADVANCE(875);
+      if (lookahead == 'E') ADVANCE(804);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 825:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'E') ADVANCE(805);
+      if (lookahead == 'E') ADVANCE(820);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 826:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'E') ADVANCE(821);
+      if (lookahead == 'E') ADVANCE(822);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 827:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'E') ADVANCE(823);
+      if (lookahead == 'E') ADVANCE(844);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 828:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'E') ADVANCE(845);
+      if (lookahead == 'F') ADVANCE(847);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 829:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'F') ADVANCE(848);
+      if (lookahead == 'G') ADVANCE(809);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 830:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'G') ADVANCE(810);
+      if (lookahead == 'H') ADVANCE(831);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 831:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'H') ADVANCE(832);
+      if (lookahead == 'I') ADVANCE(828);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 832:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'I') ADVANCE(829);
+      if (lookahead == 'I') ADVANCE(836);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 833:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'I') ADVANCE(837);
+      if (lookahead == 'L') ADVANCE(843);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 834:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'L') ADVANCE(844);
+      if (lookahead == 'L') ADVANCE(801);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 835:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'L') ADVANCE(802);
+      if (lookahead == 'N') ADVANCE(832);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 836:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'N') ADVANCE(833);
+      if (lookahead == 'N') ADVANCE(829);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 837:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'N') ADVANCE(830);
+      if (lookahead == 'O') ADVANCE(845);
+      if (lookahead == 'o') ADVANCE(883);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 838:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'O') ADVANCE(846);
-      if (lookahead == 'o') ADVANCE(884);
+      if (lookahead == 'P') ADVANCE(841);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 839:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'P') ADVANCE(842);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
-      END_STATE();
-    case 840:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'R') ADVANCE(836);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
-      END_STATE();
-    case 841:
       ACCEPT_TOKEN(aux_sym_argument_token1);
       if (lookahead == 'R') ADVANCE(835);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
+      END_STATE();
+    case 840:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'R') ADVANCE(834);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(899);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(898);
+      END_STATE();
+    case 841:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'R') ADVANCE(825);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(899);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 842:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'R') ADVANCE(826);
+      if (lookahead == 'T') ADVANCE(840);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 843:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'T') ADVANCE(841);
+      if (lookahead == 'T') ADVANCE(800);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 844:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'T') ADVANCE(801);
+      if (lookahead == 'T') ADVANCE(818);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 845:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'T') ADVANCE(819);
+      if (lookahead == 'T') ADVANCE(824);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 846:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'T') ADVANCE(825);
+      if (lookahead == 'T') ADVANCE(826);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 847:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'T') ADVANCE(827);
+      if (lookahead == 'T') ADVANCE(803);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 848:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'T') ADVANCE(804);
+      if (lookahead == 'a') ADVANCE(866);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 849:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'a') ADVANCE(867);
+      if (lookahead == 'a') ADVANCE(863);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 850:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'a') ADVANCE(864);
+      if (lookahead == 'a') ADVANCE(886);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 851:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'a') ADVANCE(887);
+      if (lookahead == 'a') ADVANCE(877);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 852:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'a') ADVANCE(878);
+      if (lookahead == 'c') ADVANCE(864);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 853:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'c') ADVANCE(865);
+      if (lookahead == 'c') ADVANCE(850);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 854:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'c') ADVANCE(851);
+      if (lookahead == 'd') ADVANCE(445);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 855:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'd') ADVANCE(446);
+      if (lookahead == 'e') ADVANCE(805);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 856:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'e') ADVANCE(806);
+      if (lookahead == 'e') ADVANCE(853);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 857:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'e') ADVANCE(867);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(899);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(898);
+      END_STATE();
+    case 858:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == 'e') ADVANCE(821);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(899);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(898);
+      END_STATE();
+    case 859:
       ACCEPT_TOKEN(aux_sym_argument_token1);
       if (lookahead == 'e') ADVANCE(854);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
-      END_STATE();
-    case 858:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'e') ADVANCE(868);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
-      END_STATE();
-    case 859:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'e') ADVANCE(822);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 860:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'e') ADVANCE(855);
+      if (lookahead == 'e') ADVANCE(880);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 861:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'e') ADVANCE(881);
+      if (lookahead == 'e') ADVANCE(848);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 862:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'e') ADVANCE(849);
+      if (lookahead == 'g') ADVANCE(810);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 863:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'g') ADVANCE(811);
+      if (lookahead == 'g') ADVANCE(858);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 864:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'g') ADVANCE(859);
+      if (lookahead == 'h') ADVANCE(851);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 865:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'h') ADVANCE(852);
+      if (lookahead == 'i') ADVANCE(870);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 866:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'i') ADVANCE(871);
+      if (lookahead == 'k') ADVANCE(898);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 867:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'k') ADVANCE(899);
+      if (lookahead == 'l') ADVANCE(898);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 868:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'l') ADVANCE(899);
+      if (lookahead == 'n') ADVANCE(898);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 869:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'n') ADVANCE(899);
+      if (lookahead == 'n') ADVANCE(865);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 870:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'n') ADVANCE(866);
+      if (lookahead == 'n') ADVANCE(862);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 871:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'n') ADVANCE(863);
+      if (lookahead == 'n') ADVANCE(881);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 872:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'n') ADVANCE(882);
+      if (lookahead == 'o') ADVANCE(887);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 873:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'o') ADVANCE(888);
+      if (lookahead == 'p') ADVANCE(898);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 874:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'p') ADVANCE(899);
+      if (lookahead == 'p') ADVANCE(878);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 875:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'p') ADVANCE(879);
+      if (lookahead == 'p') ADVANCE(806);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 876:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'p') ADVANCE(807);
+      if (lookahead == 'r') ADVANCE(869);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 877:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'r') ADVANCE(870);
+      if (lookahead == 'r') ADVANCE(894);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 878:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'r') ADVANCE(895);
+      if (lookahead == 'r') ADVANCE(856);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 879:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'r') ADVANCE(857);
+      if (lookahead == 'r') ADVANCE(861);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 880:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'r') ADVANCE(862);
+      if (lookahead == 'r') ADVANCE(882);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 881:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'r') ADVANCE(883);
+      if (lookahead == 's') ADVANCE(860);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 882:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 's') ADVANCE(861);
+      if (lookahead == 't') ADVANCE(898);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 883:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 't') ADVANCE(899);
+      if (lookahead == 't') ADVANCE(855);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 884:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 't') ADVANCE(856);
+      if (lookahead == 't') ADVANCE(875);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 885:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 't') ADVANCE(876);
+      if (lookahead == 't') ADVANCE(884);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 886:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 't') ADVANCE(885);
+      if (lookahead == 't') ADVANCE(859);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 887:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 't') ADVANCE(860);
+      if (lookahead == 'w') ADVANCE(868);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 888:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == 'w') ADVANCE(869);
+      if (lookahead == '{') ADVANCE(888);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(897);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 889:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '{') ADVANCE(889);
+      if (lookahead == '|') ADVANCE(889);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(898);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
-      END_STATE();
-    case 890:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '|') ADVANCE(890);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
           lookahead != '|' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
+      END_STATE();
+    case 890:
+      ACCEPT_TOKEN(aux_sym_argument_token1);
+      if (lookahead == '}') ADVANCE(499);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(499);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(899);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n') ADVANCE(898);
       END_STATE();
     case 891:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '}') ADVANCE(500);
+      if (lookahead == '}') ADVANCE(494);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(500);
+          lookahead == ' ') ADVANCE(494);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(899);
+          lookahead != '\n') ADVANCE(898);
       END_STATE();
     case 892:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '}') ADVANCE(495);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(495);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+      if (lookahead == '}') ADVANCE(695);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(899);
+          lookahead != '\n' &&
+          lookahead != ' ') ADVANCE(892);
       END_STATE();
     case 893:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '}') ADVANCE(696);
+      if (lookahead == '}') ADVANCE(694);
       if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(900);
+          lookahead == ']') ADVANCE(898);
+      if (lookahead == '(' ||
+          lookahead == ',' ||
+          lookahead == '[') ADVANCE(892);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
@@ -10713,78 +10682,73 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 894:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '}') ADVANCE(695);
-      if (lookahead == ')' ||
-          lookahead == ']') ADVANCE(899);
+      if (lookahead == '}') ADVANCE(492);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(893);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(894);
+          lookahead != ' ') ADVANCE(898);
       END_STATE();
     case 895:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '}') ADVANCE(493);
+      if (lookahead == '}') ADVANCE(485);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(485);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(899);
+          lookahead != '\n') ADVANCE(898);
       END_STATE();
     case 896:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '}') ADVANCE(486);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(486);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
+          lookahead == '[') ADVANCE(899);
+      if (lookahead == 'A' ||
+          lookahead == 'C' ||
+          lookahead == 'D' ||
+          lookahead == 'M' ||
+          lookahead == 'S') ADVANCE(799);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(812);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(899);
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 897:
       ACCEPT_TOKEN(aux_sym_argument_token1);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
-      if (lookahead == 'A' ||
-          lookahead == 'C' ||
-          lookahead == 'D' ||
-          lookahead == 'M' ||
-          lookahead == 'S') ADVANCE(800);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(813);
+          lookahead == '[') ADVANCE(899);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(897);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 898:
       ACCEPT_TOKEN(aux_sym_argument_token1);
       if (lookahead == '(' ||
           lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(898);
+          lookahead == '[') ADVANCE(899);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '}') ADVANCE(899);
+          lookahead != '}') ADVANCE(898);
       END_STATE();
     case 899:
       ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead == '(' ||
-          lookahead == ',' ||
-          lookahead == '[') ADVANCE(900);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
@@ -10792,17 +10756,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '}') ADVANCE(899);
       END_STATE();
     case 900:
-      ACCEPT_TOKEN(aux_sym_argument_token1);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != '}') ADVANCE(900);
-      END_STATE();
-    case 901:
       ACCEPT_TOKEN(anon_sym_RBRACE);
       END_STATE();
-    case 902:
+    case 901:
       ACCEPT_TOKEN(anon_sym_QMARK);
       END_STATE();
     default:
@@ -10812,119 +10768,120 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 32},
-  [2] = {.lex_state = 32},
-  [3] = {.lex_state = 32},
-  [4] = {.lex_state = 32},
-  [5] = {.lex_state = 32},
-  [6] = {.lex_state = 8},
-  [7] = {.lex_state = 8},
-  [8] = {.lex_state = 10},
-  [9] = {.lex_state = 10},
-  [10] = {.lex_state = 10},
-  [11] = {.lex_state = 10},
-  [12] = {.lex_state = 10},
-  [13] = {.lex_state = 10},
-  [14] = {.lex_state = 10},
-  [15] = {.lex_state = 10},
-  [16] = {.lex_state = 10},
-  [17] = {.lex_state = 6},
-  [18] = {.lex_state = 6},
-  [19] = {.lex_state = 6},
-  [20] = {.lex_state = 6},
-  [21] = {.lex_state = 6},
-  [22] = {.lex_state = 6},
-  [23] = {.lex_state = 6},
-  [24] = {.lex_state = 6},
-  [25] = {.lex_state = 6},
-  [26] = {.lex_state = 6},
-  [27] = {.lex_state = 6},
-  [28] = {.lex_state = 6},
-  [29] = {.lex_state = 6},
-  [30] = {.lex_state = 6},
-  [31] = {.lex_state = 6},
-  [32] = {.lex_state = 32},
-  [33] = {.lex_state = 32},
-  [34] = {.lex_state = 32},
-  [35] = {.lex_state = 32},
-  [36] = {.lex_state = 32},
-  [37] = {.lex_state = 32},
-  [38] = {.lex_state = 32},
-  [39] = {.lex_state = 32},
-  [40] = {.lex_state = 32},
-  [41] = {.lex_state = 32},
-  [42] = {.lex_state = 32},
-  [43] = {.lex_state = 9},
-  [44] = {.lex_state = 9},
-  [45] = {.lex_state = 32},
-  [46] = {.lex_state = 32},
-  [47] = {.lex_state = 11},
-  [48] = {.lex_state = 11},
-  [49] = {.lex_state = 9},
-  [50] = {.lex_state = 9},
-  [51] = {.lex_state = 8},
-  [52] = {.lex_state = 8},
-  [53] = {.lex_state = 8},
-  [54] = {.lex_state = 8},
-  [55] = {.lex_state = 8},
-  [56] = {.lex_state = 8},
-  [57] = {.lex_state = 8},
-  [58] = {.lex_state = 8},
-  [59] = {.lex_state = 8},
-  [60] = {.lex_state = 8},
-  [61] = {.lex_state = 11},
-  [62] = {.lex_state = 11},
+  [1] = {.lex_state = 31},
+  [2] = {.lex_state = 31},
+  [3] = {.lex_state = 31},
+  [4] = {.lex_state = 31},
+  [5] = {.lex_state = 31},
+  [6] = {.lex_state = 7},
+  [7] = {.lex_state = 7},
+  [8] = {.lex_state = 9},
+  [9] = {.lex_state = 9},
+  [10] = {.lex_state = 9},
+  [11] = {.lex_state = 9},
+  [12] = {.lex_state = 9},
+  [13] = {.lex_state = 9},
+  [14] = {.lex_state = 9},
+  [15] = {.lex_state = 9},
+  [16] = {.lex_state = 9},
+  [17] = {.lex_state = 5},
+  [18] = {.lex_state = 5},
+  [19] = {.lex_state = 5},
+  [20] = {.lex_state = 5},
+  [21] = {.lex_state = 5},
+  [22] = {.lex_state = 5},
+  [23] = {.lex_state = 5},
+  [24] = {.lex_state = 5},
+  [25] = {.lex_state = 5},
+  [26] = {.lex_state = 5},
+  [27] = {.lex_state = 5},
+  [28] = {.lex_state = 5},
+  [29] = {.lex_state = 5},
+  [30] = {.lex_state = 5},
+  [31] = {.lex_state = 5},
+  [32] = {.lex_state = 5},
+  [33] = {.lex_state = 5},
+  [34] = {.lex_state = 5},
+  [35] = {.lex_state = 5},
+  [36] = {.lex_state = 31},
+  [37] = {.lex_state = 31},
+  [38] = {.lex_state = 31},
+  [39] = {.lex_state = 31},
+  [40] = {.lex_state = 31},
+  [41] = {.lex_state = 31},
+  [42] = {.lex_state = 31},
+  [43] = {.lex_state = 8},
+  [44] = {.lex_state = 8},
+  [45] = {.lex_state = 31},
+  [46] = {.lex_state = 10},
+  [47] = {.lex_state = 10},
+  [48] = {.lex_state = 8},
+  [49] = {.lex_state = 8},
+  [50] = {.lex_state = 7},
+  [51] = {.lex_state = 7},
+  [52] = {.lex_state = 7},
+  [53] = {.lex_state = 7},
+  [54] = {.lex_state = 7},
+  [55] = {.lex_state = 7},
+  [56] = {.lex_state = 7},
+  [57] = {.lex_state = 7},
+  [58] = {.lex_state = 7},
+  [59] = {.lex_state = 7},
+  [60] = {.lex_state = 7},
+  [61] = {.lex_state = 7},
+  [62] = {.lex_state = 7},
   [63] = {.lex_state = 10},
   [64] = {.lex_state = 10},
-  [65] = {.lex_state = 10},
-  [66] = {.lex_state = 12},
-  [67] = {.lex_state = 3},
-  [68] = {.lex_state = 13},
-  [69] = {.lex_state = 13},
-  [70] = {.lex_state = 13},
-  [71] = {.lex_state = 13},
-  [72] = {.lex_state = 3},
-  [73] = {.lex_state = 13},
-  [74] = {.lex_state = 15},
-  [75] = {.lex_state = 4},
-  [76] = {.lex_state = 13},
-  [77] = {.lex_state = 16},
-  [78] = {.lex_state = 5},
-  [79] = {.lex_state = 2},
-  [80] = {.lex_state = 2},
-  [81] = {.lex_state = 17},
-  [82] = {.lex_state = 6},
-  [83] = {.lex_state = 6},
-  [84] = {.lex_state = 6},
-  [85] = {.lex_state = 6},
-  [86] = {.lex_state = 6},
-  [87] = {.lex_state = 6},
-  [88] = {.lex_state = 6},
-  [89] = {.lex_state = 6},
-  [90] = {.lex_state = 6},
-  [91] = {.lex_state = 6},
-  [92] = {.lex_state = 6},
-  [93] = {.lex_state = 6},
-  [94] = {.lex_state = 18},
-  [95] = {.lex_state = 18},
-  [96] = {.lex_state = 18},
-  [97] = {.lex_state = 9},
-  [98] = {.lex_state = 9},
-  [99] = {.lex_state = 32},
-  [100] = {.lex_state = 32},
-  [101] = {.lex_state = 32},
-  [102] = {.lex_state = 32},
-  [103] = {.lex_state = 32},
-  [104] = {.lex_state = 32},
-  [105] = {.lex_state = 32},
-  [106] = {.lex_state = 29},
-  [107] = {.lex_state = 0},
-  [108] = {.lex_state = 4},
-  [109] = {.lex_state = 18},
-  [110] = {.lex_state = 18},
-  [111] = {.lex_state = 18},
-  [112] = {.lex_state = 15},
-  [113] = {.lex_state = 18},
+  [65] = {.lex_state = 9},
+  [66] = {.lex_state = 9},
+  [67] = {.lex_state = 9},
+  [68] = {.lex_state = 11},
+  [69] = {.lex_state = 2},
+  [70] = {.lex_state = 12},
+  [71] = {.lex_state = 12},
+  [72] = {.lex_state = 12},
+  [73] = {.lex_state = 2},
+  [74] = {.lex_state = 12},
+  [75] = {.lex_state = 12},
+  [76] = {.lex_state = 3},
+  [77] = {.lex_state = 4},
+  [78] = {.lex_state = 14},
+  [79] = {.lex_state = 15},
+  [80] = {.lex_state = 16},
+  [81] = {.lex_state = 12},
+  [82] = {.lex_state = 5},
+  [83] = {.lex_state = 5},
+  [84] = {.lex_state = 5},
+  [85] = {.lex_state = 5},
+  [86] = {.lex_state = 5},
+  [87] = {.lex_state = 5},
+  [88] = {.lex_state = 5},
+  [89] = {.lex_state = 5},
+  [90] = {.lex_state = 5},
+  [91] = {.lex_state = 5},
+  [92] = {.lex_state = 5},
+  [93] = {.lex_state = 5},
+  [94] = {.lex_state = 17},
+  [95] = {.lex_state = 17},
+  [96] = {.lex_state = 17},
+  [97] = {.lex_state = 8},
+  [98] = {.lex_state = 8},
+  [99] = {.lex_state = 31},
+  [100] = {.lex_state = 31},
+  [101] = {.lex_state = 31},
+  [102] = {.lex_state = 31},
+  [103] = {.lex_state = 31},
+  [104] = {.lex_state = 31},
+  [105] = {.lex_state = 28},
+  [106] = {.lex_state = 0},
+  [107] = {.lex_state = 3},
+  [108] = {.lex_state = 17},
+  [109] = {.lex_state = 17},
+  [110] = {.lex_state = 31},
+  [111] = {.lex_state = 15},
+  [112] = {.lex_state = 17},
+  [113] = {.lex_state = 0},
+  [114] = {.lex_state = 17},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -10960,8 +10917,8 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_keycode_token6] = ACTIONS(1),
     [aux_sym_keycode_token7] = ACTIONS(1),
     [anon_sym_LT] = ACTIONS(1),
-    [anon_sym_LF] = ACTIONS(1),
-    [anon_sym_LF2] = ACTIONS(1),
+    [aux_sym_codeblock_token2] = ACTIONS(1),
+    [aux_sym__blank_token1] = ACTIONS(1),
     [aux_sym_tag_token1] = ACTIONS(1),
     [anon_sym_STAR2] = ACTIONS(1),
     [sym_url_word] = ACTIONS(1),
@@ -10973,25 +10930,26 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_QMARK] = ACTIONS(1),
   },
   [1] = {
-    [sym_help_file] = STATE(107),
+    [sym_help_file] = STATE(113),
     [sym__atom_noli] = STATE(18),
     [sym_word_noli] = STATE(18),
     [sym__atom_common] = STATE(18),
-    [sym__word_common] = STATE(85),
+    [sym__word_common] = STATE(84),
     [sym_note] = STATE(18),
     [sym_keycode] = STATE(18),
-    [sym_uppercase_name] = STATE(102),
+    [sym_uppercase_name] = STATE(103),
     [sym__uppercase_words] = STATE(18),
     [sym_block] = STATE(4),
-    [sym_codeblock] = STATE(60),
-    [sym__blank] = STATE(46),
+    [sym_codeblock] = STATE(59),
+    [sym__blank] = STATE(2),
     [sym_line] = STATE(6),
-    [sym_line_li] = STATE(95),
-    [sym__line_noli] = STATE(60),
-    [sym_column_heading] = STATE(60),
-    [sym_h1] = STATE(60),
-    [sym_h2] = STATE(60),
-    [sym_h3] = STATE(60),
+    [sym_line_li] = STATE(94),
+    [sym__line_noli] = STATE(59),
+    [sym_column_heading] = STATE(59),
+    [sym__column_heading] = STATE(104),
+    [sym_h1] = STATE(59),
+    [sym_h2] = STATE(59),
+    [sym_h3] = STATE(59),
     [sym_tag] = STATE(18),
     [sym_url] = STATE(18),
     [sym_optionlink] = STATE(18),
@@ -11002,7 +10960,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_help_file_repeat2] = STATE(4),
     [aux_sym_help_file_repeat3] = STATE(101),
     [aux_sym_block_repeat1] = STATE(6),
-    [aux_sym_block_repeat2] = STATE(95),
+    [aux_sym_block_repeat2] = STATE(94),
     [ts_builtin_sym_end] = ACTIONS(3),
     [aux_sym_word_noli_token1] = ACTIONS(5),
     [aux_sym_word_noli_token2] = ACTIONS(5),
@@ -11035,7 +10993,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_keycode_token7] = ACTIONS(21),
     [aux_sym_uppercase_name_token1] = ACTIONS(25),
     [anon_sym_LT] = ACTIONS(27),
-    [anon_sym_LF2] = ACTIONS(29),
+    [aux_sym__blank_token1] = ACTIONS(29),
     [aux_sym_line_li_token1] = ACTIONS(31),
     [sym_modeline] = ACTIONS(33),
     [aux_sym_h1_token1] = ACTIONS(35),
@@ -11047,32 +11005,33 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym__atom_noli] = STATE(18),
     [sym_word_noli] = STATE(18),
     [sym__atom_common] = STATE(18),
-    [sym__word_common] = STATE(85),
+    [sym__word_common] = STATE(84),
     [sym_note] = STATE(18),
     [sym_keycode] = STATE(18),
-    [sym_uppercase_name] = STATE(102),
+    [sym_uppercase_name] = STATE(103),
     [sym__uppercase_words] = STATE(18),
     [sym_block] = STATE(3),
-    [sym_codeblock] = STATE(60),
-    [sym__blank] = STATE(46),
+    [sym_codeblock] = STATE(59),
+    [sym__blank] = STATE(40),
     [sym_line] = STATE(6),
-    [sym_line_li] = STATE(95),
-    [sym__line_noli] = STATE(60),
-    [sym_column_heading] = STATE(60),
-    [sym_h1] = STATE(60),
-    [sym_h2] = STATE(60),
-    [sym_h3] = STATE(60),
+    [sym_line_li] = STATE(94),
+    [sym__line_noli] = STATE(59),
+    [sym_column_heading] = STATE(59),
+    [sym__column_heading] = STATE(104),
+    [sym_h1] = STATE(59),
+    [sym_h2] = STATE(59),
+    [sym_h3] = STATE(59),
     [sym_tag] = STATE(18),
     [sym_url] = STATE(18),
     [sym_optionlink] = STATE(18),
     [sym_taglink] = STATE(18),
     [sym_codespan] = STATE(18),
     [sym_argument] = STATE(18),
-    [aux_sym_help_file_repeat1] = STATE(33),
+    [aux_sym_help_file_repeat1] = STATE(40),
     [aux_sym_help_file_repeat2] = STATE(3),
-    [aux_sym_help_file_repeat3] = STATE(104),
+    [aux_sym_help_file_repeat3] = STATE(100),
     [aux_sym_block_repeat1] = STATE(6),
-    [aux_sym_block_repeat2] = STATE(95),
+    [aux_sym_block_repeat2] = STATE(94),
     [ts_builtin_sym_end] = ACTIONS(43),
     [aux_sym_word_noli_token1] = ACTIONS(5),
     [aux_sym_word_noli_token2] = ACTIONS(5),
@@ -11105,7 +11064,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_keycode_token7] = ACTIONS(21),
     [aux_sym_uppercase_name_token1] = ACTIONS(25),
     [anon_sym_LT] = ACTIONS(27),
-    [anon_sym_LF2] = ACTIONS(29),
+    [aux_sym__blank_token1] = ACTIONS(29),
     [aux_sym_line_li_token1] = ACTIONS(31),
     [sym_modeline] = ACTIONS(45),
     [aux_sym_h1_token1] = ACTIONS(35),
@@ -11117,20 +11076,21 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym__atom_noli] = STATE(18),
     [sym_word_noli] = STATE(18),
     [sym__atom_common] = STATE(18),
-    [sym__word_common] = STATE(85),
+    [sym__word_common] = STATE(84),
     [sym_note] = STATE(18),
     [sym_keycode] = STATE(18),
-    [sym_uppercase_name] = STATE(102),
+    [sym_uppercase_name] = STATE(103),
     [sym__uppercase_words] = STATE(18),
     [sym_block] = STATE(5),
-    [sym_codeblock] = STATE(60),
+    [sym_codeblock] = STATE(59),
     [sym_line] = STATE(6),
-    [sym_line_li] = STATE(95),
-    [sym__line_noli] = STATE(60),
-    [sym_column_heading] = STATE(60),
-    [sym_h1] = STATE(60),
-    [sym_h2] = STATE(60),
-    [sym_h3] = STATE(60),
+    [sym_line_li] = STATE(94),
+    [sym__line_noli] = STATE(59),
+    [sym_column_heading] = STATE(59),
+    [sym__column_heading] = STATE(104),
+    [sym_h1] = STATE(59),
+    [sym_h2] = STATE(59),
+    [sym_h3] = STATE(59),
     [sym_tag] = STATE(18),
     [sym_url] = STATE(18),
     [sym_optionlink] = STATE(18),
@@ -11138,9 +11098,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_codespan] = STATE(18),
     [sym_argument] = STATE(18),
     [aux_sym_help_file_repeat2] = STATE(5),
-    [aux_sym_help_file_repeat3] = STATE(100),
+    [aux_sym_help_file_repeat3] = STATE(102),
     [aux_sym_block_repeat1] = STATE(6),
-    [aux_sym_block_repeat2] = STATE(95),
+    [aux_sym_block_repeat2] = STATE(94),
     [ts_builtin_sym_end] = ACTIONS(47),
     [aux_sym_word_noli_token1] = ACTIONS(5),
     [aux_sym_word_noli_token2] = ACTIONS(5),
@@ -11184,20 +11144,21 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym__atom_noli] = STATE(18),
     [sym_word_noli] = STATE(18),
     [sym__atom_common] = STATE(18),
-    [sym__word_common] = STATE(85),
+    [sym__word_common] = STATE(84),
     [sym_note] = STATE(18),
     [sym_keycode] = STATE(18),
-    [sym_uppercase_name] = STATE(102),
+    [sym_uppercase_name] = STATE(103),
     [sym__uppercase_words] = STATE(18),
     [sym_block] = STATE(5),
-    [sym_codeblock] = STATE(60),
+    [sym_codeblock] = STATE(59),
     [sym_line] = STATE(6),
-    [sym_line_li] = STATE(95),
-    [sym__line_noli] = STATE(60),
-    [sym_column_heading] = STATE(60),
-    [sym_h1] = STATE(60),
-    [sym_h2] = STATE(60),
-    [sym_h3] = STATE(60),
+    [sym_line_li] = STATE(94),
+    [sym__line_noli] = STATE(59),
+    [sym_column_heading] = STATE(59),
+    [sym__column_heading] = STATE(104),
+    [sym_h1] = STATE(59),
+    [sym_h2] = STATE(59),
+    [sym_h3] = STATE(59),
     [sym_tag] = STATE(18),
     [sym_url] = STATE(18),
     [sym_optionlink] = STATE(18),
@@ -11205,10 +11166,10 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_codespan] = STATE(18),
     [sym_argument] = STATE(18),
     [aux_sym_help_file_repeat2] = STATE(5),
-    [aux_sym_help_file_repeat3] = STATE(99),
+    [aux_sym_help_file_repeat3] = STATE(100),
     [aux_sym_block_repeat1] = STATE(6),
-    [aux_sym_block_repeat2] = STATE(95),
-    [ts_builtin_sym_end] = ACTIONS(51),
+    [aux_sym_block_repeat2] = STATE(94),
+    [ts_builtin_sym_end] = ACTIONS(43),
     [aux_sym_word_noli_token1] = ACTIONS(5),
     [aux_sym_word_noli_token2] = ACTIONS(5),
     [anon_sym_STAR] = ACTIONS(7),
@@ -11241,7 +11202,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_uppercase_name_token1] = ACTIONS(25),
     [anon_sym_LT] = ACTIONS(27),
     [aux_sym_line_li_token1] = ACTIONS(31),
-    [sym_modeline] = ACTIONS(53),
+    [sym_modeline] = ACTIONS(45),
     [aux_sym_h1_token1] = ACTIONS(35),
     [aux_sym_h2_token1] = ACTIONS(37),
     [sym_url_word] = ACTIONS(39),
@@ -11251,20 +11212,21 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym__atom_noli] = STATE(18),
     [sym_word_noli] = STATE(18),
     [sym__atom_common] = STATE(18),
-    [sym__word_common] = STATE(85),
+    [sym__word_common] = STATE(84),
     [sym_note] = STATE(18),
     [sym_keycode] = STATE(18),
-    [sym_uppercase_name] = STATE(102),
+    [sym_uppercase_name] = STATE(103),
     [sym__uppercase_words] = STATE(18),
     [sym_block] = STATE(5),
-    [sym_codeblock] = STATE(60),
+    [sym_codeblock] = STATE(59),
     [sym_line] = STATE(6),
-    [sym_line_li] = STATE(95),
-    [sym__line_noli] = STATE(60),
-    [sym_column_heading] = STATE(60),
-    [sym_h1] = STATE(60),
-    [sym_h2] = STATE(60),
-    [sym_h3] = STATE(60),
+    [sym_line_li] = STATE(94),
+    [sym__line_noli] = STATE(59),
+    [sym_column_heading] = STATE(59),
+    [sym__column_heading] = STATE(104),
+    [sym_h1] = STATE(59),
+    [sym_h2] = STATE(59),
+    [sym_h3] = STATE(59),
     [sym_tag] = STATE(18),
     [sym_url] = STATE(18),
     [sym_optionlink] = STATE(18),
@@ -11273,64 +11235,65 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_argument] = STATE(18),
     [aux_sym_help_file_repeat2] = STATE(5),
     [aux_sym_block_repeat1] = STATE(6),
-    [aux_sym_block_repeat2] = STATE(95),
-    [ts_builtin_sym_end] = ACTIONS(55),
-    [aux_sym_word_noli_token1] = ACTIONS(57),
-    [aux_sym_word_noli_token2] = ACTIONS(57),
-    [anon_sym_STAR] = ACTIONS(60),
-    [anon_sym_SQUOTE] = ACTIONS(63),
-    [aux_sym__word_common_token3] = ACTIONS(66),
-    [anon_sym_PIPE] = ACTIONS(69),
-    [anon_sym_LBRACE] = ACTIONS(72),
-    [anon_sym_LBRACE_RBRACE] = ACTIONS(66),
-    [aux_sym__word_common_token4] = ACTIONS(66),
-    [anon_sym_LPAREN] = ACTIONS(57),
-    [anon_sym_LBRACK] = ACTIONS(66),
-    [anon_sym_TILDE] = ACTIONS(66),
-    [anon_sym_GT] = ACTIONS(75),
-    [anon_sym_COMMA] = ACTIONS(66),
-    [anon_sym_Note_COLON] = ACTIONS(78),
-    [anon_sym_NOTE_COLON] = ACTIONS(78),
-    [anon_sym_Notes_COLON] = ACTIONS(78),
-    [anon_sym_Warning_COLON] = ACTIONS(78),
-    [anon_sym_WARNING_COLON] = ACTIONS(78),
-    [anon_sym_Deprecated] = ACTIONS(78),
-    [anon_sym_DEPRECATED_COLON] = ACTIONS(78),
-    [aux_sym_keycode_token1] = ACTIONS(81),
-    [aux_sym_keycode_token2] = ACTIONS(81),
-    [aux_sym_keycode_token3] = ACTIONS(81),
-    [aux_sym_keycode_token4] = ACTIONS(81),
-    [aux_sym_keycode_token5] = ACTIONS(84),
-    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(84),
-    [aux_sym_keycode_token6] = ACTIONS(81),
-    [aux_sym_keycode_token7] = ACTIONS(81),
-    [aux_sym_uppercase_name_token1] = ACTIONS(87),
-    [anon_sym_LT] = ACTIONS(90),
-    [aux_sym_line_li_token1] = ACTIONS(93),
-    [sym_modeline] = ACTIONS(55),
-    [aux_sym_h1_token1] = ACTIONS(96),
-    [aux_sym_h2_token1] = ACTIONS(99),
-    [sym_url_word] = ACTIONS(102),
-    [anon_sym_BQUOTE] = ACTIONS(105),
+    [aux_sym_block_repeat2] = STATE(94),
+    [ts_builtin_sym_end] = ACTIONS(51),
+    [aux_sym_word_noli_token1] = ACTIONS(53),
+    [aux_sym_word_noli_token2] = ACTIONS(53),
+    [anon_sym_STAR] = ACTIONS(56),
+    [anon_sym_SQUOTE] = ACTIONS(59),
+    [aux_sym__word_common_token3] = ACTIONS(62),
+    [anon_sym_PIPE] = ACTIONS(65),
+    [anon_sym_LBRACE] = ACTIONS(68),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(62),
+    [aux_sym__word_common_token4] = ACTIONS(62),
+    [anon_sym_LPAREN] = ACTIONS(53),
+    [anon_sym_LBRACK] = ACTIONS(62),
+    [anon_sym_TILDE] = ACTIONS(62),
+    [anon_sym_GT] = ACTIONS(71),
+    [anon_sym_COMMA] = ACTIONS(62),
+    [anon_sym_Note_COLON] = ACTIONS(74),
+    [anon_sym_NOTE_COLON] = ACTIONS(74),
+    [anon_sym_Notes_COLON] = ACTIONS(74),
+    [anon_sym_Warning_COLON] = ACTIONS(74),
+    [anon_sym_WARNING_COLON] = ACTIONS(74),
+    [anon_sym_Deprecated] = ACTIONS(74),
+    [anon_sym_DEPRECATED_COLON] = ACTIONS(74),
+    [aux_sym_keycode_token1] = ACTIONS(77),
+    [aux_sym_keycode_token2] = ACTIONS(77),
+    [aux_sym_keycode_token3] = ACTIONS(77),
+    [aux_sym_keycode_token4] = ACTIONS(77),
+    [aux_sym_keycode_token5] = ACTIONS(80),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(80),
+    [aux_sym_keycode_token6] = ACTIONS(77),
+    [aux_sym_keycode_token7] = ACTIONS(77),
+    [aux_sym_uppercase_name_token1] = ACTIONS(83),
+    [anon_sym_LT] = ACTIONS(86),
+    [aux_sym_line_li_token1] = ACTIONS(89),
+    [sym_modeline] = ACTIONS(51),
+    [aux_sym_h1_token1] = ACTIONS(92),
+    [aux_sym_h2_token1] = ACTIONS(95),
+    [sym_url_word] = ACTIONS(98),
+    [anon_sym_BQUOTE] = ACTIONS(101),
   },
   [6] = {
     [sym__atom_noli] = STATE(18),
     [sym_word_noli] = STATE(18),
     [sym__atom_common] = STATE(18),
-    [sym__word_common] = STATE(85),
+    [sym__word_common] = STATE(84),
     [sym_note] = STATE(18),
     [sym_keycode] = STATE(18),
-    [sym_uppercase_name] = STATE(102),
+    [sym_uppercase_name] = STATE(103),
     [sym__uppercase_words] = STATE(18),
-    [sym_codeblock] = STATE(60),
-    [sym__blank] = STATE(40),
+    [sym_codeblock] = STATE(59),
+    [sym__blank] = STATE(41),
     [sym_line] = STATE(7),
-    [sym_line_li] = STATE(94),
-    [sym__line_noli] = STATE(60),
-    [sym_column_heading] = STATE(60),
-    [sym_h1] = STATE(60),
-    [sym_h2] = STATE(60),
-    [sym_h3] = STATE(60),
+    [sym_line_li] = STATE(95),
+    [sym__line_noli] = STATE(59),
+    [sym_column_heading] = STATE(59),
+    [sym__column_heading] = STATE(104),
+    [sym_h1] = STATE(59),
+    [sym_h2] = STATE(59),
+    [sym_h3] = STATE(59),
     [sym_tag] = STATE(18),
     [sym_url] = STATE(18),
     [sym_optionlink] = STATE(18),
@@ -11338,7 +11301,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_codespan] = STATE(18),
     [sym_argument] = STATE(18),
     [aux_sym_block_repeat1] = STATE(7),
-    [aux_sym_block_repeat2] = STATE(94),
+    [aux_sym_block_repeat2] = STATE(95),
     [aux_sym_word_noli_token1] = ACTIONS(5),
     [aux_sym_word_noli_token2] = ACTIONS(5),
     [anon_sym_STAR] = ACTIONS(7),
@@ -11369,8 +11332,8 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_keycode_token6] = ACTIONS(21),
     [aux_sym_keycode_token7] = ACTIONS(21),
     [aux_sym_uppercase_name_token1] = ACTIONS(25),
-    [anon_sym_LT] = ACTIONS(108),
-    [anon_sym_LF2] = ACTIONS(29),
+    [anon_sym_LT] = ACTIONS(104),
+    [aux_sym__blank_token1] = ACTIONS(29),
     [aux_sym_line_li_token1] = ACTIONS(31),
     [aux_sym_h1_token1] = ACTIONS(35),
     [aux_sym_h2_token1] = ACTIONS(37),
@@ -11381,18 +11344,19 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym__atom_noli] = STATE(18),
     [sym_word_noli] = STATE(18),
     [sym__atom_common] = STATE(18),
-    [sym__word_common] = STATE(85),
+    [sym__word_common] = STATE(84),
     [sym_note] = STATE(18),
     [sym_keycode] = STATE(18),
-    [sym_uppercase_name] = STATE(102),
+    [sym_uppercase_name] = STATE(103),
     [sym__uppercase_words] = STATE(18),
-    [sym_codeblock] = STATE(60),
+    [sym_codeblock] = STATE(59),
     [sym_line] = STATE(7),
-    [sym__line_noli] = STATE(60),
-    [sym_column_heading] = STATE(60),
-    [sym_h1] = STATE(60),
-    [sym_h2] = STATE(60),
-    [sym_h3] = STATE(60),
+    [sym__line_noli] = STATE(59),
+    [sym_column_heading] = STATE(59),
+    [sym__column_heading] = STATE(104),
+    [sym_h1] = STATE(59),
+    [sym_h2] = STATE(59),
+    [sym_h3] = STATE(59),
     [sym_tag] = STATE(18),
     [sym_url] = STATE(18),
     [sym_optionlink] = STATE(18),
@@ -11400,475 +11364,59 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_codespan] = STATE(18),
     [sym_argument] = STATE(18),
     [aux_sym_block_repeat1] = STATE(7),
-    [aux_sym_word_noli_token1] = ACTIONS(110),
-    [aux_sym_word_noli_token2] = ACTIONS(110),
-    [anon_sym_STAR] = ACTIONS(113),
-    [anon_sym_SQUOTE] = ACTIONS(116),
-    [aux_sym__word_common_token3] = ACTIONS(119),
-    [anon_sym_PIPE] = ACTIONS(122),
-    [anon_sym_LBRACE] = ACTIONS(125),
-    [anon_sym_LBRACE_RBRACE] = ACTIONS(119),
-    [aux_sym__word_common_token4] = ACTIONS(119),
-    [anon_sym_LPAREN] = ACTIONS(110),
-    [anon_sym_LBRACK] = ACTIONS(119),
-    [anon_sym_TILDE] = ACTIONS(119),
-    [anon_sym_GT] = ACTIONS(128),
-    [anon_sym_COMMA] = ACTIONS(119),
-    [anon_sym_Note_COLON] = ACTIONS(131),
-    [anon_sym_NOTE_COLON] = ACTIONS(131),
-    [anon_sym_Notes_COLON] = ACTIONS(131),
-    [anon_sym_Warning_COLON] = ACTIONS(131),
-    [anon_sym_WARNING_COLON] = ACTIONS(131),
-    [anon_sym_Deprecated] = ACTIONS(131),
-    [anon_sym_DEPRECATED_COLON] = ACTIONS(131),
-    [aux_sym_keycode_token1] = ACTIONS(134),
-    [aux_sym_keycode_token2] = ACTIONS(134),
-    [aux_sym_keycode_token3] = ACTIONS(134),
-    [aux_sym_keycode_token4] = ACTIONS(134),
-    [aux_sym_keycode_token5] = ACTIONS(137),
-    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(137),
-    [aux_sym_keycode_token6] = ACTIONS(134),
-    [aux_sym_keycode_token7] = ACTIONS(134),
-    [aux_sym_uppercase_name_token1] = ACTIONS(140),
-    [anon_sym_LT] = ACTIONS(143),
-    [anon_sym_LF2] = ACTIONS(145),
-    [aux_sym_line_li_token1] = ACTIONS(145),
-    [aux_sym_h1_token1] = ACTIONS(147),
-    [aux_sym_h2_token1] = ACTIONS(150),
-    [sym_url_word] = ACTIONS(153),
-    [anon_sym_BQUOTE] = ACTIONS(156),
+    [aux_sym_word_noli_token1] = ACTIONS(106),
+    [aux_sym_word_noli_token2] = ACTIONS(106),
+    [anon_sym_STAR] = ACTIONS(109),
+    [anon_sym_SQUOTE] = ACTIONS(112),
+    [aux_sym__word_common_token3] = ACTIONS(115),
+    [anon_sym_PIPE] = ACTIONS(118),
+    [anon_sym_LBRACE] = ACTIONS(121),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(115),
+    [aux_sym__word_common_token4] = ACTIONS(115),
+    [anon_sym_LPAREN] = ACTIONS(106),
+    [anon_sym_LBRACK] = ACTIONS(115),
+    [anon_sym_TILDE] = ACTIONS(115),
+    [anon_sym_GT] = ACTIONS(124),
+    [anon_sym_COMMA] = ACTIONS(115),
+    [anon_sym_Note_COLON] = ACTIONS(127),
+    [anon_sym_NOTE_COLON] = ACTIONS(127),
+    [anon_sym_Notes_COLON] = ACTIONS(127),
+    [anon_sym_Warning_COLON] = ACTIONS(127),
+    [anon_sym_WARNING_COLON] = ACTIONS(127),
+    [anon_sym_Deprecated] = ACTIONS(127),
+    [anon_sym_DEPRECATED_COLON] = ACTIONS(127),
+    [aux_sym_keycode_token1] = ACTIONS(130),
+    [aux_sym_keycode_token2] = ACTIONS(130),
+    [aux_sym_keycode_token3] = ACTIONS(130),
+    [aux_sym_keycode_token4] = ACTIONS(130),
+    [aux_sym_keycode_token5] = ACTIONS(133),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(133),
+    [aux_sym_keycode_token6] = ACTIONS(130),
+    [aux_sym_keycode_token7] = ACTIONS(130),
+    [aux_sym_uppercase_name_token1] = ACTIONS(136),
+    [anon_sym_LT] = ACTIONS(139),
+    [aux_sym__blank_token1] = ACTIONS(141),
+    [aux_sym_line_li_token1] = ACTIONS(141),
+    [aux_sym_h1_token1] = ACTIONS(143),
+    [aux_sym_h2_token1] = ACTIONS(146),
+    [sym_url_word] = ACTIONS(149),
+    [anon_sym_BQUOTE] = ACTIONS(152),
   },
   [8] = {
-    [sym__atom_noli] = STATE(17),
-    [sym_word_noli] = STATE(17),
-    [sym__atom_common] = STATE(17),
-    [sym__word_common] = STATE(85),
-    [sym_note] = STATE(17),
-    [sym_keycode] = STATE(17),
-    [sym__uppercase_words] = STATE(17),
-    [sym__line_noli] = STATE(64),
-    [sym_tag] = STATE(17),
-    [sym_url] = STATE(17),
-    [sym_optionlink] = STATE(17),
-    [sym_taglink] = STATE(17),
-    [sym_codespan] = STATE(17),
-    [sym_argument] = STATE(17),
-    [aux_sym_line_li_repeat2] = STATE(8),
-    [aux_sym_word_noli_token1] = ACTIONS(159),
-    [aux_sym_word_noli_token2] = ACTIONS(162),
-    [anon_sym_STAR] = ACTIONS(165),
-    [anon_sym_SQUOTE] = ACTIONS(168),
-    [aux_sym__word_common_token3] = ACTIONS(162),
-    [anon_sym_PIPE] = ACTIONS(171),
-    [anon_sym_LBRACE] = ACTIONS(174),
-    [anon_sym_LBRACE_RBRACE] = ACTIONS(162),
-    [aux_sym__word_common_token4] = ACTIONS(162),
-    [anon_sym_LPAREN] = ACTIONS(159),
-    [anon_sym_LBRACK] = ACTIONS(162),
-    [anon_sym_TILDE] = ACTIONS(162),
-    [anon_sym_GT] = ACTIONS(162),
-    [anon_sym_COMMA] = ACTIONS(162),
-    [anon_sym_Note_COLON] = ACTIONS(177),
-    [anon_sym_NOTE_COLON] = ACTIONS(177),
-    [anon_sym_Notes_COLON] = ACTIONS(177),
-    [anon_sym_Warning_COLON] = ACTIONS(177),
-    [anon_sym_WARNING_COLON] = ACTIONS(177),
-    [anon_sym_Deprecated] = ACTIONS(177),
-    [anon_sym_DEPRECATED_COLON] = ACTIONS(177),
-    [aux_sym_keycode_token1] = ACTIONS(180),
-    [aux_sym_keycode_token2] = ACTIONS(180),
-    [aux_sym_keycode_token3] = ACTIONS(180),
-    [aux_sym_keycode_token4] = ACTIONS(180),
-    [aux_sym_keycode_token5] = ACTIONS(183),
-    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(183),
-    [aux_sym_keycode_token6] = ACTIONS(180),
-    [aux_sym_keycode_token7] = ACTIONS(180),
-    [aux_sym_uppercase_name_token1] = ACTIONS(186),
-    [anon_sym_LT] = ACTIONS(189),
-    [anon_sym_LF2] = ACTIONS(191),
-    [aux_sym_line_li_token1] = ACTIONS(191),
-    [sym_url_word] = ACTIONS(193),
-    [anon_sym_BQUOTE] = ACTIONS(196),
-  },
-  [9] = {
-    [sym__atom_noli] = STATE(17),
-    [sym_word_noli] = STATE(17),
-    [sym__atom_common] = STATE(17),
-    [sym__word_common] = STATE(85),
-    [sym_note] = STATE(17),
-    [sym_keycode] = STATE(17),
-    [sym__uppercase_words] = STATE(17),
-    [sym__line_noli] = STATE(64),
-    [sym_tag] = STATE(17),
-    [sym_url] = STATE(17),
-    [sym_optionlink] = STATE(17),
-    [sym_taglink] = STATE(17),
-    [sym_codespan] = STATE(17),
-    [sym_argument] = STATE(17),
-    [aux_sym_line_li_repeat2] = STATE(8),
-    [aux_sym_word_noli_token1] = ACTIONS(5),
-    [aux_sym_word_noli_token2] = ACTIONS(11),
-    [anon_sym_STAR] = ACTIONS(7),
-    [anon_sym_SQUOTE] = ACTIONS(9),
-    [aux_sym__word_common_token3] = ACTIONS(11),
-    [anon_sym_PIPE] = ACTIONS(13),
-    [anon_sym_LBRACE] = ACTIONS(15),
-    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
-    [aux_sym__word_common_token4] = ACTIONS(11),
-    [anon_sym_LPAREN] = ACTIONS(5),
-    [anon_sym_LBRACK] = ACTIONS(11),
-    [anon_sym_TILDE] = ACTIONS(11),
-    [anon_sym_GT] = ACTIONS(11),
-    [anon_sym_COMMA] = ACTIONS(11),
-    [anon_sym_Note_COLON] = ACTIONS(19),
-    [anon_sym_NOTE_COLON] = ACTIONS(19),
-    [anon_sym_Notes_COLON] = ACTIONS(19),
-    [anon_sym_Warning_COLON] = ACTIONS(19),
-    [anon_sym_WARNING_COLON] = ACTIONS(19),
-    [anon_sym_Deprecated] = ACTIONS(19),
-    [anon_sym_DEPRECATED_COLON] = ACTIONS(19),
-    [aux_sym_keycode_token1] = ACTIONS(21),
-    [aux_sym_keycode_token2] = ACTIONS(21),
-    [aux_sym_keycode_token3] = ACTIONS(21),
-    [aux_sym_keycode_token4] = ACTIONS(21),
-    [aux_sym_keycode_token5] = ACTIONS(23),
-    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(23),
-    [aux_sym_keycode_token6] = ACTIONS(21),
-    [aux_sym_keycode_token7] = ACTIONS(21),
-    [aux_sym_uppercase_name_token1] = ACTIONS(199),
-    [anon_sym_LT] = ACTIONS(201),
-    [anon_sym_LF2] = ACTIONS(203),
-    [aux_sym_line_li_token1] = ACTIONS(203),
-    [sym_url_word] = ACTIONS(39),
-    [anon_sym_BQUOTE] = ACTIONS(41),
-  },
-  [10] = {
-    [sym__atom_noli] = STATE(17),
-    [sym_word_noli] = STATE(17),
-    [sym__atom_common] = STATE(17),
-    [sym__word_common] = STATE(85),
-    [sym_note] = STATE(17),
-    [sym_keycode] = STATE(17),
-    [sym__uppercase_words] = STATE(17),
-    [sym__line_noli] = STATE(64),
-    [sym_tag] = STATE(17),
-    [sym_url] = STATE(17),
-    [sym_optionlink] = STATE(17),
-    [sym_taglink] = STATE(17),
-    [sym_codespan] = STATE(17),
-    [sym_argument] = STATE(17),
-    [aux_sym_line_li_repeat2] = STATE(8),
-    [aux_sym_word_noli_token1] = ACTIONS(5),
-    [aux_sym_word_noli_token2] = ACTIONS(11),
-    [anon_sym_STAR] = ACTIONS(7),
-    [anon_sym_SQUOTE] = ACTIONS(9),
-    [aux_sym__word_common_token3] = ACTIONS(11),
-    [anon_sym_PIPE] = ACTIONS(13),
-    [anon_sym_LBRACE] = ACTIONS(15),
-    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
-    [aux_sym__word_common_token4] = ACTIONS(11),
-    [anon_sym_LPAREN] = ACTIONS(5),
-    [anon_sym_LBRACK] = ACTIONS(11),
-    [anon_sym_TILDE] = ACTIONS(11),
-    [anon_sym_GT] = ACTIONS(11),
-    [anon_sym_COMMA] = ACTIONS(11),
-    [anon_sym_Note_COLON] = ACTIONS(19),
-    [anon_sym_NOTE_COLON] = ACTIONS(19),
-    [anon_sym_Notes_COLON] = ACTIONS(19),
-    [anon_sym_Warning_COLON] = ACTIONS(19),
-    [anon_sym_WARNING_COLON] = ACTIONS(19),
-    [anon_sym_Deprecated] = ACTIONS(19),
-    [anon_sym_DEPRECATED_COLON] = ACTIONS(19),
-    [aux_sym_keycode_token1] = ACTIONS(21),
-    [aux_sym_keycode_token2] = ACTIONS(21),
-    [aux_sym_keycode_token3] = ACTIONS(21),
-    [aux_sym_keycode_token4] = ACTIONS(21),
-    [aux_sym_keycode_token5] = ACTIONS(23),
-    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(23),
-    [aux_sym_keycode_token6] = ACTIONS(21),
-    [aux_sym_keycode_token7] = ACTIONS(21),
-    [aux_sym_uppercase_name_token1] = ACTIONS(199),
-    [anon_sym_LT] = ACTIONS(205),
-    [anon_sym_LF2] = ACTIONS(207),
-    [aux_sym_line_li_token1] = ACTIONS(207),
-    [sym_url_word] = ACTIONS(39),
-    [anon_sym_BQUOTE] = ACTIONS(41),
-  },
-  [11] = {
-    [sym__atom_noli] = STATE(17),
-    [sym_word_noli] = STATE(17),
-    [sym__atom_common] = STATE(17),
-    [sym__word_common] = STATE(85),
-    [sym_note] = STATE(17),
-    [sym_keycode] = STATE(17),
-    [sym__uppercase_words] = STATE(17),
-    [sym__line_noli] = STATE(64),
-    [sym_tag] = STATE(17),
-    [sym_url] = STATE(17),
-    [sym_optionlink] = STATE(17),
-    [sym_taglink] = STATE(17),
-    [sym_codespan] = STATE(17),
-    [sym_argument] = STATE(17),
-    [aux_sym_line_li_repeat2] = STATE(8),
-    [aux_sym_word_noli_token1] = ACTIONS(5),
-    [aux_sym_word_noli_token2] = ACTIONS(11),
-    [anon_sym_STAR] = ACTIONS(7),
-    [anon_sym_SQUOTE] = ACTIONS(9),
-    [aux_sym__word_common_token3] = ACTIONS(11),
-    [anon_sym_PIPE] = ACTIONS(13),
-    [anon_sym_LBRACE] = ACTIONS(15),
-    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
-    [aux_sym__word_common_token4] = ACTIONS(11),
-    [anon_sym_LPAREN] = ACTIONS(5),
-    [anon_sym_LBRACK] = ACTIONS(11),
-    [anon_sym_TILDE] = ACTIONS(11),
-    [anon_sym_GT] = ACTIONS(11),
-    [anon_sym_COMMA] = ACTIONS(11),
-    [anon_sym_Note_COLON] = ACTIONS(19),
-    [anon_sym_NOTE_COLON] = ACTIONS(19),
-    [anon_sym_Notes_COLON] = ACTIONS(19),
-    [anon_sym_Warning_COLON] = ACTIONS(19),
-    [anon_sym_WARNING_COLON] = ACTIONS(19),
-    [anon_sym_Deprecated] = ACTIONS(19),
-    [anon_sym_DEPRECATED_COLON] = ACTIONS(19),
-    [aux_sym_keycode_token1] = ACTIONS(21),
-    [aux_sym_keycode_token2] = ACTIONS(21),
-    [aux_sym_keycode_token3] = ACTIONS(21),
-    [aux_sym_keycode_token4] = ACTIONS(21),
-    [aux_sym_keycode_token5] = ACTIONS(23),
-    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(23),
-    [aux_sym_keycode_token6] = ACTIONS(21),
-    [aux_sym_keycode_token7] = ACTIONS(21),
-    [aux_sym_uppercase_name_token1] = ACTIONS(199),
-    [anon_sym_LT] = ACTIONS(209),
-    [anon_sym_LF2] = ACTIONS(211),
-    [aux_sym_line_li_token1] = ACTIONS(211),
-    [sym_url_word] = ACTIONS(39),
-    [anon_sym_BQUOTE] = ACTIONS(41),
-  },
-  [12] = {
-    [sym__atom_noli] = STATE(17),
-    [sym_word_noli] = STATE(17),
-    [sym__atom_common] = STATE(17),
-    [sym__word_common] = STATE(85),
-    [sym_note] = STATE(17),
-    [sym_keycode] = STATE(17),
-    [sym__uppercase_words] = STATE(17),
-    [sym__line_noli] = STATE(64),
-    [sym_tag] = STATE(17),
-    [sym_url] = STATE(17),
-    [sym_optionlink] = STATE(17),
-    [sym_taglink] = STATE(17),
-    [sym_codespan] = STATE(17),
-    [sym_argument] = STATE(17),
-    [aux_sym_line_li_repeat2] = STATE(8),
-    [aux_sym_word_noli_token1] = ACTIONS(5),
-    [aux_sym_word_noli_token2] = ACTIONS(11),
-    [anon_sym_STAR] = ACTIONS(7),
-    [anon_sym_SQUOTE] = ACTIONS(9),
-    [aux_sym__word_common_token3] = ACTIONS(11),
-    [anon_sym_PIPE] = ACTIONS(13),
-    [anon_sym_LBRACE] = ACTIONS(15),
-    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
-    [aux_sym__word_common_token4] = ACTIONS(11),
-    [anon_sym_LPAREN] = ACTIONS(5),
-    [anon_sym_LBRACK] = ACTIONS(11),
-    [anon_sym_TILDE] = ACTIONS(11),
-    [anon_sym_GT] = ACTIONS(11),
-    [anon_sym_COMMA] = ACTIONS(11),
-    [anon_sym_Note_COLON] = ACTIONS(19),
-    [anon_sym_NOTE_COLON] = ACTIONS(19),
-    [anon_sym_Notes_COLON] = ACTIONS(19),
-    [anon_sym_Warning_COLON] = ACTIONS(19),
-    [anon_sym_WARNING_COLON] = ACTIONS(19),
-    [anon_sym_Deprecated] = ACTIONS(19),
-    [anon_sym_DEPRECATED_COLON] = ACTIONS(19),
-    [aux_sym_keycode_token1] = ACTIONS(21),
-    [aux_sym_keycode_token2] = ACTIONS(21),
-    [aux_sym_keycode_token3] = ACTIONS(21),
-    [aux_sym_keycode_token4] = ACTIONS(21),
-    [aux_sym_keycode_token5] = ACTIONS(23),
-    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(23),
-    [aux_sym_keycode_token6] = ACTIONS(21),
-    [aux_sym_keycode_token7] = ACTIONS(21),
-    [aux_sym_uppercase_name_token1] = ACTIONS(199),
-    [anon_sym_LT] = ACTIONS(213),
-    [anon_sym_LF2] = ACTIONS(215),
-    [aux_sym_line_li_token1] = ACTIONS(215),
-    [sym_url_word] = ACTIONS(39),
-    [anon_sym_BQUOTE] = ACTIONS(41),
-  },
-  [13] = {
-    [sym__atom_noli] = STATE(17),
-    [sym_word_noli] = STATE(17),
-    [sym__atom_common] = STATE(17),
-    [sym__word_common] = STATE(85),
-    [sym_note] = STATE(17),
-    [sym_keycode] = STATE(17),
-    [sym__uppercase_words] = STATE(17),
-    [sym__line_noli] = STATE(64),
-    [sym_tag] = STATE(17),
-    [sym_url] = STATE(17),
-    [sym_optionlink] = STATE(17),
-    [sym_taglink] = STATE(17),
-    [sym_codespan] = STATE(17),
-    [sym_argument] = STATE(17),
-    [aux_sym_line_li_repeat2] = STATE(9),
-    [aux_sym_word_noli_token1] = ACTIONS(5),
-    [aux_sym_word_noli_token2] = ACTIONS(11),
-    [anon_sym_STAR] = ACTIONS(7),
-    [anon_sym_SQUOTE] = ACTIONS(9),
-    [aux_sym__word_common_token3] = ACTIONS(11),
-    [anon_sym_PIPE] = ACTIONS(13),
-    [anon_sym_LBRACE] = ACTIONS(15),
-    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
-    [aux_sym__word_common_token4] = ACTIONS(11),
-    [anon_sym_LPAREN] = ACTIONS(5),
-    [anon_sym_LBRACK] = ACTIONS(11),
-    [anon_sym_TILDE] = ACTIONS(11),
-    [anon_sym_GT] = ACTIONS(11),
-    [anon_sym_COMMA] = ACTIONS(11),
-    [anon_sym_Note_COLON] = ACTIONS(19),
-    [anon_sym_NOTE_COLON] = ACTIONS(19),
-    [anon_sym_Notes_COLON] = ACTIONS(19),
-    [anon_sym_Warning_COLON] = ACTIONS(19),
-    [anon_sym_WARNING_COLON] = ACTIONS(19),
-    [anon_sym_Deprecated] = ACTIONS(19),
-    [anon_sym_DEPRECATED_COLON] = ACTIONS(19),
-    [aux_sym_keycode_token1] = ACTIONS(21),
-    [aux_sym_keycode_token2] = ACTIONS(21),
-    [aux_sym_keycode_token3] = ACTIONS(21),
-    [aux_sym_keycode_token4] = ACTIONS(21),
-    [aux_sym_keycode_token5] = ACTIONS(23),
-    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(23),
-    [aux_sym_keycode_token6] = ACTIONS(21),
-    [aux_sym_keycode_token7] = ACTIONS(21),
-    [aux_sym_uppercase_name_token1] = ACTIONS(199),
-    [anon_sym_LT] = ACTIONS(217),
-    [anon_sym_LF2] = ACTIONS(219),
-    [aux_sym_line_li_token1] = ACTIONS(219),
-    [sym_url_word] = ACTIONS(39),
-    [anon_sym_BQUOTE] = ACTIONS(41),
-  },
-  [14] = {
-    [sym__atom_noli] = STATE(17),
-    [sym_word_noli] = STATE(17),
-    [sym__atom_common] = STATE(17),
-    [sym__word_common] = STATE(85),
-    [sym_note] = STATE(17),
-    [sym_keycode] = STATE(17),
-    [sym__uppercase_words] = STATE(17),
-    [sym__line_noli] = STATE(64),
-    [sym_tag] = STATE(17),
-    [sym_url] = STATE(17),
-    [sym_optionlink] = STATE(17),
-    [sym_taglink] = STATE(17),
-    [sym_codespan] = STATE(17),
-    [sym_argument] = STATE(17),
-    [aux_sym_line_li_repeat2] = STATE(10),
-    [aux_sym_word_noli_token1] = ACTIONS(5),
-    [aux_sym_word_noli_token2] = ACTIONS(11),
-    [anon_sym_STAR] = ACTIONS(7),
-    [anon_sym_SQUOTE] = ACTIONS(9),
-    [aux_sym__word_common_token3] = ACTIONS(11),
-    [anon_sym_PIPE] = ACTIONS(13),
-    [anon_sym_LBRACE] = ACTIONS(15),
-    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
-    [aux_sym__word_common_token4] = ACTIONS(11),
-    [anon_sym_LPAREN] = ACTIONS(5),
-    [anon_sym_LBRACK] = ACTIONS(11),
-    [anon_sym_TILDE] = ACTIONS(11),
-    [anon_sym_GT] = ACTIONS(11),
-    [anon_sym_COMMA] = ACTIONS(11),
-    [anon_sym_Note_COLON] = ACTIONS(19),
-    [anon_sym_NOTE_COLON] = ACTIONS(19),
-    [anon_sym_Notes_COLON] = ACTIONS(19),
-    [anon_sym_Warning_COLON] = ACTIONS(19),
-    [anon_sym_WARNING_COLON] = ACTIONS(19),
-    [anon_sym_Deprecated] = ACTIONS(19),
-    [anon_sym_DEPRECATED_COLON] = ACTIONS(19),
-    [aux_sym_keycode_token1] = ACTIONS(21),
-    [aux_sym_keycode_token2] = ACTIONS(21),
-    [aux_sym_keycode_token3] = ACTIONS(21),
-    [aux_sym_keycode_token4] = ACTIONS(21),
-    [aux_sym_keycode_token5] = ACTIONS(23),
-    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(23),
-    [aux_sym_keycode_token6] = ACTIONS(21),
-    [aux_sym_keycode_token7] = ACTIONS(21),
-    [aux_sym_uppercase_name_token1] = ACTIONS(199),
-    [anon_sym_LT] = ACTIONS(221),
-    [anon_sym_LF2] = ACTIONS(223),
-    [aux_sym_line_li_token1] = ACTIONS(223),
-    [sym_url_word] = ACTIONS(39),
-    [anon_sym_BQUOTE] = ACTIONS(41),
-  },
-  [15] = {
-    [sym__atom_noli] = STATE(17),
-    [sym_word_noli] = STATE(17),
-    [sym__atom_common] = STATE(17),
-    [sym__word_common] = STATE(85),
-    [sym_note] = STATE(17),
-    [sym_keycode] = STATE(17),
-    [sym__uppercase_words] = STATE(17),
-    [sym__line_noli] = STATE(64),
-    [sym_tag] = STATE(17),
-    [sym_url] = STATE(17),
-    [sym_optionlink] = STATE(17),
-    [sym_taglink] = STATE(17),
-    [sym_codespan] = STATE(17),
-    [sym_argument] = STATE(17),
-    [aux_sym_line_li_repeat2] = STATE(11),
-    [aux_sym_word_noli_token1] = ACTIONS(5),
-    [aux_sym_word_noli_token2] = ACTIONS(11),
-    [anon_sym_STAR] = ACTIONS(7),
-    [anon_sym_SQUOTE] = ACTIONS(9),
-    [aux_sym__word_common_token3] = ACTIONS(11),
-    [anon_sym_PIPE] = ACTIONS(13),
-    [anon_sym_LBRACE] = ACTIONS(15),
-    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
-    [aux_sym__word_common_token4] = ACTIONS(11),
-    [anon_sym_LPAREN] = ACTIONS(5),
-    [anon_sym_LBRACK] = ACTIONS(11),
-    [anon_sym_TILDE] = ACTIONS(11),
-    [anon_sym_GT] = ACTIONS(11),
-    [anon_sym_COMMA] = ACTIONS(11),
-    [anon_sym_Note_COLON] = ACTIONS(19),
-    [anon_sym_NOTE_COLON] = ACTIONS(19),
-    [anon_sym_Notes_COLON] = ACTIONS(19),
-    [anon_sym_Warning_COLON] = ACTIONS(19),
-    [anon_sym_WARNING_COLON] = ACTIONS(19),
-    [anon_sym_Deprecated] = ACTIONS(19),
-    [anon_sym_DEPRECATED_COLON] = ACTIONS(19),
-    [aux_sym_keycode_token1] = ACTIONS(21),
-    [aux_sym_keycode_token2] = ACTIONS(21),
-    [aux_sym_keycode_token3] = ACTIONS(21),
-    [aux_sym_keycode_token4] = ACTIONS(21),
-    [aux_sym_keycode_token5] = ACTIONS(23),
-    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(23),
-    [aux_sym_keycode_token6] = ACTIONS(21),
-    [aux_sym_keycode_token7] = ACTIONS(21),
-    [aux_sym_uppercase_name_token1] = ACTIONS(199),
-    [anon_sym_LT] = ACTIONS(225),
-    [anon_sym_LF2] = ACTIONS(227),
-    [aux_sym_line_li_token1] = ACTIONS(227),
-    [sym_url_word] = ACTIONS(39),
-    [anon_sym_BQUOTE] = ACTIONS(41),
-  },
-  [16] = {
-    [sym__atom_noli] = STATE(17),
-    [sym_word_noli] = STATE(17),
-    [sym__atom_common] = STATE(17),
-    [sym__word_common] = STATE(85),
-    [sym_note] = STATE(17),
-    [sym_keycode] = STATE(17),
-    [sym__uppercase_words] = STATE(17),
-    [sym__line_noli] = STATE(64),
-    [sym_tag] = STATE(17),
-    [sym_url] = STATE(17),
-    [sym_optionlink] = STATE(17),
-    [sym_taglink] = STATE(17),
-    [sym_codespan] = STATE(17),
-    [sym_argument] = STATE(17),
+    [sym__atom_noli] = STATE(20),
+    [sym_word_noli] = STATE(20),
+    [sym__atom_common] = STATE(20),
+    [sym__word_common] = STATE(84),
+    [sym_note] = STATE(20),
+    [sym_keycode] = STATE(20),
+    [sym__uppercase_words] = STATE(20),
+    [sym__line_noli] = STATE(66),
+    [sym_tag] = STATE(20),
+    [sym_url] = STATE(20),
+    [sym_optionlink] = STATE(20),
+    [sym_taglink] = STATE(20),
+    [sym_codespan] = STATE(20),
+    [sym_argument] = STATE(20),
     [aux_sym_line_li_repeat2] = STATE(12),
     [aux_sym_word_noli_token1] = ACTIONS(5),
     [aux_sym_word_noli_token2] = ACTIONS(11),
@@ -11899,10 +11447,426 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(23),
     [aux_sym_keycode_token6] = ACTIONS(21),
     [aux_sym_keycode_token7] = ACTIONS(21),
-    [aux_sym_uppercase_name_token1] = ACTIONS(199),
-    [anon_sym_LT] = ACTIONS(229),
-    [anon_sym_LF2] = ACTIONS(231),
-    [aux_sym_line_li_token1] = ACTIONS(231),
+    [aux_sym_uppercase_name_token1] = ACTIONS(155),
+    [anon_sym_LT] = ACTIONS(157),
+    [aux_sym__blank_token1] = ACTIONS(159),
+    [aux_sym_line_li_token1] = ACTIONS(159),
+    [sym_url_word] = ACTIONS(39),
+    [anon_sym_BQUOTE] = ACTIONS(41),
+  },
+  [9] = {
+    [sym__atom_noli] = STATE(20),
+    [sym_word_noli] = STATE(20),
+    [sym__atom_common] = STATE(20),
+    [sym__word_common] = STATE(84),
+    [sym_note] = STATE(20),
+    [sym_keycode] = STATE(20),
+    [sym__uppercase_words] = STATE(20),
+    [sym__line_noli] = STATE(66),
+    [sym_tag] = STATE(20),
+    [sym_url] = STATE(20),
+    [sym_optionlink] = STATE(20),
+    [sym_taglink] = STATE(20),
+    [sym_codespan] = STATE(20),
+    [sym_argument] = STATE(20),
+    [aux_sym_line_li_repeat2] = STATE(9),
+    [aux_sym_word_noli_token1] = ACTIONS(161),
+    [aux_sym_word_noli_token2] = ACTIONS(164),
+    [anon_sym_STAR] = ACTIONS(167),
+    [anon_sym_SQUOTE] = ACTIONS(170),
+    [aux_sym__word_common_token3] = ACTIONS(164),
+    [anon_sym_PIPE] = ACTIONS(173),
+    [anon_sym_LBRACE] = ACTIONS(176),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(164),
+    [aux_sym__word_common_token4] = ACTIONS(164),
+    [anon_sym_LPAREN] = ACTIONS(161),
+    [anon_sym_LBRACK] = ACTIONS(164),
+    [anon_sym_TILDE] = ACTIONS(164),
+    [anon_sym_GT] = ACTIONS(164),
+    [anon_sym_COMMA] = ACTIONS(164),
+    [anon_sym_Note_COLON] = ACTIONS(179),
+    [anon_sym_NOTE_COLON] = ACTIONS(179),
+    [anon_sym_Notes_COLON] = ACTIONS(179),
+    [anon_sym_Warning_COLON] = ACTIONS(179),
+    [anon_sym_WARNING_COLON] = ACTIONS(179),
+    [anon_sym_Deprecated] = ACTIONS(179),
+    [anon_sym_DEPRECATED_COLON] = ACTIONS(179),
+    [aux_sym_keycode_token1] = ACTIONS(182),
+    [aux_sym_keycode_token2] = ACTIONS(182),
+    [aux_sym_keycode_token3] = ACTIONS(182),
+    [aux_sym_keycode_token4] = ACTIONS(182),
+    [aux_sym_keycode_token5] = ACTIONS(185),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(185),
+    [aux_sym_keycode_token6] = ACTIONS(182),
+    [aux_sym_keycode_token7] = ACTIONS(182),
+    [aux_sym_uppercase_name_token1] = ACTIONS(188),
+    [anon_sym_LT] = ACTIONS(191),
+    [aux_sym__blank_token1] = ACTIONS(193),
+    [aux_sym_line_li_token1] = ACTIONS(193),
+    [sym_url_word] = ACTIONS(195),
+    [anon_sym_BQUOTE] = ACTIONS(198),
+  },
+  [10] = {
+    [sym__atom_noli] = STATE(20),
+    [sym_word_noli] = STATE(20),
+    [sym__atom_common] = STATE(20),
+    [sym__word_common] = STATE(84),
+    [sym_note] = STATE(20),
+    [sym_keycode] = STATE(20),
+    [sym__uppercase_words] = STATE(20),
+    [sym__line_noli] = STATE(66),
+    [sym_tag] = STATE(20),
+    [sym_url] = STATE(20),
+    [sym_optionlink] = STATE(20),
+    [sym_taglink] = STATE(20),
+    [sym_codespan] = STATE(20),
+    [sym_argument] = STATE(20),
+    [aux_sym_line_li_repeat2] = STATE(9),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(7),
+    [anon_sym_SQUOTE] = ACTIONS(9),
+    [aux_sym__word_common_token3] = ACTIONS(11),
+    [anon_sym_PIPE] = ACTIONS(13),
+    [anon_sym_LBRACE] = ACTIONS(15),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(11),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(11),
+    [anon_sym_TILDE] = ACTIONS(11),
+    [anon_sym_GT] = ACTIONS(11),
+    [anon_sym_COMMA] = ACTIONS(11),
+    [anon_sym_Note_COLON] = ACTIONS(19),
+    [anon_sym_NOTE_COLON] = ACTIONS(19),
+    [anon_sym_Notes_COLON] = ACTIONS(19),
+    [anon_sym_Warning_COLON] = ACTIONS(19),
+    [anon_sym_WARNING_COLON] = ACTIONS(19),
+    [anon_sym_Deprecated] = ACTIONS(19),
+    [anon_sym_DEPRECATED_COLON] = ACTIONS(19),
+    [aux_sym_keycode_token1] = ACTIONS(21),
+    [aux_sym_keycode_token2] = ACTIONS(21),
+    [aux_sym_keycode_token3] = ACTIONS(21),
+    [aux_sym_keycode_token4] = ACTIONS(21),
+    [aux_sym_keycode_token5] = ACTIONS(23),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(23),
+    [aux_sym_keycode_token6] = ACTIONS(21),
+    [aux_sym_keycode_token7] = ACTIONS(21),
+    [aux_sym_uppercase_name_token1] = ACTIONS(155),
+    [anon_sym_LT] = ACTIONS(201),
+    [aux_sym__blank_token1] = ACTIONS(203),
+    [aux_sym_line_li_token1] = ACTIONS(203),
+    [sym_url_word] = ACTIONS(39),
+    [anon_sym_BQUOTE] = ACTIONS(41),
+  },
+  [11] = {
+    [sym__atom_noli] = STATE(20),
+    [sym_word_noli] = STATE(20),
+    [sym__atom_common] = STATE(20),
+    [sym__word_common] = STATE(84),
+    [sym_note] = STATE(20),
+    [sym_keycode] = STATE(20),
+    [sym__uppercase_words] = STATE(20),
+    [sym__line_noli] = STATE(66),
+    [sym_tag] = STATE(20),
+    [sym_url] = STATE(20),
+    [sym_optionlink] = STATE(20),
+    [sym_taglink] = STATE(20),
+    [sym_codespan] = STATE(20),
+    [sym_argument] = STATE(20),
+    [aux_sym_line_li_repeat2] = STATE(9),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(7),
+    [anon_sym_SQUOTE] = ACTIONS(9),
+    [aux_sym__word_common_token3] = ACTIONS(11),
+    [anon_sym_PIPE] = ACTIONS(13),
+    [anon_sym_LBRACE] = ACTIONS(15),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(11),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(11),
+    [anon_sym_TILDE] = ACTIONS(11),
+    [anon_sym_GT] = ACTIONS(11),
+    [anon_sym_COMMA] = ACTIONS(11),
+    [anon_sym_Note_COLON] = ACTIONS(19),
+    [anon_sym_NOTE_COLON] = ACTIONS(19),
+    [anon_sym_Notes_COLON] = ACTIONS(19),
+    [anon_sym_Warning_COLON] = ACTIONS(19),
+    [anon_sym_WARNING_COLON] = ACTIONS(19),
+    [anon_sym_Deprecated] = ACTIONS(19),
+    [anon_sym_DEPRECATED_COLON] = ACTIONS(19),
+    [aux_sym_keycode_token1] = ACTIONS(21),
+    [aux_sym_keycode_token2] = ACTIONS(21),
+    [aux_sym_keycode_token3] = ACTIONS(21),
+    [aux_sym_keycode_token4] = ACTIONS(21),
+    [aux_sym_keycode_token5] = ACTIONS(23),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(23),
+    [aux_sym_keycode_token6] = ACTIONS(21),
+    [aux_sym_keycode_token7] = ACTIONS(21),
+    [aux_sym_uppercase_name_token1] = ACTIONS(155),
+    [anon_sym_LT] = ACTIONS(205),
+    [aux_sym__blank_token1] = ACTIONS(207),
+    [aux_sym_line_li_token1] = ACTIONS(207),
+    [sym_url_word] = ACTIONS(39),
+    [anon_sym_BQUOTE] = ACTIONS(41),
+  },
+  [12] = {
+    [sym__atom_noli] = STATE(20),
+    [sym_word_noli] = STATE(20),
+    [sym__atom_common] = STATE(20),
+    [sym__word_common] = STATE(84),
+    [sym_note] = STATE(20),
+    [sym_keycode] = STATE(20),
+    [sym__uppercase_words] = STATE(20),
+    [sym__line_noli] = STATE(66),
+    [sym_tag] = STATE(20),
+    [sym_url] = STATE(20),
+    [sym_optionlink] = STATE(20),
+    [sym_taglink] = STATE(20),
+    [sym_codespan] = STATE(20),
+    [sym_argument] = STATE(20),
+    [aux_sym_line_li_repeat2] = STATE(9),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(7),
+    [anon_sym_SQUOTE] = ACTIONS(9),
+    [aux_sym__word_common_token3] = ACTIONS(11),
+    [anon_sym_PIPE] = ACTIONS(13),
+    [anon_sym_LBRACE] = ACTIONS(15),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(11),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(11),
+    [anon_sym_TILDE] = ACTIONS(11),
+    [anon_sym_GT] = ACTIONS(11),
+    [anon_sym_COMMA] = ACTIONS(11),
+    [anon_sym_Note_COLON] = ACTIONS(19),
+    [anon_sym_NOTE_COLON] = ACTIONS(19),
+    [anon_sym_Notes_COLON] = ACTIONS(19),
+    [anon_sym_Warning_COLON] = ACTIONS(19),
+    [anon_sym_WARNING_COLON] = ACTIONS(19),
+    [anon_sym_Deprecated] = ACTIONS(19),
+    [anon_sym_DEPRECATED_COLON] = ACTIONS(19),
+    [aux_sym_keycode_token1] = ACTIONS(21),
+    [aux_sym_keycode_token2] = ACTIONS(21),
+    [aux_sym_keycode_token3] = ACTIONS(21),
+    [aux_sym_keycode_token4] = ACTIONS(21),
+    [aux_sym_keycode_token5] = ACTIONS(23),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(23),
+    [aux_sym_keycode_token6] = ACTIONS(21),
+    [aux_sym_keycode_token7] = ACTIONS(21),
+    [aux_sym_uppercase_name_token1] = ACTIONS(155),
+    [anon_sym_LT] = ACTIONS(209),
+    [aux_sym__blank_token1] = ACTIONS(211),
+    [aux_sym_line_li_token1] = ACTIONS(211),
+    [sym_url_word] = ACTIONS(39),
+    [anon_sym_BQUOTE] = ACTIONS(41),
+  },
+  [13] = {
+    [sym__atom_noli] = STATE(20),
+    [sym_word_noli] = STATE(20),
+    [sym__atom_common] = STATE(20),
+    [sym__word_common] = STATE(84),
+    [sym_note] = STATE(20),
+    [sym_keycode] = STATE(20),
+    [sym__uppercase_words] = STATE(20),
+    [sym__line_noli] = STATE(66),
+    [sym_tag] = STATE(20),
+    [sym_url] = STATE(20),
+    [sym_optionlink] = STATE(20),
+    [sym_taglink] = STATE(20),
+    [sym_codespan] = STATE(20),
+    [sym_argument] = STATE(20),
+    [aux_sym_line_li_repeat2] = STATE(9),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(7),
+    [anon_sym_SQUOTE] = ACTIONS(9),
+    [aux_sym__word_common_token3] = ACTIONS(11),
+    [anon_sym_PIPE] = ACTIONS(13),
+    [anon_sym_LBRACE] = ACTIONS(15),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(11),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(11),
+    [anon_sym_TILDE] = ACTIONS(11),
+    [anon_sym_GT] = ACTIONS(11),
+    [anon_sym_COMMA] = ACTIONS(11),
+    [anon_sym_Note_COLON] = ACTIONS(19),
+    [anon_sym_NOTE_COLON] = ACTIONS(19),
+    [anon_sym_Notes_COLON] = ACTIONS(19),
+    [anon_sym_Warning_COLON] = ACTIONS(19),
+    [anon_sym_WARNING_COLON] = ACTIONS(19),
+    [anon_sym_Deprecated] = ACTIONS(19),
+    [anon_sym_DEPRECATED_COLON] = ACTIONS(19),
+    [aux_sym_keycode_token1] = ACTIONS(21),
+    [aux_sym_keycode_token2] = ACTIONS(21),
+    [aux_sym_keycode_token3] = ACTIONS(21),
+    [aux_sym_keycode_token4] = ACTIONS(21),
+    [aux_sym_keycode_token5] = ACTIONS(23),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(23),
+    [aux_sym_keycode_token6] = ACTIONS(21),
+    [aux_sym_keycode_token7] = ACTIONS(21),
+    [aux_sym_uppercase_name_token1] = ACTIONS(155),
+    [anon_sym_LT] = ACTIONS(213),
+    [aux_sym__blank_token1] = ACTIONS(215),
+    [aux_sym_line_li_token1] = ACTIONS(215),
+    [sym_url_word] = ACTIONS(39),
+    [anon_sym_BQUOTE] = ACTIONS(41),
+  },
+  [14] = {
+    [sym__atom_noli] = STATE(20),
+    [sym_word_noli] = STATE(20),
+    [sym__atom_common] = STATE(20),
+    [sym__word_common] = STATE(84),
+    [sym_note] = STATE(20),
+    [sym_keycode] = STATE(20),
+    [sym__uppercase_words] = STATE(20),
+    [sym__line_noli] = STATE(66),
+    [sym_tag] = STATE(20),
+    [sym_url] = STATE(20),
+    [sym_optionlink] = STATE(20),
+    [sym_taglink] = STATE(20),
+    [sym_codespan] = STATE(20),
+    [sym_argument] = STATE(20),
+    [aux_sym_line_li_repeat2] = STATE(10),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(7),
+    [anon_sym_SQUOTE] = ACTIONS(9),
+    [aux_sym__word_common_token3] = ACTIONS(11),
+    [anon_sym_PIPE] = ACTIONS(13),
+    [anon_sym_LBRACE] = ACTIONS(15),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(11),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(11),
+    [anon_sym_TILDE] = ACTIONS(11),
+    [anon_sym_GT] = ACTIONS(11),
+    [anon_sym_COMMA] = ACTIONS(11),
+    [anon_sym_Note_COLON] = ACTIONS(19),
+    [anon_sym_NOTE_COLON] = ACTIONS(19),
+    [anon_sym_Notes_COLON] = ACTIONS(19),
+    [anon_sym_Warning_COLON] = ACTIONS(19),
+    [anon_sym_WARNING_COLON] = ACTIONS(19),
+    [anon_sym_Deprecated] = ACTIONS(19),
+    [anon_sym_DEPRECATED_COLON] = ACTIONS(19),
+    [aux_sym_keycode_token1] = ACTIONS(21),
+    [aux_sym_keycode_token2] = ACTIONS(21),
+    [aux_sym_keycode_token3] = ACTIONS(21),
+    [aux_sym_keycode_token4] = ACTIONS(21),
+    [aux_sym_keycode_token5] = ACTIONS(23),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(23),
+    [aux_sym_keycode_token6] = ACTIONS(21),
+    [aux_sym_keycode_token7] = ACTIONS(21),
+    [aux_sym_uppercase_name_token1] = ACTIONS(155),
+    [anon_sym_LT] = ACTIONS(217),
+    [aux_sym__blank_token1] = ACTIONS(219),
+    [aux_sym_line_li_token1] = ACTIONS(219),
+    [sym_url_word] = ACTIONS(39),
+    [anon_sym_BQUOTE] = ACTIONS(41),
+  },
+  [15] = {
+    [sym__atom_noli] = STATE(20),
+    [sym_word_noli] = STATE(20),
+    [sym__atom_common] = STATE(20),
+    [sym__word_common] = STATE(84),
+    [sym_note] = STATE(20),
+    [sym_keycode] = STATE(20),
+    [sym__uppercase_words] = STATE(20),
+    [sym__line_noli] = STATE(66),
+    [sym_tag] = STATE(20),
+    [sym_url] = STATE(20),
+    [sym_optionlink] = STATE(20),
+    [sym_taglink] = STATE(20),
+    [sym_codespan] = STATE(20),
+    [sym_argument] = STATE(20),
+    [aux_sym_line_li_repeat2] = STATE(11),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(7),
+    [anon_sym_SQUOTE] = ACTIONS(9),
+    [aux_sym__word_common_token3] = ACTIONS(11),
+    [anon_sym_PIPE] = ACTIONS(13),
+    [anon_sym_LBRACE] = ACTIONS(15),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(11),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(11),
+    [anon_sym_TILDE] = ACTIONS(11),
+    [anon_sym_GT] = ACTIONS(11),
+    [anon_sym_COMMA] = ACTIONS(11),
+    [anon_sym_Note_COLON] = ACTIONS(19),
+    [anon_sym_NOTE_COLON] = ACTIONS(19),
+    [anon_sym_Notes_COLON] = ACTIONS(19),
+    [anon_sym_Warning_COLON] = ACTIONS(19),
+    [anon_sym_WARNING_COLON] = ACTIONS(19),
+    [anon_sym_Deprecated] = ACTIONS(19),
+    [anon_sym_DEPRECATED_COLON] = ACTIONS(19),
+    [aux_sym_keycode_token1] = ACTIONS(21),
+    [aux_sym_keycode_token2] = ACTIONS(21),
+    [aux_sym_keycode_token3] = ACTIONS(21),
+    [aux_sym_keycode_token4] = ACTIONS(21),
+    [aux_sym_keycode_token5] = ACTIONS(23),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(23),
+    [aux_sym_keycode_token6] = ACTIONS(21),
+    [aux_sym_keycode_token7] = ACTIONS(21),
+    [aux_sym_uppercase_name_token1] = ACTIONS(155),
+    [anon_sym_LT] = ACTIONS(221),
+    [aux_sym__blank_token1] = ACTIONS(223),
+    [aux_sym_line_li_token1] = ACTIONS(223),
+    [sym_url_word] = ACTIONS(39),
+    [anon_sym_BQUOTE] = ACTIONS(41),
+  },
+  [16] = {
+    [sym__atom_noli] = STATE(20),
+    [sym_word_noli] = STATE(20),
+    [sym__atom_common] = STATE(20),
+    [sym__word_common] = STATE(84),
+    [sym_note] = STATE(20),
+    [sym_keycode] = STATE(20),
+    [sym__uppercase_words] = STATE(20),
+    [sym__line_noli] = STATE(66),
+    [sym_tag] = STATE(20),
+    [sym_url] = STATE(20),
+    [sym_optionlink] = STATE(20),
+    [sym_taglink] = STATE(20),
+    [sym_codespan] = STATE(20),
+    [sym_argument] = STATE(20),
+    [aux_sym_line_li_repeat2] = STATE(13),
+    [aux_sym_word_noli_token1] = ACTIONS(5),
+    [aux_sym_word_noli_token2] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(7),
+    [anon_sym_SQUOTE] = ACTIONS(9),
+    [aux_sym__word_common_token3] = ACTIONS(11),
+    [anon_sym_PIPE] = ACTIONS(13),
+    [anon_sym_LBRACE] = ACTIONS(15),
+    [anon_sym_LBRACE_RBRACE] = ACTIONS(11),
+    [aux_sym__word_common_token4] = ACTIONS(11),
+    [anon_sym_LPAREN] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(11),
+    [anon_sym_TILDE] = ACTIONS(11),
+    [anon_sym_GT] = ACTIONS(11),
+    [anon_sym_COMMA] = ACTIONS(11),
+    [anon_sym_Note_COLON] = ACTIONS(19),
+    [anon_sym_NOTE_COLON] = ACTIONS(19),
+    [anon_sym_Notes_COLON] = ACTIONS(19),
+    [anon_sym_Warning_COLON] = ACTIONS(19),
+    [anon_sym_WARNING_COLON] = ACTIONS(19),
+    [anon_sym_Deprecated] = ACTIONS(19),
+    [anon_sym_DEPRECATED_COLON] = ACTIONS(19),
+    [aux_sym_keycode_token1] = ACTIONS(21),
+    [aux_sym_keycode_token2] = ACTIONS(21),
+    [aux_sym_keycode_token3] = ACTIONS(21),
+    [aux_sym_keycode_token4] = ACTIONS(21),
+    [aux_sym_keycode_token5] = ACTIONS(23),
+    [anon_sym_CTRL_DASH_LBRACEchar_RBRACE] = ACTIONS(23),
+    [aux_sym_keycode_token6] = ACTIONS(21),
+    [aux_sym_keycode_token7] = ACTIONS(21),
+    [aux_sym_uppercase_name_token1] = ACTIONS(155),
+    [anon_sym_LT] = ACTIONS(225),
+    [aux_sym__blank_token1] = ACTIONS(227),
+    [aux_sym_line_li_token1] = ACTIONS(227),
     [sym_url_word] = ACTIONS(39),
     [anon_sym_BQUOTE] = ACTIONS(41),
   },
@@ -11922,17 +11886,17 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(41), 1,
       anon_sym_BQUOTE,
-    ACTIONS(233), 1,
+    ACTIONS(229), 1,
       aux_sym_word_token1,
-    ACTIONS(237), 1,
+    ACTIONS(233), 1,
       anon_sym_GT,
-    ACTIONS(239), 1,
-      anon_sym_LF2,
-    STATE(20), 1,
-      aux_sym_line_li_repeat1,
-    STATE(63), 1,
+    ACTIONS(235), 1,
+      aux_sym__blank_token1,
+    STATE(14), 1,
       sym_codeblock,
-    STATE(84), 1,
+    STATE(25), 1,
+      aux_sym_line_li_repeat1,
+    STATE(88), 1,
       sym__word_common,
     ACTIONS(21), 3,
       aux_sym_keycode_token1,
@@ -11952,7 +11916,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_WARNING_COLON,
       anon_sym_Deprecated,
       anon_sym_DEPRECATED_COLON,
-    ACTIONS(235), 7,
+    ACTIONS(231), 7,
       aux_sym__word_common_token3,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
@@ -11960,7 +11924,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_COMMA,
-    STATE(88), 11,
+    STATE(90), 11,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -11987,17 +11951,17 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(41), 1,
       anon_sym_BQUOTE,
-    ACTIONS(233), 1,
+    ACTIONS(229), 1,
       aux_sym_word_token1,
-    ACTIONS(241), 1,
+    ACTIONS(237), 1,
       anon_sym_TILDE,
-    ACTIONS(243), 1,
-      anon_sym_LF2,
+    ACTIONS(240), 1,
+      aux_sym__blank_token1,
     STATE(21), 1,
       aux_sym_line_li_repeat1,
     STATE(52), 1,
       sym_codeblock,
-    STATE(84), 1,
+    STATE(88), 1,
       sym__word_common,
     ACTIONS(21), 3,
       aux_sym_keycode_token1,
@@ -12009,7 +11973,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-    ACTIONS(235), 6,
+    ACTIONS(231), 6,
       aux_sym__word_common_token3,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
@@ -12024,7 +11988,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_WARNING_COLON,
       anon_sym_Deprecated,
       anon_sym_DEPRECATED_COLON,
-    STATE(88), 11,
+    STATE(90), 11,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -12049,17 +12013,17 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(41), 1,
       anon_sym_BQUOTE,
-    ACTIONS(233), 1,
+    ACTIONS(229), 1,
       aux_sym_word_token1,
-    ACTIONS(237), 1,
+    ACTIONS(233), 1,
       anon_sym_GT,
-    ACTIONS(245), 1,
-      anon_sym_LF2,
-    STATE(13), 1,
-      sym_codeblock,
-    STATE(23), 1,
+    ACTIONS(242), 1,
+      aux_sym__blank_token1,
+    STATE(25), 1,
       aux_sym_line_li_repeat1,
-    STATE(84), 1,
+    STATE(67), 1,
+      sym_codeblock,
+    STATE(88), 1,
       sym__word_common,
     ACTIONS(21), 3,
       aux_sym_keycode_token1,
@@ -12079,7 +12043,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_WARNING_COLON,
       anon_sym_Deprecated,
       anon_sym_DEPRECATED_COLON,
-    ACTIONS(235), 7,
+    ACTIONS(231), 7,
       aux_sym__word_common_token3,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
@@ -12087,7 +12051,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_COMMA,
-    STATE(88), 11,
+    STATE(90), 11,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -12112,17 +12076,17 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(41), 1,
       anon_sym_BQUOTE,
-    ACTIONS(233), 1,
+    ACTIONS(229), 1,
       aux_sym_word_token1,
-    ACTIONS(237), 1,
+    ACTIONS(233), 1,
       anon_sym_GT,
-    ACTIONS(247), 1,
-      anon_sym_LF2,
-    STATE(23), 1,
+    ACTIONS(244), 1,
+      aux_sym__blank_token1,
+    STATE(19), 1,
       aux_sym_line_li_repeat1,
     STATE(65), 1,
       sym_codeblock,
-    STATE(84), 1,
+    STATE(88), 1,
       sym__word_common,
     ACTIONS(21), 3,
       aux_sym_keycode_token1,
@@ -12142,7 +12106,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_WARNING_COLON,
       anon_sym_Deprecated,
       anon_sym_DEPRECATED_COLON,
-    ACTIONS(235), 7,
+    ACTIONS(231), 7,
       aux_sym__word_common_token3,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
@@ -12150,7 +12114,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_COMMA,
-    STATE(88), 11,
+    STATE(90), 11,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -12177,17 +12141,17 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(41), 1,
       anon_sym_BQUOTE,
-    ACTIONS(233), 1,
+    ACTIONS(229), 1,
       aux_sym_word_token1,
-    ACTIONS(249), 1,
+    ACTIONS(246), 1,
       anon_sym_TILDE,
-    ACTIONS(251), 1,
-      anon_sym_LF2,
-    STATE(23), 1,
+    ACTIONS(249), 1,
+      aux_sym__blank_token1,
+    STATE(25), 1,
       aux_sym_line_li_repeat1,
-    STATE(54), 1,
+    STATE(57), 1,
       sym_codeblock,
-    STATE(84), 1,
+    STATE(88), 1,
       sym__word_common,
     ACTIONS(21), 3,
       aux_sym_keycode_token1,
@@ -12199,7 +12163,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-    ACTIONS(235), 6,
+    ACTIONS(231), 6,
       aux_sym__word_common_token3,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
@@ -12214,7 +12178,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_WARNING_COLON,
       anon_sym_Deprecated,
       anon_sym_DEPRECATED_COLON,
-    STATE(88), 11,
+    STATE(90), 11,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -12239,17 +12203,17 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(41), 1,
       anon_sym_BQUOTE,
-    ACTIONS(233), 1,
+    ACTIONS(229), 1,
       aux_sym_word_token1,
-    ACTIONS(237), 1,
+    ACTIONS(233), 1,
       anon_sym_GT,
-    ACTIONS(253), 1,
-      anon_sym_LF2,
-    STATE(15), 1,
+    ACTIONS(251), 1,
+      aux_sym__blank_token1,
+    STATE(8), 1,
       sym_codeblock,
-    STATE(23), 1,
+    STATE(25), 1,
       aux_sym_line_li_repeat1,
-    STATE(84), 1,
+    STATE(88), 1,
       sym__word_common,
     ACTIONS(21), 3,
       aux_sym_keycode_token1,
@@ -12269,7 +12233,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_WARNING_COLON,
       anon_sym_Deprecated,
       anon_sym_DEPRECATED_COLON,
-    ACTIONS(235), 7,
+    ACTIONS(231), 7,
       aux_sym__word_common_token3,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
@@ -12277,7 +12241,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_COMMA,
-    STATE(88), 11,
+    STATE(90), 11,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -12290,37 +12254,37 @@ static const uint16_t ts_small_parse_table[] = {
       sym_codespan,
       sym_argument,
   [484] = 15,
-    ACTIONS(255), 1,
-      aux_sym_word_token1,
-    ACTIONS(258), 1,
+    ACTIONS(7), 1,
       anon_sym_STAR,
-    ACTIONS(261), 1,
+    ACTIONS(9), 1,
       anon_sym_SQUOTE,
-    ACTIONS(267), 1,
+    ACTIONS(13), 1,
       anon_sym_PIPE,
-    ACTIONS(270), 1,
+    ACTIONS(15), 1,
       anon_sym_LBRACE,
-    ACTIONS(282), 1,
-      anon_sym_LF2,
-    ACTIONS(284), 1,
+    ACTIONS(39), 1,
       sym_url_word,
-    ACTIONS(287), 1,
+    ACTIONS(41), 1,
       anon_sym_BQUOTE,
-    STATE(23), 1,
+    ACTIONS(229), 1,
+      aux_sym_word_token1,
+    ACTIONS(253), 1,
+      aux_sym__blank_token1,
+    STATE(30), 1,
       aux_sym_line_li_repeat1,
-    STATE(84), 1,
+    STATE(88), 1,
       sym__word_common,
-    ACTIONS(276), 3,
+    ACTIONS(21), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(279), 5,
+    ACTIONS(23), 5,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-    ACTIONS(273), 7,
+    ACTIONS(19), 7,
       anon_sym_Note_COLON,
       anon_sym_NOTE_COLON,
       anon_sym_Notes_COLON,
@@ -12328,7 +12292,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_WARNING_COLON,
       anon_sym_Deprecated,
       anon_sym_DEPRECATED_COLON,
-    ACTIONS(264), 8,
+    ACTIONS(231), 8,
       aux_sym__word_common_token3,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
@@ -12337,7 +12301,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_GT,
       anon_sym_COMMA,
-    STATE(88), 11,
+    STATE(90), 11,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -12362,13 +12326,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(41), 1,
       anon_sym_BQUOTE,
-    ACTIONS(233), 1,
+    ACTIONS(229), 1,
       aux_sym_word_token1,
-    ACTIONS(290), 1,
-      anon_sym_LF2,
-    STATE(23), 1,
+    ACTIONS(255), 1,
+      aux_sym__blank_token1,
+    STATE(27), 1,
       aux_sym_line_li_repeat1,
-    STATE(84), 1,
+    STATE(88), 1,
       sym__word_common,
     ACTIONS(21), 3,
       aux_sym_keycode_token1,
@@ -12388,7 +12352,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_WARNING_COLON,
       anon_sym_Deprecated,
       anon_sym_DEPRECATED_COLON,
-    ACTIONS(235), 8,
+    ACTIONS(231), 8,
       aux_sym__word_common_token3,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
@@ -12397,7 +12361,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_GT,
       anon_sym_COMMA,
-    STATE(88), 11,
+    STATE(90), 11,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -12410,37 +12374,37 @@ static const uint16_t ts_small_parse_table[] = {
       sym_codespan,
       sym_argument,
   [634] = 15,
-    ACTIONS(7), 1,
-      anon_sym_STAR,
-    ACTIONS(9), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(13), 1,
-      anon_sym_PIPE,
-    ACTIONS(15), 1,
-      anon_sym_LBRACE,
-    ACTIONS(39), 1,
-      sym_url_word,
-    ACTIONS(41), 1,
-      anon_sym_BQUOTE,
-    ACTIONS(233), 1,
+    ACTIONS(257), 1,
       aux_sym_word_token1,
-    ACTIONS(292), 1,
-      anon_sym_LF2,
-    STATE(23), 1,
+    ACTIONS(260), 1,
+      anon_sym_STAR,
+    ACTIONS(263), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(269), 1,
+      anon_sym_PIPE,
+    ACTIONS(272), 1,
+      anon_sym_LBRACE,
+    ACTIONS(284), 1,
+      aux_sym__blank_token1,
+    ACTIONS(286), 1,
+      sym_url_word,
+    ACTIONS(289), 1,
+      anon_sym_BQUOTE,
+    STATE(25), 1,
       aux_sym_line_li_repeat1,
-    STATE(84), 1,
+    STATE(88), 1,
       sym__word_common,
-    ACTIONS(21), 3,
+    ACTIONS(278), 3,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(23), 5,
+    ACTIONS(281), 5,
       aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-    ACTIONS(19), 7,
+    ACTIONS(275), 7,
       anon_sym_Note_COLON,
       anon_sym_NOTE_COLON,
       anon_sym_Notes_COLON,
@@ -12448,7 +12412,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_WARNING_COLON,
       anon_sym_Deprecated,
       anon_sym_DEPRECATED_COLON,
-    ACTIONS(235), 8,
+    ACTIONS(266), 8,
       aux_sym__word_common_token3,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
@@ -12457,7 +12421,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_GT,
       anon_sym_COMMA,
-    STATE(88), 11,
+    STATE(90), 11,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -12482,13 +12446,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(41), 1,
       anon_sym_BQUOTE,
-    ACTIONS(233), 1,
+    ACTIONS(229), 1,
       aux_sym_word_token1,
-    ACTIONS(294), 1,
-      anon_sym_LF2,
-    STATE(23), 1,
+    ACTIONS(292), 1,
+      aux_sym__blank_token1,
+    STATE(25), 1,
       aux_sym_line_li_repeat1,
-    STATE(84), 1,
+    STATE(88), 1,
       sym__word_common,
     ACTIONS(21), 3,
       aux_sym_keycode_token1,
@@ -12508,7 +12472,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_WARNING_COLON,
       anon_sym_Deprecated,
       anon_sym_DEPRECATED_COLON,
-    ACTIONS(235), 8,
+    ACTIONS(231), 8,
       aux_sym__word_common_token3,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
@@ -12517,7 +12481,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_GT,
       anon_sym_COMMA,
-    STATE(88), 11,
+    STATE(90), 11,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -12542,13 +12506,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(41), 1,
       anon_sym_BQUOTE,
-    ACTIONS(233), 1,
+    ACTIONS(229), 1,
       aux_sym_word_token1,
-    ACTIONS(296), 1,
-      anon_sym_LF2,
+    ACTIONS(294), 1,
+      aux_sym__blank_token1,
     STATE(25), 1,
       aux_sym_line_li_repeat1,
-    STATE(84), 1,
+    STATE(88), 1,
       sym__word_common,
     ACTIONS(21), 3,
       aux_sym_keycode_token1,
@@ -12568,7 +12532,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_WARNING_COLON,
       anon_sym_Deprecated,
       anon_sym_DEPRECATED_COLON,
-    ACTIONS(235), 8,
+    ACTIONS(231), 8,
       aux_sym__word_common_token3,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
@@ -12577,7 +12541,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_GT,
       anon_sym_COMMA,
-    STATE(88), 11,
+    STATE(90), 11,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -12589,7 +12553,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [859] = 14,
+  [859] = 16,
     ACTIONS(7), 1,
       anon_sym_STAR,
     ACTIONS(9), 1,
@@ -12602,11 +12566,15 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(41), 1,
       anon_sym_BQUOTE,
-    ACTIONS(233), 1,
+    ACTIONS(229), 1,
       aux_sym_word_token1,
+    ACTIONS(296), 1,
+      aux_sym__blank_token1,
     STATE(24), 1,
+      sym_tag,
+    STATE(25), 1,
       aux_sym_line_li_repeat1,
-    STATE(84), 1,
+    STATE(88), 1,
       sym__word_common,
     ACTIONS(21), 3,
       aux_sym_keycode_token1,
@@ -12626,7 +12594,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_WARNING_COLON,
       anon_sym_Deprecated,
       anon_sym_DEPRECATED_COLON,
-    ACTIONS(235), 8,
+    ACTIONS(231), 8,
       aux_sym__word_common_token3,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
@@ -12635,19 +12603,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_GT,
       anon_sym_COMMA,
-    STATE(88), 11,
+    STATE(90), 10,
       sym__atom,
       sym_word,
       sym__atom_common,
       sym_note,
       sym_keycode,
-      sym_tag,
       sym_url,
       sym_optionlink,
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [931] = 14,
+  [936] = 16,
     ACTIONS(7), 1,
       anon_sym_STAR,
     ACTIONS(9), 1,
@@ -12660,11 +12627,134 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(41), 1,
       anon_sym_BQUOTE,
-    ACTIONS(233), 1,
+    ACTIONS(229), 1,
       aux_sym_word_token1,
+    ACTIONS(298), 1,
+      aux_sym__blank_token1,
+    STATE(23), 1,
+      sym_tag,
+    STATE(25), 1,
+      aux_sym_line_li_repeat1,
+    STATE(88), 1,
+      sym__word_common,
+    ACTIONS(21), 3,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+    ACTIONS(23), 5,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+    ACTIONS(19), 7,
+      anon_sym_Note_COLON,
+      anon_sym_NOTE_COLON,
+      anon_sym_Notes_COLON,
+      anon_sym_Warning_COLON,
+      anon_sym_WARNING_COLON,
+      anon_sym_Deprecated,
+      anon_sym_DEPRECATED_COLON,
+    ACTIONS(231), 8,
+      aux_sym__word_common_token3,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      anon_sym_LBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+    STATE(90), 10,
+      sym__atom,
+      sym_word,
+      sym__atom_common,
+      sym_note,
+      sym_keycode,
+      sym_url,
+      sym_optionlink,
+      sym_taglink,
+      sym_codespan,
+      sym_argument,
+  [1013] = 15,
+    ACTIONS(7), 1,
+      anon_sym_STAR,
+    ACTIONS(9), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
+      anon_sym_LBRACE,
+    ACTIONS(39), 1,
+      sym_url_word,
+    ACTIONS(41), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(229), 1,
+      aux_sym_word_token1,
+    ACTIONS(300), 1,
+      aux_sym__blank_token1,
+    STATE(25), 1,
+      aux_sym_line_li_repeat1,
+    STATE(88), 1,
+      sym__word_common,
+    ACTIONS(21), 3,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+    ACTIONS(23), 5,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+    ACTIONS(19), 7,
+      anon_sym_Note_COLON,
+      anon_sym_NOTE_COLON,
+      anon_sym_Notes_COLON,
+      anon_sym_Warning_COLON,
+      anon_sym_WARNING_COLON,
+      anon_sym_Deprecated,
+      anon_sym_DEPRECATED_COLON,
+    ACTIONS(231), 8,
+      aux_sym__word_common_token3,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      anon_sym_LBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+    STATE(90), 11,
+      sym__atom,
+      sym_word,
+      sym__atom_common,
+      sym_note,
+      sym_keycode,
+      sym_tag,
+      sym_url,
+      sym_optionlink,
+      sym_taglink,
+      sym_codespan,
+      sym_argument,
+  [1088] = 15,
+    ACTIONS(7), 1,
+      anon_sym_STAR,
+    ACTIONS(9), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
+      anon_sym_LBRACE,
+    ACTIONS(39), 1,
+      sym_url_word,
+    ACTIONS(41), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(229), 1,
+      aux_sym_word_token1,
+    ACTIONS(302), 1,
+      aux_sym__blank_token1,
     STATE(26), 1,
       aux_sym_line_li_repeat1,
-    STATE(84), 1,
+    STATE(88), 1,
       sym__word_common,
     ACTIONS(21), 3,
       aux_sym_keycode_token1,
@@ -12684,7 +12774,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_WARNING_COLON,
       anon_sym_Deprecated,
       anon_sym_DEPRECATED_COLON,
-    ACTIONS(235), 8,
+    ACTIONS(231), 8,
       aux_sym__word_common_token3,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
@@ -12693,7 +12783,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_GT,
       anon_sym_COMMA,
-    STATE(88), 11,
+    STATE(90), 11,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -12705,7 +12795,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1003] = 14,
+  [1163] = 14,
     ACTIONS(7), 1,
       anon_sym_STAR,
     ACTIONS(9), 1,
@@ -12718,11 +12808,127 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(41), 1,
       anon_sym_BQUOTE,
-    ACTIONS(233), 1,
+    ACTIONS(229), 1,
+      aux_sym_word_token1,
+    STATE(29), 1,
+      aux_sym_line_li_repeat1,
+    STATE(88), 1,
+      sym__word_common,
+    ACTIONS(21), 3,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+    ACTIONS(23), 5,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+    ACTIONS(19), 7,
+      anon_sym_Note_COLON,
+      anon_sym_NOTE_COLON,
+      anon_sym_Notes_COLON,
+      anon_sym_Warning_COLON,
+      anon_sym_WARNING_COLON,
+      anon_sym_Deprecated,
+      anon_sym_DEPRECATED_COLON,
+    ACTIONS(231), 8,
+      aux_sym__word_common_token3,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      anon_sym_LBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+    STATE(90), 11,
+      sym__atom,
+      sym_word,
+      sym__atom_common,
+      sym_note,
+      sym_keycode,
+      sym_tag,
+      sym_url,
+      sym_optionlink,
+      sym_taglink,
+      sym_codespan,
+      sym_argument,
+  [1235] = 14,
+    ACTIONS(7), 1,
+      anon_sym_STAR,
+    ACTIONS(9), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
+      anon_sym_LBRACE,
+    ACTIONS(39), 1,
+      sym_url_word,
+    ACTIONS(41), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(229), 1,
+      aux_sym_word_token1,
+    STATE(28), 1,
+      aux_sym_line_li_repeat1,
+    STATE(88), 1,
+      sym__word_common,
+    ACTIONS(21), 3,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+    ACTIONS(23), 5,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+    ACTIONS(19), 7,
+      anon_sym_Note_COLON,
+      anon_sym_NOTE_COLON,
+      anon_sym_Notes_COLON,
+      anon_sym_Warning_COLON,
+      anon_sym_WARNING_COLON,
+      anon_sym_Deprecated,
+      anon_sym_DEPRECATED_COLON,
+    ACTIONS(231), 8,
+      aux_sym__word_common_token3,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      anon_sym_LBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+    STATE(90), 11,
+      sym__atom,
+      sym_word,
+      sym__atom_common,
+      sym_note,
+      sym_keycode,
+      sym_tag,
+      sym_url,
+      sym_optionlink,
+      sym_taglink,
+      sym_codespan,
+      sym_argument,
+  [1307] = 14,
+    ACTIONS(7), 1,
+      anon_sym_STAR,
+    ACTIONS(9), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_PIPE,
+    ACTIONS(15), 1,
+      anon_sym_LBRACE,
+    ACTIONS(39), 1,
+      sym_url_word,
+    ACTIONS(41), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(229), 1,
       aux_sym_word_token1,
     STATE(22), 1,
       aux_sym_line_li_repeat1,
-    STATE(84), 1,
+    STATE(88), 1,
       sym__word_common,
     ACTIONS(21), 3,
       aux_sym_keycode_token1,
@@ -12742,7 +12948,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_WARNING_COLON,
       anon_sym_Deprecated,
       anon_sym_DEPRECATED_COLON,
-    ACTIONS(235), 8,
+    ACTIONS(231), 8,
       aux_sym__word_common_token3,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
@@ -12751,7 +12957,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_GT,
       anon_sym_COMMA,
-    STATE(88), 11,
+    STATE(90), 11,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -12763,7 +12969,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1075] = 14,
+  [1379] = 14,
     ACTIONS(7), 1,
       anon_sym_STAR,
     ACTIONS(9), 1,
@@ -12776,11 +12982,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_url_word,
     ACTIONS(41), 1,
       anon_sym_BQUOTE,
-    ACTIONS(233), 1,
+    ACTIONS(229), 1,
       aux_sym_word_token1,
-    STATE(19), 1,
+    STATE(17), 1,
       aux_sym_line_li_repeat1,
-    STATE(84), 1,
+    STATE(88), 1,
       sym__word_common,
     ACTIONS(21), 3,
       aux_sym_keycode_token1,
@@ -12800,7 +13006,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_WARNING_COLON,
       anon_sym_Deprecated,
       anon_sym_DEPRECATED_COLON,
-    ACTIONS(235), 8,
+    ACTIONS(231), 8,
       aux_sym__word_common_token3,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
@@ -12809,7 +13015,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_GT,
       anon_sym_COMMA,
-    STATE(88), 11,
+    STATE(90), 11,
       sym__atom,
       sym_word,
       sym__atom_common,
@@ -12821,14 +13027,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_taglink,
       sym_codespan,
       sym_argument,
-  [1147] = 5,
+  [1451] = 4,
     ACTIONS(29), 1,
-      anon_sym_LF2,
-    STATE(33), 1,
-      aux_sym_help_file_repeat1,
-    STATE(46), 1,
+      aux_sym__blank_token1,
+    STATE(42), 2,
       sym__blank,
-    ACTIONS(300), 13,
+      aux_sym_help_file_repeat1,
+    ACTIONS(306), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
@@ -12842,7 +13047,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(298), 25,
+    ACTIONS(304), 25,
       ts_builtin_sym_end,
       anon_sym_STAR,
       anon_sym_SQUOTE,
@@ -12868,14 +13073,15 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [1199] = 5,
-    ACTIONS(306), 1,
-      anon_sym_LF2,
-    STATE(33), 1,
-      aux_sym_help_file_repeat1,
-    STATE(46), 1,
+  [1501] = 5,
+    ACTIONS(29), 1,
+      aux_sym__blank_token1,
+    ACTIONS(312), 1,
+      aux_sym_line_li_token1,
+    STATE(39), 2,
       sym__blank,
-    ACTIONS(304), 13,
+      aux_sym_help_file_repeat1,
+    ACTIONS(310), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
@@ -12889,7 +13095,99 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(302), 25,
+    ACTIONS(308), 24,
+      ts_builtin_sym_end,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+      anon_sym_Note_COLON,
+      anon_sym_NOTE_COLON,
+      anon_sym_Notes_COLON,
+      anon_sym_Warning_COLON,
+      anon_sym_WARNING_COLON,
+      anon_sym_Deprecated,
+      anon_sym_DEPRECATED_COLON,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      sym_modeline,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [1553] = 5,
+    ACTIONS(29), 1,
+      aux_sym__blank_token1,
+    ACTIONS(312), 1,
+      aux_sym_line_li_token1,
+    STATE(42), 2,
+      sym__blank,
+      aux_sym_help_file_repeat1,
+    ACTIONS(306), 13,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+    ACTIONS(304), 24,
+      ts_builtin_sym_end,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+      anon_sym_Note_COLON,
+      anon_sym_NOTE_COLON,
+      anon_sym_Notes_COLON,
+      anon_sym_Warning_COLON,
+      anon_sym_WARNING_COLON,
+      anon_sym_Deprecated,
+      anon_sym_DEPRECATED_COLON,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      sym_modeline,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [1605] = 4,
+    ACTIONS(29), 1,
+      aux_sym__blank_token1,
+    STATE(40), 2,
+      sym__blank,
+      aux_sym_help_file_repeat1,
+    ACTIONS(306), 13,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+    ACTIONS(304), 25,
       ts_builtin_sym_end,
       anon_sym_STAR,
       anon_sym_SQUOTE,
@@ -12915,14 +13213,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [1251] = 5,
-    ACTIONS(29), 1,
-      anon_sym_LF2,
-    STATE(33), 1,
-      aux_sym_help_file_repeat1,
-    STATE(46), 1,
+  [1655] = 4,
+    ACTIONS(318), 1,
+      aux_sym__blank_token1,
+    STATE(40), 2,
       sym__blank,
-    ACTIONS(311), 13,
+      aux_sym_help_file_repeat1,
+    ACTIONS(316), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
@@ -12936,7 +13233,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(309), 25,
+    ACTIONS(314), 25,
       ts_builtin_sym_end,
       anon_sym_STAR,
       anon_sym_SQUOTE,
@@ -12962,14 +13259,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [1303] = 5,
+  [1705] = 4,
     ACTIONS(29), 1,
-      anon_sym_LF2,
-    STATE(33), 1,
-      aux_sym_help_file_repeat1,
-    STATE(46), 1,
+      aux_sym__blank_token1,
+    STATE(39), 2,
       sym__blank,
-    ACTIONS(315), 13,
+      aux_sym_help_file_repeat1,
+    ACTIONS(310), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
@@ -12983,7 +13279,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(313), 25,
+    ACTIONS(308), 25,
       ts_builtin_sym_end,
       anon_sym_STAR,
       anon_sym_SQUOTE,
@@ -13009,109 +13305,12 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [1355] = 5,
+  [1755] = 4,
     ACTIONS(29), 1,
-      anon_sym_LF2,
-    STATE(33), 1,
-      aux_sym_help_file_repeat1,
-    STATE(46), 1,
+      aux_sym__blank_token1,
+    STATE(40), 2,
       sym__blank,
-    ACTIONS(300), 13,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-    ACTIONS(298), 25,
-      ts_builtin_sym_end,
-      anon_sym_STAR,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_LBRACK,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      anon_sym_COMMA,
-      anon_sym_Note_COLON,
-      anon_sym_NOTE_COLON,
-      anon_sym_Notes_COLON,
-      anon_sym_Warning_COLON,
-      anon_sym_WARNING_COLON,
-      anon_sym_Deprecated,
-      anon_sym_DEPRECATED_COLON,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      aux_sym_line_li_token1,
-      sym_modeline,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE,
-  [1407] = 5,
-    ACTIONS(29), 1,
-      anon_sym_LF2,
-    STATE(34), 1,
       aux_sym_help_file_repeat1,
-    STATE(46), 1,
-      sym__blank,
-    ACTIONS(319), 13,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-    ACTIONS(317), 25,
-      ts_builtin_sym_end,
-      anon_sym_STAR,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_LBRACK,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      anon_sym_COMMA,
-      anon_sym_Note_COLON,
-      anon_sym_NOTE_COLON,
-      anon_sym_Notes_COLON,
-      anon_sym_Warning_COLON,
-      anon_sym_WARNING_COLON,
-      anon_sym_Deprecated,
-      anon_sym_DEPRECATED_COLON,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      aux_sym_line_li_token1,
-      sym_modeline,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE,
-  [1459] = 6,
-    ACTIONS(29), 1,
-      anon_sym_LF2,
-    ACTIONS(325), 1,
-      aux_sym_line_li_token1,
-    STATE(35), 1,
-      aux_sym_help_file_repeat1,
-    STATE(46), 1,
-      sym__blank,
     ACTIONS(323), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
@@ -13126,53 +13325,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(321), 24,
-      ts_builtin_sym_end,
-      anon_sym_STAR,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_LBRACK,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      anon_sym_COMMA,
-      anon_sym_Note_COLON,
-      anon_sym_NOTE_COLON,
-      anon_sym_Notes_COLON,
-      anon_sym_Warning_COLON,
-      anon_sym_WARNING_COLON,
-      anon_sym_Deprecated,
-      anon_sym_DEPRECATED_COLON,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      sym_modeline,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE,
-  [1513] = 5,
-    ACTIONS(29), 1,
-      anon_sym_LF2,
-    STATE(33), 1,
-      aux_sym_help_file_repeat1,
-    STATE(46), 1,
-      sym__blank,
-    ACTIONS(319), 13,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-    ACTIONS(317), 25,
+    ACTIONS(321), 25,
       ts_builtin_sym_end,
       anon_sym_STAR,
       anon_sym_SQUOTE,
@@ -13198,161 +13351,19 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [1565] = 5,
-    ACTIONS(29), 1,
-      anon_sym_LF2,
-    STATE(32), 1,
-      aux_sym_help_file_repeat1,
-    STATE(46), 1,
-      sym__blank,
-    ACTIONS(329), 13,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-    ACTIONS(327), 25,
-      ts_builtin_sym_end,
-      anon_sym_STAR,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_LBRACK,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      anon_sym_COMMA,
-      anon_sym_Note_COLON,
-      anon_sym_NOTE_COLON,
-      anon_sym_Notes_COLON,
-      anon_sym_Warning_COLON,
-      anon_sym_WARNING_COLON,
-      anon_sym_Deprecated,
-      anon_sym_DEPRECATED_COLON,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      aux_sym_line_li_token1,
-      sym_modeline,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE,
-  [1617] = 5,
-    ACTIONS(29), 1,
-      anon_sym_LF2,
-    STATE(36), 1,
-      aux_sym_help_file_repeat1,
-    STATE(46), 1,
-      sym__blank,
-    ACTIONS(329), 13,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-    ACTIONS(327), 25,
-      ts_builtin_sym_end,
-      anon_sym_STAR,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_LBRACK,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      anon_sym_COMMA,
-      anon_sym_Note_COLON,
-      anon_sym_NOTE_COLON,
-      anon_sym_Notes_COLON,
-      anon_sym_Warning_COLON,
-      anon_sym_WARNING_COLON,
-      anon_sym_Deprecated,
-      anon_sym_DEPRECATED_COLON,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      aux_sym_line_li_token1,
-      sym_modeline,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE,
-  [1669] = 6,
-    ACTIONS(29), 1,
-      anon_sym_LF2,
-    ACTIONS(325), 1,
-      aux_sym_line_li_token1,
-    STATE(39), 1,
-      aux_sym_help_file_repeat1,
-    STATE(46), 1,
-      sym__blank,
-    ACTIONS(333), 13,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-    ACTIONS(331), 24,
-      ts_builtin_sym_end,
-      anon_sym_STAR,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_LBRACK,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      anon_sym_COMMA,
-      anon_sym_Note_COLON,
-      anon_sym_NOTE_COLON,
-      anon_sym_Notes_COLON,
-      anon_sym_Warning_COLON,
-      anon_sym_WARNING_COLON,
-      anon_sym_Deprecated,
-      anon_sym_DEPRECATED_COLON,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      sym_modeline,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE,
-  [1723] = 6,
-    ACTIONS(337), 1,
-      anon_sym_LF2,
-    ACTIONS(340), 1,
+  [1805] = 6,
+    ACTIONS(327), 1,
+      aux_sym__blank_token1,
+    ACTIONS(329), 1,
       aux_sym_line_code_token1,
-    STATE(43), 1,
+    STATE(44), 1,
       aux_sym_codeblock_repeat1,
-    STATE(49), 1,
+    STATE(48), 1,
       sym_line_code,
-    ACTIONS(343), 2,
+    ACTIONS(331), 2,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
-    ACTIONS(335), 34,
+    ACTIONS(325), 34,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_STAR,
@@ -13387,19 +13398,105 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_li_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [1776] = 6,
+  [1858] = 6,
+    ACTIONS(335), 1,
+      aux_sym__blank_token1,
+    ACTIONS(338), 1,
+      aux_sym_line_code_token1,
+    STATE(44), 1,
+      aux_sym_codeblock_repeat1,
+    STATE(48), 1,
+      sym_line_code,
+    ACTIONS(341), 2,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+    ACTIONS(333), 34,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      anon_sym_LBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+      anon_sym_Note_COLON,
+      anon_sym_NOTE_COLON,
+      anon_sym_Notes_COLON,
+      anon_sym_Warning_COLON,
+      anon_sym_WARNING_COLON,
+      anon_sym_Deprecated,
+      anon_sym_DEPRECATED_COLON,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+      aux_sym_line_li_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [1911] = 2,
+    ACTIONS(345), 13,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+    ACTIONS(343), 26,
+      ts_builtin_sym_end,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+      anon_sym_Note_COLON,
+      anon_sym_NOTE_COLON,
+      anon_sym_Notes_COLON,
+      anon_sym_Warning_COLON,
+      anon_sym_WARNING_COLON,
+      anon_sym_Deprecated,
+      anon_sym_DEPRECATED_COLON,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym__blank_token1,
+      aux_sym_line_li_token1,
+      sym_modeline,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [1955] = 5,
     ACTIONS(347), 1,
-      anon_sym_LF2,
-    ACTIONS(349), 1,
+      aux_sym__blank_token1,
+    ACTIONS(350), 1,
       aux_sym_line_code_token1,
-    STATE(43), 1,
+    STATE(46), 1,
       aux_sym_codeblock_repeat1,
-    STATE(49), 1,
+    STATE(64), 1,
       sym_line_code,
-    ACTIONS(351), 2,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-    ACTIONS(345), 34,
+    ACTIONS(333), 34,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_STAR,
@@ -13434,100 +13531,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_li_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [1829] = 2,
-    ACTIONS(355), 13,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-    ACTIONS(353), 26,
-      ts_builtin_sym_end,
-      anon_sym_STAR,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_LBRACK,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      anon_sym_COMMA,
-      anon_sym_Note_COLON,
-      anon_sym_NOTE_COLON,
-      anon_sym_Notes_COLON,
-      anon_sym_Warning_COLON,
-      anon_sym_WARNING_COLON,
-      anon_sym_Deprecated,
-      anon_sym_DEPRECATED_COLON,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-      sym_modeline,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE,
-  [1873] = 2,
-    ACTIONS(359), 13,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-    ACTIONS(357), 26,
-      ts_builtin_sym_end,
-      anon_sym_STAR,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_LBRACK,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      anon_sym_COMMA,
-      anon_sym_Note_COLON,
-      anon_sym_NOTE_COLON,
-      anon_sym_Notes_COLON,
-      anon_sym_Warning_COLON,
-      anon_sym_WARNING_COLON,
-      anon_sym_Deprecated,
-      anon_sym_DEPRECATED_COLON,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      anon_sym_LF2,
-      aux_sym_line_li_token1,
-      sym_modeline,
-      aux_sym_h1_token1,
-      aux_sym_h2_token1,
-      sym_url_word,
-      anon_sym_BQUOTE,
-  [1917] = 5,
-    ACTIONS(361), 1,
-      anon_sym_LF2,
-    ACTIONS(364), 1,
+  [2004] = 5,
+    ACTIONS(353), 1,
+      aux_sym__blank_token1,
+    ACTIONS(355), 1,
       aux_sym_line_code_token1,
-    STATE(47), 1,
+    STATE(46), 1,
       aux_sym_codeblock_repeat1,
-    STATE(61), 1,
+    STATE(64), 1,
       sym_line_code,
-    ACTIONS(335), 34,
+    ACTIONS(325), 34,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_STAR,
@@ -13562,56 +13575,12 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_li_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [1966] = 5,
-    ACTIONS(367), 1,
-      anon_sym_LF2,
-    ACTIONS(369), 1,
-      aux_sym_line_code_token1,
-    STATE(47), 1,
-      aux_sym_codeblock_repeat1,
-    STATE(61), 1,
-      sym_line_code,
-    ACTIONS(345), 34,
-      aux_sym_word_noli_token1,
-      aux_sym_word_noli_token2,
-      anon_sym_STAR,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_LPAREN,
-      anon_sym_LBRACK,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      anon_sym_COMMA,
-      anon_sym_Note_COLON,
-      anon_sym_NOTE_COLON,
-      anon_sym_Notes_COLON,
-      anon_sym_Warning_COLON,
-      anon_sym_WARNING_COLON,
-      anon_sym_Deprecated,
-      anon_sym_DEPRECATED_COLON,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      aux_sym_line_li_token1,
-      sym_url_word,
-      anon_sym_BQUOTE,
-  [2015] = 2,
-    ACTIONS(373), 3,
-      anon_sym_LF2,
+  [2053] = 2,
+    ACTIONS(359), 3,
+      aux_sym__blank_token1,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
-    ACTIONS(371), 35,
+    ACTIONS(357), 35,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_STAR,
@@ -13647,12 +13616,12 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_code_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2058] = 2,
-    ACTIONS(377), 3,
-      anon_sym_LF2,
+  [2096] = 2,
+    ACTIONS(363), 3,
+      aux_sym__blank_token1,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
-    ACTIONS(375), 35,
+    ACTIONS(361), 35,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_STAR,
@@ -13688,8 +13657,8 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_code_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2101] = 2,
-    ACTIONS(379), 13,
+  [2139] = 2,
+    ACTIONS(365), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
@@ -13703,7 +13672,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(381), 24,
+    ACTIONS(367), 24,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -13722,14 +13691,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DEPRECATED_COLON,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       aux_sym_line_li_token1,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2143] = 2,
-    ACTIONS(383), 13,
+  [2181] = 2,
+    ACTIONS(369), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
@@ -13743,7 +13712,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(385), 24,
+    ACTIONS(371), 24,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -13762,14 +13731,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DEPRECATED_COLON,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       aux_sym_line_li_token1,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2185] = 2,
-    ACTIONS(387), 13,
+  [2223] = 2,
+    ACTIONS(373), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
@@ -13783,7 +13752,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(389), 24,
+    ACTIONS(375), 24,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -13802,14 +13771,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DEPRECATED_COLON,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       aux_sym_line_li_token1,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2227] = 2,
-    ACTIONS(391), 13,
+  [2265] = 2,
+    ACTIONS(377), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
@@ -13823,7 +13792,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(393), 24,
+    ACTIONS(379), 24,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -13842,14 +13811,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DEPRECATED_COLON,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       aux_sym_line_li_token1,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2269] = 2,
-    ACTIONS(395), 13,
+  [2307] = 2,
+    ACTIONS(381), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
@@ -13863,7 +13832,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(397), 24,
+    ACTIONS(383), 24,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -13882,14 +13851,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DEPRECATED_COLON,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       aux_sym_line_li_token1,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2311] = 2,
-    ACTIONS(399), 13,
+  [2349] = 2,
+    ACTIONS(385), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
@@ -13903,7 +13872,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(401), 24,
+    ACTIONS(387), 24,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -13922,14 +13891,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DEPRECATED_COLON,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       aux_sym_line_li_token1,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2353] = 2,
-    ACTIONS(403), 13,
+  [2391] = 2,
+    ACTIONS(389), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
@@ -13943,7 +13912,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(405), 24,
+    ACTIONS(391), 24,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -13962,14 +13931,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DEPRECATED_COLON,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       aux_sym_line_li_token1,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2395] = 2,
-    ACTIONS(407), 13,
+  [2433] = 2,
+    ACTIONS(393), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
@@ -13983,7 +13952,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(409), 24,
+    ACTIONS(395), 24,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -14002,14 +13971,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DEPRECATED_COLON,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       aux_sym_line_li_token1,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2437] = 2,
-    ACTIONS(411), 13,
+  [2475] = 2,
+    ACTIONS(397), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
@@ -14023,7 +13992,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(413), 24,
+    ACTIONS(399), 24,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -14042,14 +14011,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DEPRECATED_COLON,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       aux_sym_line_li_token1,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2479] = 2,
-    ACTIONS(415), 13,
+  [2517] = 2,
+    ACTIONS(401), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
       anon_sym_PIPE,
@@ -14063,7 +14032,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(417), 24,
+    ACTIONS(403), 24,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -14082,26 +14051,33 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DEPRECATED_COLON,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       aux_sym_line_li_token1,
       aux_sym_h1_token1,
       aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2521] = 2,
-    ACTIONS(373), 1,
-      anon_sym_LF2,
-    ACTIONS(371), 35,
+  [2559] = 2,
+    ACTIONS(405), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+    ACTIONS(407), 24,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
-      anon_sym_LPAREN,
       anon_sym_LBRACK,
       anon_sym_TILDE,
       anon_sym_GT,
@@ -14113,62 +14089,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_WARNING_COLON,
       anon_sym_Deprecated,
       anon_sym_DEPRECATED_COLON,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
+      aux_sym__blank_token1,
       aux_sym_line_li_token1,
-      aux_sym_line_code_token1,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2562] = 2,
-    ACTIONS(377), 1,
-      anon_sym_LF2,
-    ACTIONS(375), 35,
+  [2601] = 2,
+    ACTIONS(409), 13,
       aux_sym_word_noli_token1,
       aux_sym_word_noli_token2,
-      anon_sym_STAR,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_LPAREN,
-      anon_sym_LBRACK,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      anon_sym_COMMA,
-      anon_sym_Note_COLON,
-      anon_sym_NOTE_COLON,
-      anon_sym_Notes_COLON,
-      anon_sym_Warning_COLON,
-      anon_sym_WARNING_COLON,
-      anon_sym_Deprecated,
-      anon_sym_DEPRECATED_COLON,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      aux_sym_uppercase_name_token1,
-      anon_sym_LT,
-      aux_sym_line_li_token1,
-      aux_sym_line_code_token1,
-      sym_url_word,
-      anon_sym_BQUOTE,
-  [2603] = 2,
-    ACTIONS(383), 12,
-      aux_sym_word_noli_token1,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       anon_sym_LPAREN,
@@ -14180,8 +14112,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(385), 23,
-      aux_sym_word_noli_token2,
+    ACTIONS(411), 24,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -14200,12 +14131,132 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DEPRECATED_COLON,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       aux_sym_line_li_token1,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
       sym_url_word,
       anon_sym_BQUOTE,
   [2643] = 2,
-    ACTIONS(419), 12,
+    ACTIONS(413), 13,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+    ACTIONS(415), 24,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+      anon_sym_Note_COLON,
+      anon_sym_NOTE_COLON,
+      anon_sym_Notes_COLON,
+      anon_sym_Warning_COLON,
+      anon_sym_WARNING_COLON,
+      anon_sym_Deprecated,
+      anon_sym_DEPRECATED_COLON,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym__blank_token1,
+      aux_sym_line_li_token1,
+      aux_sym_h1_token1,
+      aux_sym_h2_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [2685] = 2,
+    ACTIONS(363), 1,
+      aux_sym__blank_token1,
+    ACTIONS(361), 35,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      anon_sym_LBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+      anon_sym_Note_COLON,
+      anon_sym_NOTE_COLON,
+      anon_sym_Notes_COLON,
+      anon_sym_Warning_COLON,
+      anon_sym_WARNING_COLON,
+      anon_sym_Deprecated,
+      anon_sym_DEPRECATED_COLON,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+      aux_sym_line_li_token1,
+      aux_sym_line_code_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [2726] = 2,
+    ACTIONS(359), 1,
+      aux_sym__blank_token1,
+    ACTIONS(357), 35,
+      aux_sym_word_noli_token1,
+      aux_sym_word_noli_token2,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      anon_sym_LBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+      anon_sym_Note_COLON,
+      anon_sym_NOTE_COLON,
+      anon_sym_Notes_COLON,
+      anon_sym_Warning_COLON,
+      anon_sym_WARNING_COLON,
+      anon_sym_Deprecated,
+      anon_sym_DEPRECATED_COLON,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+      aux_sym_line_li_token1,
+      aux_sym_line_code_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [2767] = 2,
+    ACTIONS(373), 12,
       aux_sym_word_noli_token1,
       anon_sym_PIPE,
       anon_sym_LBRACE,
@@ -14218,7 +14269,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(421), 23,
+    ACTIONS(375), 23,
       aux_sym_word_noli_token2,
       anon_sym_STAR,
       anon_sym_SQUOTE,
@@ -14238,12 +14289,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DEPRECATED_COLON,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       aux_sym_line_li_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2683] = 2,
-    ACTIONS(391), 12,
+  [2807] = 2,
+    ACTIONS(417), 12,
       aux_sym_word_noli_token1,
       anon_sym_PIPE,
       anon_sym_LBRACE,
@@ -14256,7 +14307,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token1,
       anon_sym_LT,
-    ACTIONS(393), 23,
+    ACTIONS(419), 23,
       aux_sym_word_noli_token2,
       anon_sym_STAR,
       anon_sym_SQUOTE,
@@ -14276,17 +14327,55 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DEPRECATED_COLON,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       aux_sym_line_li_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2723] = 4,
-    ACTIONS(429), 1,
+  [2847] = 2,
+    ACTIONS(393), 12,
+      aux_sym_word_noli_token1,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym_uppercase_name_token1,
+      anon_sym_LT,
+    ACTIONS(395), 23,
+      aux_sym_word_noli_token2,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+      anon_sym_Note_COLON,
+      anon_sym_NOTE_COLON,
+      anon_sym_Notes_COLON,
+      anon_sym_Warning_COLON,
+      anon_sym_WARNING_COLON,
+      anon_sym_Deprecated,
+      anon_sym_DEPRECATED_COLON,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym__blank_token1,
+      aux_sym_line_li_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [2887] = 4,
+    ACTIONS(427), 1,
       aux_sym_optionlink_token1,
-    ACTIONS(427), 2,
+    ACTIONS(425), 2,
       aux_sym__word_common_token1,
       aux_sym__word_common_token2,
-    ACTIONS(423), 15,
+    ACTIONS(421), 15,
       aux_sym_word_token1,
       anon_sym_STAR,
       anon_sym_PIPE,
@@ -14302,7 +14391,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token3,
       sym_url_word,
       anon_sym_BQUOTE,
-    ACTIONS(425), 16,
+    ACTIONS(423), 16,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       anon_sym_LBRACE_RBRACE,
@@ -14318,20 +14407,20 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      anon_sym_LF2,
-  [2766] = 3,
-    ACTIONS(431), 2,
+      aux_sym__blank_token1,
+  [2930] = 3,
+    ACTIONS(429), 2,
       aux_sym_codeblock_token1,
-      anon_sym_LF,
-    ACTIONS(423), 7,
+      aux_sym_codeblock_token2,
+    ACTIONS(421), 7,
       aux_sym_word_token1,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-      anon_sym_LF2,
-    ACTIONS(425), 24,
+      aux_sym__blank_token1,
+    ACTIONS(423), 24,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -14356,12 +14445,12 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2806] = 4,
-    ACTIONS(437), 1,
+  [2970] = 4,
+    ACTIONS(435), 1,
       aux_sym_uppercase_name_token2,
-    STATE(68), 1,
+    STATE(70), 1,
       aux_sym_uppercase_name_repeat1,
-    ACTIONS(433), 10,
+    ACTIONS(431), 10,
       aux_sym_word_token1,
       anon_sym_PIPE,
       anon_sym_LBRACE,
@@ -14372,7 +14461,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token4,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-    ACTIONS(435), 21,
+    ACTIONS(433), 21,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -14391,170 +14480,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DEPRECATED_COLON,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [2848] = 4,
+  [3012] = 5,
     ACTIONS(444), 1,
       aux_sym_uppercase_name_token2,
-    STATE(68), 1,
+    STATE(74), 1,
       aux_sym_uppercase_name_repeat1,
-    ACTIONS(440), 10,
-      aux_sym_word_token1,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-    ACTIONS(442), 21,
+    ACTIONS(440), 2,
       anon_sym_STAR,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_LBRACK,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      anon_sym_COMMA,
-      anon_sym_Note_COLON,
-      anon_sym_NOTE_COLON,
-      anon_sym_Notes_COLON,
-      anon_sym_Warning_COLON,
-      anon_sym_WARNING_COLON,
-      anon_sym_Deprecated,
-      anon_sym_DEPRECATED_COLON,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      anon_sym_LF2,
-      sym_url_word,
-      anon_sym_BQUOTE,
-  [2890] = 5,
-    ACTIONS(444), 1,
-      aux_sym_uppercase_name_token2,
-    STATE(73), 1,
-      aux_sym_uppercase_name_repeat1,
-    ACTIONS(448), 2,
-      anon_sym_STAR,
-      anon_sym_LF2,
-    ACTIONS(446), 10,
-      aux_sym_word_token1,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-    ACTIONS(450), 19,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_LBRACK,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      anon_sym_COMMA,
-      anon_sym_Note_COLON,
-      anon_sym_NOTE_COLON,
-      anon_sym_Notes_COLON,
-      anon_sym_Warning_COLON,
-      anon_sym_WARNING_COLON,
-      anon_sym_Deprecated,
-      anon_sym_DEPRECATED_COLON,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      sym_url_word,
-      anon_sym_BQUOTE,
-  [2934] = 4,
-    ACTIONS(444), 1,
-      aux_sym_uppercase_name_token2,
-    STATE(69), 1,
-      aux_sym_uppercase_name_repeat1,
-    ACTIONS(446), 10,
-      aux_sym_word_token1,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-    ACTIONS(450), 21,
-      anon_sym_STAR,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_LBRACK,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      anon_sym_COMMA,
-      anon_sym_Note_COLON,
-      anon_sym_NOTE_COLON,
-      anon_sym_Notes_COLON,
-      anon_sym_Warning_COLON,
-      anon_sym_WARNING_COLON,
-      anon_sym_Deprecated,
-      anon_sym_DEPRECATED_COLON,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      anon_sym_LF2,
-      sym_url_word,
-      anon_sym_BQUOTE,
-  [2976] = 3,
-    ACTIONS(452), 2,
-      aux_sym_codeblock_token1,
-      anon_sym_LF,
-    ACTIONS(423), 7,
-      aux_sym_word_token1,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      anon_sym_LF2,
-    ACTIONS(425), 24,
-      anon_sym_STAR,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_LPAREN,
-      anon_sym_LBRACK,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      anon_sym_COMMA,
-      anon_sym_Note_COLON,
-      anon_sym_NOTE_COLON,
-      anon_sym_Notes_COLON,
-      anon_sym_Warning_COLON,
-      anon_sym_WARNING_COLON,
-      anon_sym_Deprecated,
-      anon_sym_DEPRECATED_COLON,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      sym_url_word,
-      anon_sym_BQUOTE,
-  [3016] = 5,
-    ACTIONS(444), 1,
-      aux_sym_uppercase_name_token2,
-    STATE(68), 1,
-      aux_sym_uppercase_name_repeat1,
-    ACTIONS(454), 2,
-      anon_sym_STAR,
-      anon_sym_LF2,
-    ACTIONS(440), 10,
+      aux_sym__blank_token1,
+    ACTIONS(438), 10,
       aux_sym_word_token1,
       anon_sym_PIPE,
       anon_sym_LBRACE,
@@ -14585,19 +14522,59 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3060] = 3,
-    ACTIONS(460), 1,
-      anon_sym_SQUOTE2,
-    ACTIONS(456), 7,
+  [3056] = 4,
+    ACTIONS(444), 1,
+      aux_sym_uppercase_name_token2,
+    STATE(75), 1,
+      aux_sym_uppercase_name_repeat1,
+    ACTIONS(438), 10,
       aux_sym_word_token1,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+    ACTIONS(442), 21,
+      anon_sym_STAR,
       anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+      anon_sym_Note_COLON,
+      anon_sym_NOTE_COLON,
+      anon_sym_Notes_COLON,
+      anon_sym_Warning_COLON,
+      anon_sym_WARNING_COLON,
+      anon_sym_Deprecated,
+      anon_sym_DEPRECATED_COLON,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym__blank_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [3098] = 3,
+    ACTIONS(446), 2,
+      aux_sym_codeblock_token1,
+      aux_sym_codeblock_token2,
+    ACTIONS(421), 7,
+      aux_sym_word_token1,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(458), 24,
+      aux_sym__blank_token1,
+    ACTIONS(423), 24,
       anon_sym_STAR,
+      anon_sym_SQUOTE,
       aux_sym__word_common_token3,
       anon_sym_LBRACE_RBRACE,
       aux_sym__word_common_token4,
@@ -14618,16 +14595,92 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      anon_sym_LF2,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3099] = 3,
-    ACTIONS(462), 1,
+  [3138] = 5,
+    ACTIONS(444), 1,
+      aux_sym_uppercase_name_token2,
+    STATE(70), 1,
+      aux_sym_uppercase_name_repeat1,
+    ACTIONS(450), 2,
+      anon_sym_STAR,
+      aux_sym__blank_token1,
+    ACTIONS(448), 10,
+      aux_sym_word_token1,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+    ACTIONS(452), 19,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+      anon_sym_Note_COLON,
+      anon_sym_NOTE_COLON,
+      anon_sym_Notes_COLON,
+      anon_sym_Warning_COLON,
+      anon_sym_WARNING_COLON,
+      anon_sym_Deprecated,
+      anon_sym_DEPRECATED_COLON,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [3182] = 4,
+    ACTIONS(444), 1,
+      aux_sym_uppercase_name_token2,
+    STATE(70), 1,
+      aux_sym_uppercase_name_repeat1,
+    ACTIONS(448), 10,
+      aux_sym_word_token1,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+    ACTIONS(452), 21,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+      anon_sym_Note_COLON,
+      anon_sym_NOTE_COLON,
+      anon_sym_Notes_COLON,
+      anon_sym_Warning_COLON,
+      anon_sym_WARNING_COLON,
+      anon_sym_Deprecated,
+      anon_sym_DEPRECATED_COLON,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym__blank_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [3224] = 3,
+    ACTIONS(454), 1,
       aux_sym_tag_token1,
-    ACTIONS(425), 2,
+    ACTIONS(423), 2,
       anon_sym_STAR,
-      anon_sym_LF2,
-    ACTIONS(423), 29,
+      aux_sym__blank_token1,
+    ACTIONS(421), 29,
       aux_sym_word_token1,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -14657,8 +14710,152 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token7,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3138] = 2,
-    ACTIONS(464), 11,
+  [3263] = 3,
+    ACTIONS(460), 1,
+      anon_sym_QMARK,
+    ACTIONS(456), 6,
+      aux_sym_word_token1,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+    ACTIONS(458), 25,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      anon_sym_LBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+      anon_sym_Note_COLON,
+      anon_sym_NOTE_COLON,
+      anon_sym_Notes_COLON,
+      anon_sym_Warning_COLON,
+      anon_sym_WARNING_COLON,
+      anon_sym_Deprecated,
+      anon_sym_DEPRECATED_COLON,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym__blank_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [3302] = 3,
+    ACTIONS(462), 1,
+      aux_sym_argument_token1,
+    ACTIONS(423), 3,
+      anon_sym_LBRACE_RBRACE,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym__blank_token1,
+    ACTIONS(421), 28,
+      aux_sym_word_token1,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      aux_sym__word_common_token3,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      anon_sym_LBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+      anon_sym_Note_COLON,
+      anon_sym_NOTE_COLON,
+      anon_sym_Notes_COLON,
+      anon_sym_Warning_COLON,
+      anon_sym_WARNING_COLON,
+      anon_sym_Deprecated,
+      anon_sym_DEPRECATED_COLON,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [3341] = 3,
+    ACTIONS(468), 1,
+      anon_sym_SQUOTE2,
+    ACTIONS(464), 7,
+      aux_sym_word_token1,
+      anon_sym_SQUOTE,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+    ACTIONS(466), 24,
+      anon_sym_STAR,
+      aux_sym__word_common_token3,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      anon_sym_LBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+      anon_sym_Note_COLON,
+      anon_sym_NOTE_COLON,
+      anon_sym_Notes_COLON,
+      anon_sym_Warning_COLON,
+      anon_sym_WARNING_COLON,
+      anon_sym_Deprecated,
+      anon_sym_DEPRECATED_COLON,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      aux_sym__blank_token1,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [3380] = 3,
+    ACTIONS(470), 1,
+      aux_sym_taglink_token1,
+    ACTIONS(423), 2,
+      aux_sym__word_common_token3,
+      aux_sym__blank_token1,
+    ACTIONS(421), 29,
+      aux_sym_word_token1,
+      anon_sym_STAR,
+      anon_sym_SQUOTE,
+      anon_sym_PIPE,
+      anon_sym_LBRACE,
+      anon_sym_LBRACE_RBRACE,
+      aux_sym__word_common_token4,
+      anon_sym_LPAREN,
+      anon_sym_LBRACK,
+      anon_sym_TILDE,
+      anon_sym_GT,
+      anon_sym_COMMA,
+      anon_sym_Note_COLON,
+      anon_sym_NOTE_COLON,
+      anon_sym_Notes_COLON,
+      anon_sym_Warning_COLON,
+      anon_sym_WARNING_COLON,
+      anon_sym_Deprecated,
+      anon_sym_DEPRECATED_COLON,
+      aux_sym_keycode_token1,
+      aux_sym_keycode_token2,
+      aux_sym_keycode_token3,
+      aux_sym_keycode_token4,
+      aux_sym_keycode_token5,
+      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
+      aux_sym_keycode_token6,
+      aux_sym_keycode_token7,
+      sym_url_word,
+      anon_sym_BQUOTE,
+  [3419] = 2,
+    ACTIONS(472), 11,
       aux_sym_word_token1,
       anon_sym_PIPE,
       anon_sym_LBRACE,
@@ -14670,7 +14867,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
       aux_sym_uppercase_name_token2,
-    ACTIONS(466), 21,
+    ACTIONS(474), 21,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -14689,56 +14886,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DEPRECATED_COLON,
       aux_sym_keycode_token5,
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3175] = 3,
-    ACTIONS(468), 1,
-      aux_sym_taglink_token1,
-    ACTIONS(425), 2,
-      aux_sym__word_common_token3,
-      anon_sym_LF2,
-    ACTIONS(423), 29,
-      aux_sym_word_token1,
-      anon_sym_STAR,
-      anon_sym_SQUOTE,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_LPAREN,
-      anon_sym_LBRACK,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      anon_sym_COMMA,
-      anon_sym_Note_COLON,
-      anon_sym_NOTE_COLON,
-      anon_sym_Notes_COLON,
-      anon_sym_Warning_COLON,
-      anon_sym_WARNING_COLON,
-      anon_sym_Deprecated,
-      anon_sym_DEPRECATED_COLON,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      sym_url_word,
-      anon_sym_BQUOTE,
-  [3214] = 3,
-    ACTIONS(474), 1,
-      anon_sym_QMARK,
-    ACTIONS(470), 6,
+  [3456] = 2,
+    ACTIONS(476), 6,
       aux_sym_word_token1,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(472), 25,
+    ACTIONS(478), 25,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -14761,21 +14920,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3253] = 3,
-    ACTIONS(476), 1,
-      anon_sym_LF,
-    ACTIONS(423), 7,
+  [3492] = 2,
+    ACTIONS(480), 6,
       aux_sym_word_token1,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-      anon_sym_LF2,
-    ACTIONS(425), 24,
+    ACTIONS(482), 25,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -14798,20 +14954,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
+      aux_sym__blank_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3292] = 3,
-    ACTIONS(478), 1,
-      anon_sym_LF,
-    ACTIONS(423), 7,
+  [3528] = 2,
+    ACTIONS(484), 6,
       aux_sym_word_token1,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-      anon_sym_LF2,
-    ACTIONS(425), 24,
+    ACTIONS(486), 25,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -14834,53 +14988,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
+      aux_sym__blank_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3331] = 3,
-    ACTIONS(480), 1,
-      aux_sym_argument_token1,
-    ACTIONS(425), 3,
-      anon_sym_LBRACE_RBRACE,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      anon_sym_LF2,
-    ACTIONS(423), 28,
-      aux_sym_word_token1,
-      anon_sym_STAR,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_LPAREN,
-      anon_sym_LBRACK,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      anon_sym_COMMA,
-      anon_sym_Note_COLON,
-      anon_sym_NOTE_COLON,
-      anon_sym_Notes_COLON,
-      anon_sym_Warning_COLON,
-      anon_sym_WARNING_COLON,
-      anon_sym_Deprecated,
-      anon_sym_DEPRECATED_COLON,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      sym_url_word,
-      anon_sym_BQUOTE,
-  [3370] = 2,
-    ACTIONS(482), 6,
+  [3564] = 2,
+    ACTIONS(488), 6,
       aux_sym_word_token1,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(484), 25,
+    ACTIONS(490), 25,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -14903,18 +15022,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3406] = 2,
-    ACTIONS(486), 6,
+  [3600] = 2,
+    ACTIONS(492), 6,
       aux_sym_word_token1,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(488), 25,
+    ACTIONS(494), 25,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -14937,18 +15056,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3442] = 2,
-    ACTIONS(490), 6,
+  [3636] = 2,
+    ACTIONS(496), 6,
       aux_sym_word_token1,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(492), 25,
+    ACTIONS(498), 25,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -14971,18 +15090,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3478] = 2,
-    ACTIONS(494), 6,
+  [3672] = 2,
+    ACTIONS(500), 6,
       aux_sym_word_token1,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(496), 25,
+    ACTIONS(502), 25,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -15005,18 +15124,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3514] = 2,
-    ACTIONS(498), 6,
+  [3708] = 2,
+    ACTIONS(504), 6,
       aux_sym_word_token1,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(500), 25,
+    ACTIONS(506), 25,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -15039,18 +15158,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3550] = 2,
-    ACTIONS(502), 6,
+  [3744] = 2,
+    ACTIONS(508), 6,
       aux_sym_word_token1,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(504), 25,
+    ACTIONS(510), 25,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -15073,18 +15192,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3586] = 2,
-    ACTIONS(506), 6,
+  [3780] = 2,
+    ACTIONS(512), 6,
       aux_sym_word_token1,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(508), 25,
+    ACTIONS(514), 25,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -15107,18 +15226,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3622] = 2,
-    ACTIONS(510), 6,
+  [3816] = 2,
+    ACTIONS(516), 6,
       aux_sym_word_token1,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(512), 25,
+    ACTIONS(518), 25,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -15141,18 +15260,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3658] = 2,
-    ACTIONS(514), 6,
+  [3852] = 2,
+    ACTIONS(520), 6,
       aux_sym_word_token1,
       anon_sym_PIPE,
       anon_sym_LBRACE,
       aux_sym_keycode_token1,
       aux_sym_keycode_token2,
       aux_sym_keycode_token3,
-    ACTIONS(516), 25,
+    ACTIONS(522), 25,
       anon_sym_STAR,
       anon_sym_SQUOTE,
       aux_sym__word_common_token3,
@@ -15175,232 +15294,129 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
       aux_sym_keycode_token6,
       aux_sym_keycode_token7,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
       sym_url_word,
       anon_sym_BQUOTE,
-  [3694] = 2,
-    ACTIONS(518), 6,
-      aux_sym_word_token1,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-    ACTIONS(520), 25,
-      anon_sym_STAR,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_LPAREN,
-      anon_sym_LBRACK,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      anon_sym_COMMA,
-      anon_sym_Note_COLON,
-      anon_sym_NOTE_COLON,
-      anon_sym_Notes_COLON,
-      anon_sym_Warning_COLON,
-      anon_sym_WARNING_COLON,
-      anon_sym_Deprecated,
-      anon_sym_DEPRECATED_COLON,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      anon_sym_LF2,
-      sym_url_word,
-      anon_sym_BQUOTE,
-  [3730] = 2,
-    ACTIONS(522), 6,
-      aux_sym_word_token1,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-    ACTIONS(524), 25,
-      anon_sym_STAR,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_LPAREN,
-      anon_sym_LBRACK,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      anon_sym_COMMA,
-      anon_sym_Note_COLON,
-      anon_sym_NOTE_COLON,
-      anon_sym_Notes_COLON,
-      anon_sym_Warning_COLON,
-      anon_sym_WARNING_COLON,
-      anon_sym_Deprecated,
-      anon_sym_DEPRECATED_COLON,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      anon_sym_LF2,
-      sym_url_word,
-      anon_sym_BQUOTE,
-  [3766] = 2,
-    ACTIONS(526), 6,
-      aux_sym_word_token1,
-      anon_sym_PIPE,
-      anon_sym_LBRACE,
-      aux_sym_keycode_token1,
-      aux_sym_keycode_token2,
-      aux_sym_keycode_token3,
-    ACTIONS(528), 25,
-      anon_sym_STAR,
-      anon_sym_SQUOTE,
-      aux_sym__word_common_token3,
-      anon_sym_LBRACE_RBRACE,
-      aux_sym__word_common_token4,
-      anon_sym_LPAREN,
-      anon_sym_LBRACK,
-      anon_sym_TILDE,
-      anon_sym_GT,
-      anon_sym_COMMA,
-      anon_sym_Note_COLON,
-      anon_sym_NOTE_COLON,
-      anon_sym_Notes_COLON,
-      anon_sym_Warning_COLON,
-      anon_sym_WARNING_COLON,
-      anon_sym_Deprecated,
-      anon_sym_DEPRECATED_COLON,
-      aux_sym_keycode_token4,
-      aux_sym_keycode_token5,
-      anon_sym_CTRL_DASH_LBRACEchar_RBRACE,
-      aux_sym_keycode_token6,
-      aux_sym_keycode_token7,
-      anon_sym_LF2,
-      sym_url_word,
-      anon_sym_BQUOTE,
-  [3802] = 5,
+  [3888] = 5,
     ACTIONS(29), 1,
-      anon_sym_LF2,
+      aux_sym__blank_token1,
     ACTIONS(31), 1,
       aux_sym_line_li_token1,
-    ACTIONS(530), 1,
-      anon_sym_LT,
-    STATE(37), 1,
-      sym__blank,
-    STATE(96), 2,
-      sym_line_li,
-      aux_sym_block_repeat2,
-  [3819] = 5,
-    ACTIONS(29), 1,
-      anon_sym_LF2,
-    ACTIONS(31), 1,
-      aux_sym_line_li_token1,
-    ACTIONS(532), 1,
+    ACTIONS(524), 1,
       anon_sym_LT,
     STATE(41), 1,
       sym__blank,
     STATE(96), 2,
       sym_line_li,
       aux_sym_block_repeat2,
-  [3836] = 4,
-    ACTIONS(534), 1,
+  [3905] = 5,
+    ACTIONS(29), 1,
+      aux_sym__blank_token1,
+    ACTIONS(31), 1,
+      aux_sym_line_li_token1,
+    ACTIONS(526), 1,
       anon_sym_LT,
-    ACTIONS(537), 1,
-      anon_sym_LF2,
-    ACTIONS(539), 1,
+    STATE(36), 1,
+      sym__blank,
+    STATE(96), 2,
+      sym_line_li,
+      aux_sym_block_repeat2,
+  [3922] = 4,
+    ACTIONS(528), 1,
+      anon_sym_LT,
+    ACTIONS(531), 1,
+      aux_sym__blank_token1,
+    ACTIONS(533), 1,
       aux_sym_line_li_token1,
     STATE(96), 2,
       sym_line_li,
       aux_sym_block_repeat2,
-  [3850] = 4,
-    ACTIONS(347), 1,
-      anon_sym_LF2,
-    ACTIONS(349), 1,
+  [3936] = 4,
+    ACTIONS(327), 1,
+      aux_sym__blank_token1,
+    ACTIONS(329), 1,
       aux_sym_line_code_token1,
-    STATE(44), 1,
+    STATE(43), 1,
       aux_sym_codeblock_repeat1,
-    STATE(49), 1,
-      sym_line_code,
-  [3863] = 4,
-    ACTIONS(367), 1,
-      anon_sym_LF2,
-    ACTIONS(369), 1,
-      aux_sym_line_code_token1,
     STATE(48), 1,
-      aux_sym_codeblock_repeat1,
-    STATE(61), 1,
       sym_line_code,
-  [3876] = 3,
-    ACTIONS(542), 1,
+  [3949] = 4,
+    ACTIONS(353), 1,
+      aux_sym__blank_token1,
+    ACTIONS(355), 1,
+      aux_sym_line_code_token1,
+    STATE(47), 1,
+      aux_sym_codeblock_repeat1,
+    STATE(64), 1,
+      sym_line_code,
+  [3962] = 3,
+    ACTIONS(536), 1,
       ts_builtin_sym_end,
-    ACTIONS(544), 1,
+    ACTIONS(538), 1,
       sym_modeline,
-    STATE(103), 1,
+    STATE(99), 1,
       aux_sym_help_file_repeat3,
-  [3886] = 3,
-    ACTIONS(544), 1,
-      sym_modeline,
-    ACTIONS(546), 1,
-      ts_builtin_sym_end,
-    STATE(103), 1,
-      aux_sym_help_file_repeat3,
-  [3896] = 3,
-    ACTIONS(51), 1,
-      ts_builtin_sym_end,
-    ACTIONS(544), 1,
-      sym_modeline,
-    STATE(103), 1,
-      aux_sym_help_file_repeat3,
-  [3906] = 3,
-    ACTIONS(548), 1,
-      anon_sym_STAR,
-    ACTIONS(550), 1,
-      anon_sym_LF2,
-    STATE(27), 1,
-      sym_tag,
-  [3916] = 3,
-    ACTIONS(552), 1,
-      ts_builtin_sym_end,
-    ACTIONS(554), 1,
-      sym_modeline,
-    STATE(103), 1,
-      aux_sym_help_file_repeat3,
-  [3926] = 3,
+  [3972] = 3,
     ACTIONS(47), 1,
       ts_builtin_sym_end,
-    ACTIONS(544), 1,
+    ACTIONS(541), 1,
       sym_modeline,
-    STATE(103), 1,
+    STATE(99), 1,
       aux_sym_help_file_repeat3,
-  [3936] = 1,
-    ACTIONS(325), 1,
-      aux_sym_line_li_token1,
-  [3940] = 1,
-    ACTIONS(557), 1,
-      aux_sym_codespan_token1,
-  [3944] = 1,
-    ACTIONS(559), 1,
+  [3982] = 3,
+    ACTIONS(43), 1,
       ts_builtin_sym_end,
-  [3948] = 1,
-    ACTIONS(462), 1,
+    ACTIONS(541), 1,
+      sym_modeline,
+    STATE(99), 1,
+      aux_sym_help_file_repeat3,
+  [3992] = 3,
+    ACTIONS(541), 1,
+      sym_modeline,
+    ACTIONS(543), 1,
+      ts_builtin_sym_end,
+    STATE(99), 1,
+      aux_sym_help_file_repeat3,
+  [4002] = 3,
+    ACTIONS(545), 1,
+      anon_sym_STAR,
+    ACTIONS(547), 1,
+      aux_sym__blank_token1,
+    STATE(31), 1,
+      sym_tag,
+  [4012] = 1,
+    ACTIONS(549), 1,
+      anon_sym_TILDE,
+  [4016] = 1,
+    ACTIONS(551), 1,
+      aux_sym_codespan_token1,
+  [4020] = 1,
+    ACTIONS(553), 1,
+      aux_sym_codeblock_token2,
+  [4024] = 1,
+    ACTIONS(454), 1,
       aux_sym_tag_token1,
-  [3952] = 1,
-    ACTIONS(561), 1,
+  [4028] = 1,
+    ACTIONS(555), 1,
       anon_sym_BQUOTE2,
-  [3956] = 1,
-    ACTIONS(563), 1,
+  [4032] = 1,
+    ACTIONS(557), 1,
+      anon_sym_STAR2,
+  [4036] = 1,
+    ACTIONS(312), 1,
+      aux_sym_line_li_token1,
+  [4040] = 1,
+    ACTIONS(559), 1,
+      anon_sym_SQUOTE2,
+  [4044] = 1,
+    ACTIONS(561), 1,
       anon_sym_RBRACE,
-  [3960] = 1,
+  [4048] = 1,
+    ACTIONS(563), 1,
+      ts_builtin_sym_end,
+  [4052] = 1,
     ACTIONS(565), 1,
       anon_sym_PIPE2,
-  [3964] = 1,
-    ACTIONS(567), 1,
-      anon_sym_SQUOTE2,
-  [3968] = 1,
-    ACTIONS(569), 1,
-      anon_sym_STAR2,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
@@ -15416,348 +15432,346 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(26)] = 709,
   [SMALL_STATE(27)] = 784,
   [SMALL_STATE(28)] = 859,
-  [SMALL_STATE(29)] = 931,
-  [SMALL_STATE(30)] = 1003,
-  [SMALL_STATE(31)] = 1075,
-  [SMALL_STATE(32)] = 1147,
-  [SMALL_STATE(33)] = 1199,
-  [SMALL_STATE(34)] = 1251,
-  [SMALL_STATE(35)] = 1303,
-  [SMALL_STATE(36)] = 1355,
-  [SMALL_STATE(37)] = 1407,
-  [SMALL_STATE(38)] = 1459,
-  [SMALL_STATE(39)] = 1513,
-  [SMALL_STATE(40)] = 1565,
-  [SMALL_STATE(41)] = 1617,
-  [SMALL_STATE(42)] = 1669,
-  [SMALL_STATE(43)] = 1723,
-  [SMALL_STATE(44)] = 1776,
-  [SMALL_STATE(45)] = 1829,
-  [SMALL_STATE(46)] = 1873,
-  [SMALL_STATE(47)] = 1917,
-  [SMALL_STATE(48)] = 1966,
-  [SMALL_STATE(49)] = 2015,
-  [SMALL_STATE(50)] = 2058,
-  [SMALL_STATE(51)] = 2101,
-  [SMALL_STATE(52)] = 2143,
-  [SMALL_STATE(53)] = 2185,
-  [SMALL_STATE(54)] = 2227,
-  [SMALL_STATE(55)] = 2269,
-  [SMALL_STATE(56)] = 2311,
-  [SMALL_STATE(57)] = 2353,
-  [SMALL_STATE(58)] = 2395,
-  [SMALL_STATE(59)] = 2437,
-  [SMALL_STATE(60)] = 2479,
-  [SMALL_STATE(61)] = 2521,
-  [SMALL_STATE(62)] = 2562,
-  [SMALL_STATE(63)] = 2603,
-  [SMALL_STATE(64)] = 2643,
-  [SMALL_STATE(65)] = 2683,
-  [SMALL_STATE(66)] = 2723,
-  [SMALL_STATE(67)] = 2766,
-  [SMALL_STATE(68)] = 2806,
-  [SMALL_STATE(69)] = 2848,
-  [SMALL_STATE(70)] = 2890,
-  [SMALL_STATE(71)] = 2934,
-  [SMALL_STATE(72)] = 2976,
-  [SMALL_STATE(73)] = 3016,
-  [SMALL_STATE(74)] = 3060,
-  [SMALL_STATE(75)] = 3099,
-  [SMALL_STATE(76)] = 3138,
-  [SMALL_STATE(77)] = 3175,
-  [SMALL_STATE(78)] = 3214,
-  [SMALL_STATE(79)] = 3253,
-  [SMALL_STATE(80)] = 3292,
-  [SMALL_STATE(81)] = 3331,
-  [SMALL_STATE(82)] = 3370,
-  [SMALL_STATE(83)] = 3406,
-  [SMALL_STATE(84)] = 3442,
-  [SMALL_STATE(85)] = 3478,
-  [SMALL_STATE(86)] = 3514,
-  [SMALL_STATE(87)] = 3550,
-  [SMALL_STATE(88)] = 3586,
-  [SMALL_STATE(89)] = 3622,
-  [SMALL_STATE(90)] = 3658,
-  [SMALL_STATE(91)] = 3694,
-  [SMALL_STATE(92)] = 3730,
-  [SMALL_STATE(93)] = 3766,
-  [SMALL_STATE(94)] = 3802,
-  [SMALL_STATE(95)] = 3819,
-  [SMALL_STATE(96)] = 3836,
-  [SMALL_STATE(97)] = 3850,
-  [SMALL_STATE(98)] = 3863,
-  [SMALL_STATE(99)] = 3876,
-  [SMALL_STATE(100)] = 3886,
-  [SMALL_STATE(101)] = 3896,
-  [SMALL_STATE(102)] = 3906,
-  [SMALL_STATE(103)] = 3916,
-  [SMALL_STATE(104)] = 3926,
-  [SMALL_STATE(105)] = 3936,
-  [SMALL_STATE(106)] = 3940,
-  [SMALL_STATE(107)] = 3944,
-  [SMALL_STATE(108)] = 3948,
-  [SMALL_STATE(109)] = 3952,
-  [SMALL_STATE(110)] = 3956,
-  [SMALL_STATE(111)] = 3960,
-  [SMALL_STATE(112)] = 3964,
-  [SMALL_STATE(113)] = 3968,
+  [SMALL_STATE(29)] = 936,
+  [SMALL_STATE(30)] = 1013,
+  [SMALL_STATE(31)] = 1088,
+  [SMALL_STATE(32)] = 1163,
+  [SMALL_STATE(33)] = 1235,
+  [SMALL_STATE(34)] = 1307,
+  [SMALL_STATE(35)] = 1379,
+  [SMALL_STATE(36)] = 1451,
+  [SMALL_STATE(37)] = 1501,
+  [SMALL_STATE(38)] = 1553,
+  [SMALL_STATE(39)] = 1605,
+  [SMALL_STATE(40)] = 1655,
+  [SMALL_STATE(41)] = 1705,
+  [SMALL_STATE(42)] = 1755,
+  [SMALL_STATE(43)] = 1805,
+  [SMALL_STATE(44)] = 1858,
+  [SMALL_STATE(45)] = 1911,
+  [SMALL_STATE(46)] = 1955,
+  [SMALL_STATE(47)] = 2004,
+  [SMALL_STATE(48)] = 2053,
+  [SMALL_STATE(49)] = 2096,
+  [SMALL_STATE(50)] = 2139,
+  [SMALL_STATE(51)] = 2181,
+  [SMALL_STATE(52)] = 2223,
+  [SMALL_STATE(53)] = 2265,
+  [SMALL_STATE(54)] = 2307,
+  [SMALL_STATE(55)] = 2349,
+  [SMALL_STATE(56)] = 2391,
+  [SMALL_STATE(57)] = 2433,
+  [SMALL_STATE(58)] = 2475,
+  [SMALL_STATE(59)] = 2517,
+  [SMALL_STATE(60)] = 2559,
+  [SMALL_STATE(61)] = 2601,
+  [SMALL_STATE(62)] = 2643,
+  [SMALL_STATE(63)] = 2685,
+  [SMALL_STATE(64)] = 2726,
+  [SMALL_STATE(65)] = 2767,
+  [SMALL_STATE(66)] = 2807,
+  [SMALL_STATE(67)] = 2847,
+  [SMALL_STATE(68)] = 2887,
+  [SMALL_STATE(69)] = 2930,
+  [SMALL_STATE(70)] = 2970,
+  [SMALL_STATE(71)] = 3012,
+  [SMALL_STATE(72)] = 3056,
+  [SMALL_STATE(73)] = 3098,
+  [SMALL_STATE(74)] = 3138,
+  [SMALL_STATE(75)] = 3182,
+  [SMALL_STATE(76)] = 3224,
+  [SMALL_STATE(77)] = 3263,
+  [SMALL_STATE(78)] = 3302,
+  [SMALL_STATE(79)] = 3341,
+  [SMALL_STATE(80)] = 3380,
+  [SMALL_STATE(81)] = 3419,
+  [SMALL_STATE(82)] = 3456,
+  [SMALL_STATE(83)] = 3492,
+  [SMALL_STATE(84)] = 3528,
+  [SMALL_STATE(85)] = 3564,
+  [SMALL_STATE(86)] = 3600,
+  [SMALL_STATE(87)] = 3636,
+  [SMALL_STATE(88)] = 3672,
+  [SMALL_STATE(89)] = 3708,
+  [SMALL_STATE(90)] = 3744,
+  [SMALL_STATE(91)] = 3780,
+  [SMALL_STATE(92)] = 3816,
+  [SMALL_STATE(93)] = 3852,
+  [SMALL_STATE(94)] = 3888,
+  [SMALL_STATE(95)] = 3905,
+  [SMALL_STATE(96)] = 3922,
+  [SMALL_STATE(97)] = 3936,
+  [SMALL_STATE(98)] = 3949,
+  [SMALL_STATE(99)] = 3962,
+  [SMALL_STATE(100)] = 3972,
+  [SMALL_STATE(101)] = 3982,
+  [SMALL_STATE(102)] = 3992,
+  [SMALL_STATE(103)] = 4002,
+  [SMALL_STATE(104)] = 4012,
+  [SMALL_STATE(105)] = 4016,
+  [SMALL_STATE(106)] = 4020,
+  [SMALL_STATE(107)] = 4024,
+  [SMALL_STATE(108)] = 4028,
+  [SMALL_STATE(109)] = 4032,
+  [SMALL_STATE(110)] = 4036,
+  [SMALL_STATE(111)] = 4040,
+  [SMALL_STATE(112)] = 4044,
+  [SMALL_STATE(113)] = 4048,
+  [SMALL_STATE(114)] = 4052,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_help_file, 0, 0, 0),
-  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(85),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
-  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(77),
-  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(81),
-  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(92),
-  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(90),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
-  [25] = {.entry = {.count = 1, .reusable = false}}, SHIFT(70),
-  [27] = {.entry = {.count = 1, .reusable = false}}, SHIFT(105),
+  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(84),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
+  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(80),
+  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(78),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(93),
+  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(83),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
+  [25] = {.entry = {.count = 1, .reusable = false}}, SHIFT(71),
+  [27] = {.entry = {.count = 1, .reusable = false}}, SHIFT(110),
   [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
-  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
   [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
-  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
-  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
-  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(106),
-  [43] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_help_file, 1, 0, 4),
-  [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(104),
-  [47] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_help_file, 2, 0, 4),
-  [49] = {.entry = {.count = 1, .reusable = true}}, SHIFT(100),
-  [51] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_help_file, 1, 0, 0),
-  [53] = {.entry = {.count = 1, .reusable = true}}, SHIFT(99),
-  [55] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0),
-  [57] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(85),
-  [60] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(75),
-  [63] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(66),
-  [66] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(85),
-  [69] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(77),
-  [72] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(81),
-  [75] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(72),
-  [78] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(92),
-  [81] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(90),
-  [84] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(90),
-  [87] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(70),
-  [90] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(105),
-  [93] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(30),
-  [96] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(29),
-  [99] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(28),
-  [102] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(83),
-  [105] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(106),
-  [108] = {.entry = {.count = 1, .reusable = false}}, SHIFT(42),
-  [110] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(85),
-  [113] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(75),
-  [116] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(66),
-  [119] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(85),
-  [122] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(77),
-  [125] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(81),
-  [128] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(72),
-  [131] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(92),
-  [134] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(90),
-  [137] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(90),
-  [140] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(70),
-  [143] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0),
-  [145] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0),
-  [147] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(29),
-  [150] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(28),
-  [153] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(83),
-  [156] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(106),
-  [159] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(85),
-  [162] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(85),
-  [165] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(75),
-  [168] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(66),
-  [171] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(77),
-  [174] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(81),
-  [177] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(92),
-  [180] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(90),
-  [183] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(90),
-  [186] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(71),
-  [189] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0),
-  [191] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0),
-  [193] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(83),
-  [196] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(106),
-  [199] = {.entry = {.count = 1, .reusable = false}}, SHIFT(71),
-  [201] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 5, 0, 16),
-  [203] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 5, 0, 16),
-  [205] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 5, 0, 15),
-  [207] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 5, 0, 15),
-  [209] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, 0, 12),
-  [211] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, 0, 12),
-  [213] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, 0, 11),
-  [215] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, 0, 11),
-  [217] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, 0, 16),
-  [219] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, 0, 16),
-  [221] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, 0, 15),
-  [223] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, 0, 15),
-  [225] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 3, 0, 12),
-  [227] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 3, 0, 12),
-  [229] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 3, 0, 11),
-  [231] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 3, 0, 11),
-  [233] = {.entry = {.count = 1, .reusable = false}}, SHIFT(84),
-  [235] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
-  [237] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
-  [239] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
-  [241] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
-  [243] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
-  [245] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [247] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
-  [249] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
-  [251] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
-  [253] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [255] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0), SHIFT_REPEAT(84),
-  [258] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0), SHIFT_REPEAT(75),
-  [261] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0), SHIFT_REPEAT(66),
-  [264] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0), SHIFT_REPEAT(84),
-  [267] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0), SHIFT_REPEAT(77),
-  [270] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0), SHIFT_REPEAT(81),
-  [273] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0), SHIFT_REPEAT(92),
-  [276] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0), SHIFT_REPEAT(90),
-  [279] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0), SHIFT_REPEAT(90),
-  [282] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0),
-  [284] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0), SHIFT_REPEAT(83),
-  [287] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0), SHIFT_REPEAT(106),
-  [290] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
-  [292] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
-  [294] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
-  [296] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
-  [298] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 3, 0, 14),
-  [300] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 3, 0, 14),
-  [302] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_help_file_repeat1, 2, 0, 7),
-  [304] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_help_file_repeat1, 2, 0, 7),
-  [306] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat1, 2, 0, 7), SHIFT_REPEAT(45),
-  [309] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 4, 0, 20),
-  [311] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 4, 0, 20),
-  [313] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 4, 0, 19),
-  [315] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 4, 0, 19),
-  [317] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 3, 0, 13),
-  [319] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 3, 0, 13),
-  [321] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 3, 0, 0),
-  [323] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 3, 0, 0),
-  [325] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [327] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 2, 0, 8),
-  [329] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 2, 0, 8),
-  [331] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 2, 0, 0),
-  [333] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 2, 0, 0),
-  [335] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 2, 0, 0),
-  [337] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 2, 0, 0), SHIFT_REPEAT(50),
-  [340] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 2, 0, 0), SHIFT_REPEAT(50),
-  [343] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 2, 0, 0),
-  [345] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_codeblock, 3, 0, 10),
-  [347] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
-  [349] = {.entry = {.count = 1, .reusable = false}}, SHIFT(50),
-  [351] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_codeblock, 3, 0, 10),
-  [353] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__blank, 1, 0, 2),
-  [355] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__blank, 1, 0, 2),
-  [357] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_help_file_repeat1, 1, 0, 4),
-  [359] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_help_file_repeat1, 1, 0, 4),
-  [361] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 2, 0, 0), SHIFT_REPEAT(62),
-  [364] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 2, 0, 0), SHIFT_REPEAT(62),
-  [367] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
-  [369] = {.entry = {.count = 1, .reusable = false}}, SHIFT(62),
-  [371] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 1, 0, 0),
-  [373] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 1, 0, 0),
-  [375] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_code, 1, 0, 0),
-  [377] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_code, 1, 0, 0),
-  [379] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h3, 3, 0, 6),
-  [381] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h3, 3, 0, 6),
-  [383] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__line_noli, 2, 0, 0),
-  [385] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__line_noli, 2, 0, 0),
-  [387] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h3, 2, 0, 6),
-  [389] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h3, 2, 0, 6),
-  [391] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__line_noli, 3, 0, 0),
-  [393] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__line_noli, 3, 0, 0),
-  [395] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h3, 4, 0, 6),
-  [397] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h3, 4, 0, 6),
-  [399] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_column_heading, 4, 0, 18),
-  [401] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_column_heading, 4, 0, 18),
-  [403] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_column_heading, 3, 0, 6),
-  [405] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_column_heading, 3, 0, 6),
-  [407] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h2, 3, 0, 0),
-  [409] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h2, 3, 0, 0),
-  [411] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h1, 3, 0, 0),
-  [413] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h1, 3, 0, 0),
-  [415] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line, 1, 0, 0),
-  [417] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line, 1, 0, 0),
-  [419] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 1, 0, 17),
-  [421] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 1, 0, 17),
-  [423] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__word_common, 1, 0, 0),
-  [425] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__word_common, 1, 0, 0),
-  [427] = {.entry = {.count = 1, .reusable = false}}, SHIFT(74),
-  [429] = {.entry = {.count = 1, .reusable = false}}, SHIFT(112),
-  [431] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
-  [433] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_uppercase_name_repeat1, 2, 0, 0),
-  [435] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_uppercase_name_repeat1, 2, 0, 0),
-  [437] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_uppercase_name_repeat1, 2, 0, 0), SHIFT_REPEAT(76),
-  [440] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__uppercase_words, 2, 0, 5),
-  [442] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__uppercase_words, 2, 0, 5),
-  [444] = {.entry = {.count = 1, .reusable = false}}, SHIFT(76),
-  [446] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__uppercase_words, 1, 0, 1),
-  [448] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_uppercase_name, 1, 0, 0),
-  [450] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__uppercase_words, 1, 0, 1),
-  [452] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
-  [454] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_uppercase_name, 2, 0, 0),
-  [456] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__word_common, 2, 0, 0),
-  [458] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__word_common, 2, 0, 0),
-  [460] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
-  [462] = {.entry = {.count = 1, .reusable = true}}, SHIFT(113),
-  [464] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_uppercase_name_repeat1, 1, 0, 0),
-  [466] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_uppercase_name_repeat1, 1, 0, 0),
-  [468] = {.entry = {.count = 1, .reusable = true}}, SHIFT(111),
-  [470] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_argument, 3, 0, 9),
-  [472] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument, 3, 0, 9),
-  [474] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
-  [476] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
-  [478] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [480] = {.entry = {.count = 1, .reusable = false}}, SHIFT(110),
-  [482] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_optionlink, 3, 0, 9),
-  [484] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_optionlink, 3, 0, 9),
-  [486] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_url, 1, 0, 3),
-  [488] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_url, 1, 0, 3),
-  [490] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_word, 1, 0, 0),
-  [492] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_word, 1, 0, 0),
-  [494] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_word_noli, 1, 0, 0),
-  [496] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_word_noli, 1, 0, 0),
-  [498] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_argument, 4, 0, 9),
-  [500] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument, 4, 0, 9),
-  [502] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_codespan, 3, 0, 9),
-  [504] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_codespan, 3, 0, 9),
-  [506] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 1, 0, 0),
-  [508] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 1, 0, 0),
-  [510] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_taglink, 3, 0, 9),
-  [512] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_taglink, 3, 0, 9),
-  [514] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keycode, 1, 0, 0),
-  [516] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keycode, 1, 0, 0),
-  [518] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__word_common, 3, 0, 0),
-  [520] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__word_common, 3, 0, 0),
-  [522] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_note, 1, 0, 0),
-  [524] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_note, 1, 0, 0),
-  [526] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 3, 0, 9),
-  [528] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 3, 0, 9),
-  [530] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
-  [532] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
-  [534] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat2, 2, 0, 0), SHIFT_REPEAT(105),
-  [537] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_block_repeat2, 2, 0, 0),
-  [539] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat2, 2, 0, 0), SHIFT_REPEAT(30),
-  [542] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_help_file, 2, 0, 0),
-  [544] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
-  [546] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_help_file, 3, 0, 4),
-  [548] = {.entry = {.count = 1, .reusable = true}}, SHIFT(108),
-  [550] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
-  [552] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_help_file_repeat3, 2, 0, 0),
-  [554] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat3, 2, 0, 0), SHIFT_REPEAT(103),
-  [557] = {.entry = {.count = 1, .reusable = true}}, SHIFT(109),
-  [559] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [561] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
-  [563] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
-  [565] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
-  [567] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
-  [569] = {.entry = {.count = 1, .reusable = true}}, SHIFT(93),
+  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
+  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(105),
+  [43] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_help_file, 1, 0, 0),
+  [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(100),
+  [47] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_help_file, 2, 0, 0),
+  [49] = {.entry = {.count = 1, .reusable = true}}, SHIFT(102),
+  [51] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0),
+  [53] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(84),
+  [56] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(76),
+  [59] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(68),
+  [62] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(84),
+  [65] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(80),
+  [68] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(78),
+  [71] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(73),
+  [74] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(93),
+  [77] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(83),
+  [80] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(83),
+  [83] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(71),
+  [86] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(110),
+  [89] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(34),
+  [92] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(33),
+  [95] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(32),
+  [98] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(87),
+  [101] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat2, 2, 0, 0), SHIFT_REPEAT(105),
+  [104] = {.entry = {.count = 1, .reusable = false}}, SHIFT(37),
+  [106] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(84),
+  [109] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(76),
+  [112] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(68),
+  [115] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(84),
+  [118] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(80),
+  [121] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(78),
+  [124] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(73),
+  [127] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(93),
+  [130] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(83),
+  [133] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(83),
+  [136] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(71),
+  [139] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0),
+  [141] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0),
+  [143] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(33),
+  [146] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(32),
+  [149] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(87),
+  [152] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(105),
+  [155] = {.entry = {.count = 1, .reusable = false}}, SHIFT(72),
+  [157] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 3, 0, 8),
+  [159] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 3, 0, 8),
+  [161] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(84),
+  [164] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(84),
+  [167] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(76),
+  [170] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(68),
+  [173] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(80),
+  [176] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(78),
+  [179] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(93),
+  [182] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(83),
+  [185] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(83),
+  [188] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(72),
+  [191] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0),
+  [193] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0),
+  [195] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(87),
+  [198] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 2, 0, 0), SHIFT_REPEAT(105),
+  [201] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 5, 0, 12),
+  [203] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 5, 0, 12),
+  [205] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 5, 0, 11),
+  [207] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 5, 0, 11),
+  [209] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, 0, 8),
+  [211] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, 0, 8),
+  [213] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, 0, 7),
+  [215] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, 0, 7),
+  [217] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, 0, 12),
+  [219] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, 0, 12),
+  [221] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 4, 0, 11),
+  [223] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 4, 0, 11),
+  [225] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_li, 3, 0, 7),
+  [227] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_li, 3, 0, 7),
+  [229] = {.entry = {.count = 1, .reusable = false}}, SHIFT(88),
+  [231] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
+  [233] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
+  [235] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [237] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__column_heading, 1, 1, 0), SHIFT(88),
+  [240] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [242] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
+  [244] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [246] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__column_heading, 2, 1, 0), SHIFT(88),
+  [249] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [251] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [253] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
+  [255] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [257] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0), SHIFT_REPEAT(88),
+  [260] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0), SHIFT_REPEAT(76),
+  [263] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0), SHIFT_REPEAT(68),
+  [266] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0), SHIFT_REPEAT(88),
+  [269] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0), SHIFT_REPEAT(80),
+  [272] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0), SHIFT_REPEAT(78),
+  [275] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0), SHIFT_REPEAT(93),
+  [278] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0), SHIFT_REPEAT(83),
+  [281] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0), SHIFT_REPEAT(83),
+  [284] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0),
+  [286] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0), SHIFT_REPEAT(87),
+  [289] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 2, 0, 0), SHIFT_REPEAT(105),
+  [292] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
+  [294] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [296] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
+  [298] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
+  [300] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [302] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [304] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 3, 0, 0),
+  [306] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 3, 0, 0),
+  [308] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 2, 0, 0),
+  [310] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 2, 0, 0),
+  [312] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [314] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_help_file_repeat1, 2, 0, 0),
+  [316] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_help_file_repeat1, 2, 0, 0),
+  [318] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat1, 2, 0, 0), SHIFT_REPEAT(45),
+  [321] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 4, 0, 0),
+  [323] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 4, 0, 0),
+  [325] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_codeblock, 3, 0, 6),
+  [327] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [329] = {.entry = {.count = 1, .reusable = false}}, SHIFT(49),
+  [331] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_codeblock, 3, 0, 6),
+  [333] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 2, 0, 0),
+  [335] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 2, 0, 0), SHIFT_REPEAT(49),
+  [338] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 2, 0, 0), SHIFT_REPEAT(49),
+  [341] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 2, 0, 0),
+  [343] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__blank, 1, 0, 2),
+  [345] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__blank, 1, 0, 2),
+  [347] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 2, 0, 0), SHIFT_REPEAT(63),
+  [350] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 2, 0, 0), SHIFT_REPEAT(63),
+  [353] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
+  [355] = {.entry = {.count = 1, .reusable = false}}, SHIFT(63),
+  [357] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_codeblock_repeat1, 1, 0, 0),
+  [359] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_codeblock_repeat1, 1, 0, 0),
+  [361] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line_code, 1, 0, 0),
+  [363] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_code, 1, 0, 0),
+  [365] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h2, 5, 0, 9),
+  [367] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h2, 5, 0, 9),
+  [369] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h1, 4, 0, 9),
+  [371] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h1, 4, 0, 9),
+  [373] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__line_noli, 2, 0, 0),
+  [375] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__line_noli, 2, 0, 0),
+  [377] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h3, 2, 0, 0),
+  [379] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h3, 2, 0, 0),
+  [381] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h1, 5, 0, 9),
+  [383] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h1, 5, 0, 9),
+  [385] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_column_heading, 3, 0, 10),
+  [387] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_column_heading, 3, 0, 10),
+  [389] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h3, 3, 0, 0),
+  [391] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h3, 3, 0, 0),
+  [393] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__line_noli, 3, 0, 0),
+  [395] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__line_noli, 3, 0, 0),
+  [397] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h2, 3, 0, 9),
+  [399] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h2, 3, 0, 9),
+  [401] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_line, 1, 0, 0),
+  [403] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line, 1, 0, 0),
+  [405] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h3, 4, 0, 0),
+  [407] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h3, 4, 0, 0),
+  [409] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h1, 3, 0, 9),
+  [411] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h1, 3, 0, 9),
+  [413] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_h2, 4, 0, 9),
+  [415] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_h2, 4, 0, 9),
+  [417] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_line_li_repeat2, 1, 0, 13),
+  [419] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat2, 1, 0, 13),
+  [421] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__word_common, 1, 0, 0),
+  [423] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__word_common, 1, 0, 0),
+  [425] = {.entry = {.count = 1, .reusable = false}}, SHIFT(79),
+  [427] = {.entry = {.count = 1, .reusable = false}}, SHIFT(111),
+  [429] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
+  [431] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_uppercase_name_repeat1, 2, 0, 0),
+  [433] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_uppercase_name_repeat1, 2, 0, 0),
+  [435] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_uppercase_name_repeat1, 2, 0, 0), SHIFT_REPEAT(81),
+  [438] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__uppercase_words, 1, 0, 1),
+  [440] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_uppercase_name, 1, 0, 0),
+  [442] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__uppercase_words, 1, 0, 1),
+  [444] = {.entry = {.count = 1, .reusable = false}}, SHIFT(81),
+  [446] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
+  [448] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__uppercase_words, 2, 0, 4),
+  [450] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_uppercase_name, 2, 0, 0),
+  [452] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__uppercase_words, 2, 0, 4),
+  [454] = {.entry = {.count = 1, .reusable = true}}, SHIFT(109),
+  [456] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_argument, 3, 0, 5),
+  [458] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument, 3, 0, 5),
+  [460] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
+  [462] = {.entry = {.count = 1, .reusable = false}}, SHIFT(112),
+  [464] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__word_common, 2, 0, 0),
+  [466] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__word_common, 2, 0, 0),
+  [468] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
+  [470] = {.entry = {.count = 1, .reusable = true}}, SHIFT(114),
+  [472] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_uppercase_name_repeat1, 1, 0, 0),
+  [474] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_uppercase_name_repeat1, 1, 0, 0),
+  [476] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_codespan, 3, 0, 5),
+  [478] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_codespan, 3, 0, 5),
+  [480] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keycode, 1, 0, 0),
+  [482] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keycode, 1, 0, 0),
+  [484] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_word_noli, 1, 0, 0),
+  [486] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_word_noli, 1, 0, 0),
+  [488] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_argument, 4, 0, 5),
+  [490] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument, 4, 0, 5),
+  [492] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 3, 0, 5),
+  [494] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 3, 0, 5),
+  [496] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_url, 1, 0, 3),
+  [498] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_url, 1, 0, 3),
+  [500] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_word, 1, 0, 0),
+  [502] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_word, 1, 0, 0),
+  [504] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__word_common, 3, 0, 0),
+  [506] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__word_common, 3, 0, 0),
+  [508] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_line_li_repeat1, 1, 0, 0),
+  [510] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_line_li_repeat1, 1, 0, 0),
+  [512] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_optionlink, 3, 0, 5),
+  [514] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_optionlink, 3, 0, 5),
+  [516] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_taglink, 3, 0, 5),
+  [518] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_taglink, 3, 0, 5),
+  [520] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_note, 1, 0, 0),
+  [522] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_note, 1, 0, 0),
+  [524] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [526] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [528] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat2, 2, 0, 0), SHIFT_REPEAT(110),
+  [531] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_block_repeat2, 2, 0, 0),
+  [533] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat2, 2, 0, 0), SHIFT_REPEAT(34),
+  [536] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_help_file_repeat3, 2, 0, 0),
+  [538] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_help_file_repeat3, 2, 0, 0), SHIFT_REPEAT(99),
+  [541] = {.entry = {.count = 1, .reusable = true}}, SHIFT(99),
+  [543] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_help_file, 3, 0, 0),
+  [545] = {.entry = {.count = 1, .reusable = true}}, SHIFT(107),
+  [547] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [549] = {.entry = {.count = 1, .reusable = true}}, SHIFT(106),
+  [551] = {.entry = {.count = 1, .reusable = true}}, SHIFT(108),
+  [553] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
+  [555] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
+  [557] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
+  [559] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
+  [561] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
+  [563] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [565] = {.entry = {.count = 1, .reusable = true}}, SHIFT(92),
 };
 
 #ifdef __cplusplus

--- a/test/corpus/arguments.txt
+++ b/test/corpus/arguments.txt
@@ -133,12 +133,12 @@ NOT an argument
 ================================================================================
 a '{' '}' block
 {foo "{bar}" `{baz}` |{baz| } {}
-foo { bar 
+foo { bar
 { {} foo{{ foo{{{
- {{ 
- {{{ 
+ {{
+ {{{
 { }	foo
-,	inside { }: 
+,	inside { }:
 \}	literal } x
 \{	literal { x
 
@@ -205,16 +205,17 @@ EXTERNAL *netrw-externapp* {{{2
   (block
     (line
       (h1
-        (word)
-        (word)
+        (delimiter)
+        (heading
+          (word)
+          (word))
         (tag
           (word))
         (word))))
   (block
     (line
       (h3
-        (uppercase_name)
+        (heading)
         (tag
           (word))
         (word)))))
-

--- a/test/corpus/heading3-column_heading.txt
+++ b/test/corpus/heading3-column_heading.txt
@@ -15,15 +15,17 @@ Text
   (block
     (line
       (h3
-        (uppercase_name))))
+        (heading))))
   (block
     (line
       (word)))
   (block
     (line
       (column_heading
-        (word)
-        (word)))
+        (heading
+          (word)
+          (word))
+        (delimiter)))
     (line
       (word))))
 
@@ -41,7 +43,7 @@ HELLO WORLD
   (block
     (line
       (h3
-        (uppercase_name))))
+        (heading))))
   (block
     (line
       (word))))
@@ -60,7 +62,7 @@ Test
   (block
     (line
       (h3
-        (uppercase_name)
+        (heading)
         (tag
           (word)))))
   (block
@@ -81,7 +83,9 @@ Below
   (block
     (line
       (column_heading
-        (word))))
+        (heading
+          (word))
+        (delimiter))))
   (block
     (line
       (word))))
@@ -122,8 +126,10 @@ nvim_ui_try_resize({width}, {height})                   *nvim_ui_try_resize()*
   (block
     (line
       (column_heading
-        (word)
-        (word))))
+        (heading
+          (word)
+          (word))
+        (delimiter))))
   (block
     (line
       (word)
@@ -142,7 +148,9 @@ nvim_ui_try_resize({width}, {height})                   *nvim_ui_try_resize()*
   (block
     (line
       (column_heading
-        (word)))
+        (heading
+          (word))
+        (delimiter)))
     (line
       (taglink
         (word))
@@ -170,11 +178,13 @@ column_heading should NOT parse atoms (links, tags, etc.) (FIXME)
   (block
     (line
       (column_heading
-        (optionlink
-          (word))
-        (word)
-        (optionlink
-          (word)))))
+        (heading
+          (optionlink
+            (word))
+          (word)
+          (optionlink
+            (word)))
+        (delimiter))))
   (block
     (line
       (word))))


### PR DESCRIPTION
Problems: Header titles cannot be extracted easily (e.g., for generating a table of contents).

Solution: Expose nodes for separators (`separator`) and actual heading text (`heading`).

Closes #133 