### PR TITLE
ci: ignore failing upstream help files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,12 +44,16 @@ jobs:
           files: |-
             .tests/neovim/runtime/doc/*.txt
             !.tests/neovim/runtime/doc/builtin.txt
+            !.tests/neovim/runtime/doc/dev_test.txt
             !.tests/neovim/runtime/doc/index.txt
             !.tests/neovim/runtime/doc/motion.txt
+            !.tests/neovim/runtime/doc/news.txt
+            !.tests/neovim/runtime/doc/nvim.txt
             !.tests/neovim/runtime/doc/options.txt
+            !.tests/neovim/runtime/doc/pi_*.txt
             !.tests/neovim/runtime/doc/quickfix.txt
             !.tests/neovim/runtime/doc/quickref.txt
             !.tests/neovim/runtime/doc/tips.txt
-            !.tests/neovim/runtime/doc/visual.txt
             !.tests/neovim/runtime/doc/usr_*.txt
-            !.tests/neovim/runtime/doc/pi_*.txt
+            !.tests/neovim/runtime/doc/vimfn.txt
+            !.tests/neovim/runtime/doc/visual.txt


### PR DESCRIPTION
Problem:
These files have unknown number of errors, and since we don't have a `tree-sitter/parse-action` check in neovim core yet, chasing down the errors is too time-consuming.

Solution:
Ignore the files until we decide what we want to do. Maybe it makes more sense to run the `gen_help_html.lua` validation here instead of `tree-sitter/parse-action`?