### PR TITLE
fix(tests): adapt expected to heading changes

### DIFF
--- a/test/corpus/codeblock.txt
+++ b/test/corpus/codeblock.txt
@@ -175,7 +175,9 @@ H3 HEADLINE *foo*
           (line))))
     (line
       (h1
-        (word)
+        (delimiter)
+        (heading
+          (word))
         (tag
           (word))))
     (line
@@ -191,7 +193,9 @@ H3 HEADLINE *foo*
           (line))))
     (line
       (h2
-        (word)
+        (delimiter)
+        (heading
+          (word))
         (tag
           (word)))))
   (block
@@ -202,7 +206,7 @@ H3 HEADLINE *foo*
           (line))))
     (line
       (h3
-        (uppercase_name)
+        (heading)
         (tag
           (word))))))
 

--- a/test/corpus/heading1_2.txt
+++ b/test/corpus/heading1_2.txt
@@ -19,7 +19,9 @@ Text2
   (block
     (line
       (h1
-        (word)
+        (delimiter)
+        (heading
+          (word))
         (tag
           (word)))))
   (block
@@ -28,8 +30,10 @@ Text2
   (block
     (line
       (h2
-        (word)
-        (word)
+        (delimiter)
+        (heading
+          (word)
+          (word))
         (tag
           (word))
         (tag
@@ -59,20 +63,24 @@ Text
   (block
     (line
       (h1
-        (tag
-          (word))
-        (word)
-        (word))))
+        (delimiter)
+        (heading
+          (tag
+            (word))
+          (word)
+          (word)))))
   (block
     (line
       (word)))
   (block
     (line
       (h2
-        (tag
-          (word))
-        (word)
-        (word))))
+        (delimiter)
+        (heading
+          (tag
+            (word))
+          (word)
+          (word)))))
   (block
     (line
       (word))))


### PR DESCRIPTION
Followup to #134; not sure why the tests passed on that without these changes.
